### PR TITLE
fixed Don't create &quot; in inline CSS attributes

### DIFF
--- a/src/language-html/embed/attribute.js
+++ b/src/language-html/embed/attribute.js
@@ -60,10 +60,10 @@ function printAttributeWithValuePrinter(printValue) {
     }
 
     valueDoc = mapDoc(valueDoc, (doc) =>
-      typeof doc === "string" ? doc.replaceAll('"', "&quot;") : doc,
+      typeof doc === "string" ? doc.replaceAll('"', '"') : doc,
     );
 
-    return [path.node.rawName, '="', group(valueDoc), '"'];
+    return [path.node.rawName, "='", group(valueDoc), "'"];
   };
 }
 

--- a/tests/format/angular/angular/__snapshots__/format.test.js.snap
+++ b/tests/format/angular/angular/__snapshots__/format.test.js.snap
@@ -19,12 +19,12 @@ printWidth: 80
 </div>
 
 =====================================output=====================================
-<div ng-if="$ctrl.shouldShowWarning && !$ctrl.loading">Warning!</div>
+<div ng-if='$ctrl.shouldShowWarning && !$ctrl.loading'>Warning!</div>
 
 <div
-  class="common--error-message"
+  class='common--error-message'
   test-hook="upper-error-message"
-  ng-if="
+  ng-if='
     !$ctrl.showsFormBelowPlain() &&
     !!$ctrl.error.message &&
     !(
@@ -32,10 +32,10 @@ printWidth: 80
       $ctrl.form.$valid &&
       $ctrl.error.form === $ctrl.form
     )
-  "
+  '
 >
-  <div ng-if="$ctrl.error.html" ng-bind-html="$ctrl.error.message"></div>
-  <div ng-if="!$ctrl.error.html" ng-bind="$ctrl.error.message"></div>
+  <div ng-if='$ctrl.error.html' ng-bind-html="$ctrl.error.message"></div>
+  <div ng-if='!$ctrl.error.html' ng-bind="$ctrl.error.message"></div>
 </div>
 
 ================================================================================
@@ -60,12 +60,12 @@ printWidth: 80
 </div>
 
 =====================================output=====================================
-<div ng-if="$ctrl.shouldShowWarning && !$ctrl.loading">Warning!</div>
+<div ng-if='$ctrl.shouldShowWarning && !$ctrl.loading'>Warning!</div>
 
 <div
-  class="common--error-message"
+  class='common--error-message'
   test-hook="upper-error-message"
-  ng-if="
+  ng-if='
     !$ctrl.showsFormBelowPlain() &&
     !!$ctrl.error.message &&
     !(
@@ -73,10 +73,10 @@ printWidth: 80
       $ctrl.form.$valid &&
       $ctrl.error.form === $ctrl.form
     )
-  "
+  '
 >
-  <div ng-if="$ctrl.error.html" ng-bind-html="$ctrl.error.message"></div>
-  <div ng-if="!$ctrl.error.html" ng-bind="$ctrl.error.message"></div>
+  <div ng-if='$ctrl.error.html' ng-bind-html="$ctrl.error.message"></div>
+  <div ng-if='!$ctrl.error.html' ng-bind="$ctrl.error.message"></div>
 </div>
 
 ================================================================================
@@ -101,18 +101,18 @@ printWidth: 1
 
 =====================================output=====================================
 <div
-  ng-if="
+  ng-if='
     $ctrl.shouldShowWarning &&
     !$ctrl.loading
-  "
+  '
 >
   Warning!
 </div>
 
 <div
-  class="common--error-message"
+  class='common--error-message'
   test-hook="upper-error-message"
-  ng-if="
+  ng-if='
     !$ctrl.showsFormBelowPlain() &&
     !!$ctrl
       .error
@@ -130,22 +130,22 @@ printWidth: 1
         .form ===
         $ctrl.form
     )
-  "
+  '
 >
   <div
-    ng-if="
+    ng-if='
       $ctrl
         .error
         .html
-    "
+    '
     ng-bind-html="$ctrl.error.message"
   ></div>
   <div
-    ng-if="
+    ng-if='
       !$ctrl
         .error
         .html
-    "
+    '
     ng-bind="$ctrl.error.message"
   ></div>
 </div>
@@ -172,12 +172,12 @@ trailingComma: "es5"
 </div>
 
 =====================================output=====================================
-<div ng-if="$ctrl.shouldShowWarning && !$ctrl.loading">Warning!</div>
+<div ng-if='$ctrl.shouldShowWarning && !$ctrl.loading'>Warning!</div>
 
 <div
-  class="common--error-message"
+  class='common--error-message'
   test-hook="upper-error-message"
-  ng-if="
+  ng-if='
     !$ctrl.showsFormBelowPlain() &&
     !!$ctrl.error.message &&
     !(
@@ -185,10 +185,10 @@ trailingComma: "es5"
       $ctrl.form.$valid &&
       $ctrl.error.form === $ctrl.form
     )
-  "
+  '
 >
-  <div ng-if="$ctrl.error.html" ng-bind-html="$ctrl.error.message"></div>
-  <div ng-if="!$ctrl.error.html" ng-bind="$ctrl.error.message"></div>
+  <div ng-if='$ctrl.error.html' ng-bind-html="$ctrl.error.message"></div>
+  <div ng-if='!$ctrl.error.html' ng-bind="$ctrl.error.message"></div>
 </div>
 
 ================================================================================
@@ -213,12 +213,12 @@ trailingComma: "none"
 </div>
 
 =====================================output=====================================
-<div ng-if="$ctrl.shouldShowWarning && !$ctrl.loading">Warning!</div>
+<div ng-if='$ctrl.shouldShowWarning && !$ctrl.loading'>Warning!</div>
 
 <div
-  class="common--error-message"
+  class='common--error-message'
   test-hook="upper-error-message"
-  ng-if="
+  ng-if='
     !$ctrl.showsFormBelowPlain() &&
     !!$ctrl.error.message &&
     !(
@@ -226,10 +226,10 @@ trailingComma: "none"
       $ctrl.form.$valid &&
       $ctrl.error.form === $ctrl.form
     )
-  "
+  '
 >
-  <div ng-if="$ctrl.error.html" ng-bind-html="$ctrl.error.message"></div>
-  <div ng-if="!$ctrl.error.html" ng-bind="$ctrl.error.message"></div>
+  <div ng-if='$ctrl.error.html' ng-bind-html="$ctrl.error.message"></div>
+  <div ng-if='!$ctrl.error.html' ng-bind="$ctrl.error.message"></div>
 </div>
 
 ================================================================================
@@ -436,123 +436,123 @@ printWidth: 80
 
 =====================================output=====================================
 <div
-  bindon-target="a | b: c : d : e"
-  [(target)]="a | b: c : d : e"
-  bind-target="a | b: c : d : e"
-  [target]="a | b: c : d : e"
-  [target]="a | pipe"
-  [target]="0 - 1"
-  [target]="-1"
-  [target]="a ? 1 : 2"
-  [target]=""
-  [target]="a(1)(2)"
-  [target]="a[b]"
-  [target]="[1]"
-  [target]="{a: 1}"
-  [target]="{a: 1}"
-  [target]="{
+  bindon-target='a | b: c : d : e'
+  [(target)]='a | b: c : d : e'
+  bind-target='a | b: c : d : e'
+  [target]='a | b: c : d : e'
+  [target]='a | pipe'
+  [target]='0 - 1'
+  [target]='-1'
+  [target]='a ? 1 : 2'
+  [target]=''
+  [target]='a(1)(2)'
+  [target]='a[b]'
+  [target]='[1]'
+  [target]='{a: 1}'
+  [target]='{a: 1}'
+  [target]='{
     trailingComma: 'notAllowed',
-  }"
-  [target]="[
+  }'
+  [target]='[
     longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
-  ]"
-  [target]="true"
-  [target]="undefined"
-  [target]="null"
-  [target]="1"
-  [target]="1"
-  [target]="'hello'"
-  [target]="a(1, 2)"
-  [target]="a.b(1, 2)"
-  [target]="x!"
-  [target]="!x"
-  [target]="a"
-  [target]="a"
-  [target]="a // hello"
-  [target]="a.b"
-  [target]="a?.b"
-  [target]="a?.[b]"
+  ]'
+  [target]='true'
+  [target]='undefined'
+  [target]='null'
+  [target]='1'
+  [target]='1'
+  [target]=''hello''
+  [target]='a(1, 2)'
+  [target]='a.b(1, 2)'
+  [target]='x!'
+  [target]='!x'
+  [target]='a'
+  [target]='a'
+  [target]='a // hello'
+  [target]='a.b'
+  [target]='a?.b'
+  [target]='a?.[b]'
   [target]=" javascript : 'hello world' "
-  [target]="a?.b()"
-  [target]="a?.b"
-  [target]="this.a"
-  on-target="a = 1"
-  (target)="a = 1"
-  (target)="a.b = 1"
-  (target)="a[b] = 1"
-  (target)="(a) // hello"
-  (target)="(a); (b)"
-  (event)="(0)"
-  (event)="(a.b)"
-  (event)="(a?.b)"
-  (event)="(a?.[b])"
-  (event)="(hello)"
-  (event)="hello()"
-  (event)="(a && b)"
-  (event)="a && b()"
-  (event)="foo = $event"
-  (event)="(foo == $event)"
-  *ngIf="something ? true : false"
-  *ngIf="a | pipe"
-  *ngFor="let hero of heroes"
-  *ngFor="
+  [target]='a?.b()'
+  [target]='a?.b'
+  [target]='this.a'
+  on-target='a = 1'
+  (target)='a = 1'
+  (target)='a.b = 1'
+  (target)='a[b] = 1'
+  (target)='(a) // hello'
+  (target)='(a); (b)'
+  (event)='(0)'
+  (event)='(a.b)'
+  (event)='(a?.b)'
+  (event)='(a?.[b])'
+  (event)='(hello)'
+  (event)='hello()'
+  (event)='(a && b)'
+  (event)='a && b()'
+  (event)='foo = $event'
+  (event)='(foo == $event)'
+  *ngIf='something ? true : false'
+  *ngIf='a | pipe'
+  *ngFor='let hero of heroes'
+  *ngFor='
     let hero of [1, 2, 3, 666666666666666666666666666666666666];
     let i = index
-  "
-  *ngFor="let hero of heroes; trackBy: trackByHeroes"
-  *ngFor="let item of items; index as i; trackBy: trackByFn"
-  *ngFor="let hero of heroes; let i = index"
-  *ngFor="let hero of heroes; value: myValue"
-  *ngIf="condition; else elseBlock"
-  *ngIf="condition; then thenBlock; else elseBlock"
-  *ngIf="condition as value; else elseBlock"
-  *directive="let hero"
-  *directive="let hero = hello"
-  *directive="let hero of heroes"
-  *directive="let hero of heroes"
-  *directive="a"
-  *directive="a as b"
-  *directive="a; b"
-  *directive="a; b"
-  *directive="a; b: c"
-  *directive="a; b: c"
-  *directive="a; b: c as d"
-  *directive="a; b as c"
-  *ngIf="
+  '
+  *ngFor='let hero of heroes; trackBy: trackByHeroes'
+  *ngFor='let item of items; index as i; trackBy: trackByFn'
+  *ngFor='let hero of heroes; let i = index'
+  *ngFor='let hero of heroes; value: myValue'
+  *ngIf='condition; else elseBlock'
+  *ngIf='condition; then thenBlock; else elseBlock'
+  *ngIf='condition as value; else elseBlock'
+  *directive='let hero'
+  *directive='let hero = hello'
+  *directive='let hero of heroes'
+  *directive='let hero of heroes'
+  *directive='a'
+  *directive='a as b'
+  *directive='a; b'
+  *directive='a; b'
+  *directive='a; b: c'
+  *directive='a; b: c'
+  *directive='a; b: c as d'
+  *directive='a; b as c'
+  *ngIf='
     listRow.NextScheduledSendStatus == 1 ||
     listRow.NextScheduledSendStatus == 2 ||
     listRow.NextScheduledSendStatus == 3
-  "
-  *ngIf="
+  '
+  *ngIf='
     listRow.NextScheduledSendStatus == 1 ||
       listRow.NextScheduledSendStatus == 2 ||
       listRow.NextScheduledSendStatus == 3;
     else hello
-  "
-  (target)="
+  '
+  (target)='
     (listRow.NextScheduledSendStatus == 1 ||
       listRow.NextScheduledSendStatus == 2 ||
       listRow.NextScheduledSendStatus == 3)
-  "
-  [target]="
+  '
+  [target]='
     listRow.NextScheduledSendStatus == 1 ||
     listRow.NextScheduledSendStatus == 2 ||
     listRow.NextScheduledSendStatus == 3
-  "
-  [target]="{
+  '
+  [target]='{
     longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: true,
-  }"
-  [error]="'We couldn\\\\\\'t find anything with that name.'"
-  *ngIf="form.controls.details?.controls.amount?.errors.min"
-  [ngClass]="{
+  }'
+  [error]=''We couldn\\\\\\'t find anything with that name.''
+  *ngIf='form.controls.details?.controls.amount?.errors.min'
+  [ngClass]='{
     'btn-success': (dialog$ | async).level === dialogLevelEnum.SUCCESS,
     'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
     'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER,
-  }"
-  [stickout]="+toolAssembly.stickoutMm"
-  test="{{ 'test' | translate }}"
-  test="foo {{       invalid invalid       }} bar {{ valid }} baz"
-  test="foo
+  }'
+  [stickout]='+toolAssembly.stickoutMm'
+  test='{{ 'test' | translate }}'
+  test='foo {{       invalid invalid       }} bar {{ valid }} baz'
+  test='foo
 
     {{       invalid
              invalid       }}
@@ -561,31 +561,31 @@ printWidth: 80
 
           {{ valid }}
 
-    baz"
-  i18n="Normal i18n text"
-  i18n="
+    baz'
+  i18n='Normal i18n text'
+  i18n='
     This is a very long internationalization description text, exceeding the
     configured print width, but could easily be formatted
-  "
-  i18n-test="Attribute i18n text"
-  i18n-test="
+  '
+  i18n-test='Attribute i18n text'
+  i18n-test='
     This is a very long internationalization description text, exceeding the
     configured print width, but could easily be formatted
-  "
-  i18n="
+  '
+  i18n='
     This is a very long internationalization description text, exceeding the
     configured print width, but could easily be formatted
-  "
-  i18n="
+  '
+  i18n='
     This is yet another very long internationalization description text,
     exceeding the configured print width, but could easily be formatted
-  "
-  i18n="@@customId"
-  i18n="Some description@@customIdWithDescription"
-  i18n="some meaning|Some description@@customIdWithDescription"
-  i18n="
+  '
+  i18n='@@customId'
+  i18n='Some description@@customIdWithDescription'
+  i18n='some meaning|Some description@@customIdWithDescription'
+  i18n='
     some meaning|Some very long internationalization description text exceeding
-    the configured print width@@customIdWithDescription"
+    the configured print width@@customIdWithDescription'
 ></div>
 
 ================================================================================
@@ -715,123 +715,123 @@ printWidth: 80
 
 =====================================output=====================================
 <div
-  bindon-target="a | b: c : d : e"
-  [(target)]="a | b: c : d : e"
-  bind-target="a | b: c : d : e"
-  [target]="a | b: c : d : e"
-  [target]="a | pipe"
-  [target]="0 - 1"
-  [target]="-1"
-  [target]="a ? 1 : 2"
-  [target]=""
-  [target]="a(1)(2)"
-  [target]="a[b]"
-  [target]="[1]"
-  [target]="{ a: 1 }"
-  [target]="{ a: 1 }"
-  [target]="{
+  bindon-target='a | b: c : d : e'
+  [(target)]='a | b: c : d : e'
+  bind-target='a | b: c : d : e'
+  [target]='a | b: c : d : e'
+  [target]='a | pipe'
+  [target]='0 - 1'
+  [target]='-1'
+  [target]='a ? 1 : 2'
+  [target]=''
+  [target]='a(1)(2)'
+  [target]='a[b]'
+  [target]='[1]'
+  [target]='{ a: 1 }'
+  [target]='{ a: 1 }'
+  [target]='{
     trailingComma: 'notAllowed',
-  }"
-  [target]="[
+  }'
+  [target]='[
     longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
-  ]"
-  [target]="true"
-  [target]="undefined"
-  [target]="null"
-  [target]="1"
-  [target]="1"
-  [target]="'hello'"
-  [target]="a(1, 2)"
-  [target]="a.b(1, 2)"
-  [target]="x!"
-  [target]="!x"
-  [target]="a"
-  [target]="a"
-  [target]="a // hello"
-  [target]="a.b"
-  [target]="a?.b"
-  [target]="a?.[b]"
+  ]'
+  [target]='true'
+  [target]='undefined'
+  [target]='null'
+  [target]='1'
+  [target]='1'
+  [target]=''hello''
+  [target]='a(1, 2)'
+  [target]='a.b(1, 2)'
+  [target]='x!'
+  [target]='!x'
+  [target]='a'
+  [target]='a'
+  [target]='a // hello'
+  [target]='a.b'
+  [target]='a?.b'
+  [target]='a?.[b]'
   [target]=" javascript : 'hello world' "
-  [target]="a?.b()"
-  [target]="a?.b"
-  [target]="this.a"
-  on-target="a = 1"
-  (target)="a = 1"
-  (target)="a.b = 1"
-  (target)="a[b] = 1"
-  (target)="(a) // hello"
-  (target)="(a); (b)"
-  (event)="(0)"
-  (event)="(a.b)"
-  (event)="(a?.b)"
-  (event)="(a?.[b])"
-  (event)="(hello)"
-  (event)="hello()"
-  (event)="(a && b)"
-  (event)="a && b()"
-  (event)="foo = $event"
-  (event)="(foo == $event)"
-  *ngIf="something ? true : false"
-  *ngIf="a | pipe"
-  *ngFor="let hero of heroes"
-  *ngFor="
+  [target]='a?.b()'
+  [target]='a?.b'
+  [target]='this.a'
+  on-target='a = 1'
+  (target)='a = 1'
+  (target)='a.b = 1'
+  (target)='a[b] = 1'
+  (target)='(a) // hello'
+  (target)='(a); (b)'
+  (event)='(0)'
+  (event)='(a.b)'
+  (event)='(a?.b)'
+  (event)='(a?.[b])'
+  (event)='(hello)'
+  (event)='hello()'
+  (event)='(a && b)'
+  (event)='a && b()'
+  (event)='foo = $event'
+  (event)='(foo == $event)'
+  *ngIf='something ? true : false'
+  *ngIf='a | pipe'
+  *ngFor='let hero of heroes'
+  *ngFor='
     let hero of [1, 2, 3, 666666666666666666666666666666666666];
     let i = index
-  "
-  *ngFor="let hero of heroes; trackBy: trackByHeroes"
-  *ngFor="let item of items; index as i; trackBy: trackByFn"
-  *ngFor="let hero of heroes; let i = index"
-  *ngFor="let hero of heroes; value: myValue"
-  *ngIf="condition; else elseBlock"
-  *ngIf="condition; then thenBlock; else elseBlock"
-  *ngIf="condition as value; else elseBlock"
-  *directive="let hero"
-  *directive="let hero = hello"
-  *directive="let hero of heroes"
-  *directive="let hero of heroes"
-  *directive="a"
-  *directive="a as b"
-  *directive="a; b"
-  *directive="a; b"
-  *directive="a; b: c"
-  *directive="a; b: c"
-  *directive="a; b: c as d"
-  *directive="a; b as c"
-  *ngIf="
+  '
+  *ngFor='let hero of heroes; trackBy: trackByHeroes'
+  *ngFor='let item of items; index as i; trackBy: trackByFn'
+  *ngFor='let hero of heroes; let i = index'
+  *ngFor='let hero of heroes; value: myValue'
+  *ngIf='condition; else elseBlock'
+  *ngIf='condition; then thenBlock; else elseBlock'
+  *ngIf='condition as value; else elseBlock'
+  *directive='let hero'
+  *directive='let hero = hello'
+  *directive='let hero of heroes'
+  *directive='let hero of heroes'
+  *directive='a'
+  *directive='a as b'
+  *directive='a; b'
+  *directive='a; b'
+  *directive='a; b: c'
+  *directive='a; b: c'
+  *directive='a; b: c as d'
+  *directive='a; b as c'
+  *ngIf='
     listRow.NextScheduledSendStatus == 1 ||
     listRow.NextScheduledSendStatus == 2 ||
     listRow.NextScheduledSendStatus == 3
-  "
-  *ngIf="
+  '
+  *ngIf='
     listRow.NextScheduledSendStatus == 1 ||
       listRow.NextScheduledSendStatus == 2 ||
       listRow.NextScheduledSendStatus == 3;
     else hello
-  "
-  (target)="
+  '
+  (target)='
     (listRow.NextScheduledSendStatus == 1 ||
       listRow.NextScheduledSendStatus == 2 ||
       listRow.NextScheduledSendStatus == 3)
-  "
-  [target]="
+  '
+  [target]='
     listRow.NextScheduledSendStatus == 1 ||
     listRow.NextScheduledSendStatus == 2 ||
     listRow.NextScheduledSendStatus == 3
-  "
-  [target]="{
+  '
+  [target]='{
     longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: true,
-  }"
-  [error]="'We couldn\\\\\\'t find anything with that name.'"
-  *ngIf="form.controls.details?.controls.amount?.errors.min"
-  [ngClass]="{
+  }'
+  [error]=''We couldn\\\\\\'t find anything with that name.''
+  *ngIf='form.controls.details?.controls.amount?.errors.min'
+  [ngClass]='{
     'btn-success': (dialog$ | async).level === dialogLevelEnum.SUCCESS,
     'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
     'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER,
-  }"
-  [stickout]="+toolAssembly.stickoutMm"
-  test="{{ 'test' | translate }}"
-  test="foo {{       invalid invalid       }} bar {{ valid }} baz"
-  test="foo
+  }'
+  [stickout]='+toolAssembly.stickoutMm'
+  test='{{ 'test' | translate }}'
+  test='foo {{       invalid invalid       }} bar {{ valid }} baz'
+  test='foo
 
     {{       invalid
              invalid       }}
@@ -840,31 +840,31 @@ printWidth: 80
 
           {{ valid }}
 
-    baz"
-  i18n="Normal i18n text"
-  i18n="
+    baz'
+  i18n='Normal i18n text'
+  i18n='
     This is a very long internationalization description text, exceeding the
     configured print width, but could easily be formatted
-  "
-  i18n-test="Attribute i18n text"
-  i18n-test="
+  '
+  i18n-test='Attribute i18n text'
+  i18n-test='
     This is a very long internationalization description text, exceeding the
     configured print width, but could easily be formatted
-  "
-  i18n="
+  '
+  i18n='
     This is a very long internationalization description text, exceeding the
     configured print width, but could easily be formatted
-  "
-  i18n="
+  '
+  i18n='
     This is yet another very long internationalization description text,
     exceeding the configured print width, but could easily be formatted
-  "
-  i18n="@@customId"
-  i18n="Some description@@customIdWithDescription"
-  i18n="some meaning|Some description@@customIdWithDescription"
-  i18n="
+  '
+  i18n='@@customId'
+  i18n='Some description@@customIdWithDescription'
+  i18n='some meaning|Some description@@customIdWithDescription'
+  i18n='
     some meaning|Some very long internationalization description text exceeding
-    the configured print width@@customIdWithDescription"
+    the configured print width@@customIdWithDescription'
 ></div>
 
 ================================================================================
@@ -993,219 +993,219 @@ printWidth: 1
 
 =====================================output=====================================
 <div
-  bindon-target="
+  bindon-target='
     a
       | b
         : c
         : d
         : e
-  "
-  [(target)]="
+  '
+  [(target)]='
     a
       | b
         : c
         : d
         : e
-  "
-  bind-target="
+  '
+  bind-target='
     a
       | b
         : c
         : d
         : e
-  "
-  [target]="
+  '
+  [target]='
     a
       | b
         : c
         : d
         : e
-  "
-  [target]="
+  '
+  [target]='
     a
       | pipe
-  "
-  [target]="
+  '
+  [target]='
     0 -
     1
-  "
-  [target]="
+  '
+  [target]='
     -1
-  "
-  [target]="
+  '
+  [target]='
     a
       ? 1
       : 2
-  "
-  [target]="
+  '
+  [target]='
 
-  "
-  [target]="
+  '
+  [target]='
     a(
       1
     )(
       2
     )
-  "
-  [target]="
+  '
+  [target]='
     a[
       b
     ]
-  "
-  [target]="[
+  '
+  [target]='[
     1,
-  ]"
-  [target]="{
+  ]'
+  [target]='{
     a: 1,
-  }"
-  [target]="{
+  }'
+  [target]='{
     a: 1,
-  }"
-  [target]="{
+  }'
+  [target]='{
     trailingComma:
       'notAllowed',
-  }"
-  [target]="[
+  }'
+  [target]='[
     longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
-  ]"
-  [target]="
+  ]'
+  [target]='
     true
-  "
-  [target]="
+  '
+  [target]='
     undefined
-  "
-  [target]="
+  '
+  [target]='
     null
-  "
-  [target]="
+  '
+  [target]='
     1
-  "
-  [target]="
+  '
+  [target]='
     1
-  "
-  [target]="
+  '
+  [target]='
     'hello'
-  "
-  [target]="
+  '
+  [target]='
     a(
       1,
       2
     )
-  "
-  [target]="
+  '
+  [target]='
     a.b(
       1,
       2
     )
-  "
-  [target]="
+  '
+  [target]='
     x!
-  "
-  [target]="
+  '
+  [target]='
     !x
-  "
-  [target]="
+  '
+  [target]='
     a
-  "
-  [target]="
+  '
+  [target]='
     a
-  "
-  [target]="
+  '
+  [target]='
     a // hello
-  "
-  [target]="
+  '
+  [target]='
     a.b
-  "
-  [target]="
+  '
+  [target]='
     a?.b
-  "
-  [target]="
+  '
+  [target]='
     a?.[
       b
     ]
-  "
+  '
   [target]=" javascript : 'hello world' "
-  [target]="
+  [target]='
     a?.b()
-  "
-  [target]="
+  '
+  [target]='
     a?.b
-  "
-  [target]="
+  '
+  [target]='
     this
       .a
-  "
-  on-target="
+  '
+  on-target='
     a = 1
-  "
-  (target)="
+  '
+  (target)='
     a = 1
-  "
-  (target)="
+  '
+  (target)='
     a.b = 1
-  "
-  (target)="
+  '
+  (target)='
     a[
       b
     ] =
       1
-  "
-  (target)="
+  '
+  (target)='
     (a) // hello
-  "
-  (target)="
+  '
+  (target)='
     (a);
     (b)
-  "
-  (event)="
+  '
+  (event)='
     (0)
-  "
-  (event)="
+  '
+  (event)='
     (a.b)
-  "
-  (event)="
+  '
+  (event)='
     (a?.b)
-  "
-  (event)="
+  '
+  (event)='
     (a?.[
       b
     ])
-  "
-  (event)="
+  '
+  (event)='
     (hello)
-  "
-  (event)="
+  '
+  (event)='
     hello()
-  "
-  (event)="
+  '
+  (event)='
     (a &&
       b)
-  "
-  (event)="
+  '
+  (event)='
     a &&
       b()
-  "
-  (event)="
+  '
+  (event)='
     foo =
       $event
-  "
-  (event)="
+  '
+  (event)='
     (foo ==
       $event)
-  "
-  *ngIf="
+  '
+  *ngIf='
     something
       ? true
       : false
-  "
-  *ngIf="
+  '
+  *ngIf='
     a
       | pipe
-  "
-  *ngFor="
+  '
+  *ngFor='
     let hero of heroes
-  "
-  *ngFor="
+  '
+  *ngFor='
     let hero of [
       1,
       2,
@@ -1213,88 +1213,88 @@ printWidth: 1
       666666666666666666666666666666666666,
     ];
     let i = index
-  "
-  *ngFor="
+  '
+  *ngFor='
     let hero of heroes;
     trackBy: trackByHeroes
-  "
-  *ngFor="
+  '
+  *ngFor='
     let item of items;
     index as i;
     trackBy: trackByFn
-  "
-  *ngFor="
+  '
+  *ngFor='
     let hero of heroes;
     let i = index
-  "
-  *ngFor="
+  '
+  *ngFor='
     let hero of heroes;
     value: myValue
-  "
-  *ngIf="
+  '
+  *ngIf='
     condition;
     else elseBlock
-  "
-  *ngIf="
+  '
+  *ngIf='
     condition;
     then thenBlock;
     else elseBlock
-  "
-  *ngIf="
+  '
+  *ngIf='
     condition as value;
     else elseBlock
-  "
-  *directive="
+  '
+  *directive='
     let hero
-  "
-  *directive="
+  '
+  *directive='
     let hero = hello
-  "
-  *directive="
+  '
+  *directive='
     let hero of heroes
-  "
-  *directive="
+  '
+  *directive='
     let hero of heroes
-  "
-  *directive="
+  '
+  *directive='
     a
-  "
-  *directive="
+  '
+  *directive='
     a as b
-  "
-  *directive="
+  '
+  *directive='
     a;
     b
-  "
-  *directive="
+  '
+  *directive='
     a;
     b
-  "
-  *directive="
+  '
+  *directive='
     a;
     b: c
-  "
-  *directive="
+  '
+  *directive='
     a;
     b: c
-  "
-  *directive="
+  '
+  *directive='
     a;
     b: c as d
-  "
-  *directive="
+  '
+  *directive='
     a;
     b as c
-  "
-  *ngIf="
+  '
+  *ngIf='
     listRow.NextScheduledSendStatus ==
       1 ||
     listRow.NextScheduledSendStatus ==
       2 ||
     listRow.NextScheduledSendStatus ==
       3
-  "
-  *ngIf="
+  '
+  *ngIf='
     listRow.NextScheduledSendStatus ==
       1 ||
       listRow.NextScheduledSendStatus ==
@@ -1302,30 +1302,30 @@ printWidth: 1
       listRow.NextScheduledSendStatus ==
         3;
     else hello
-  "
-  (target)="
+  '
+  (target)='
     (listRow.NextScheduledSendStatus ==
       1 ||
       listRow.NextScheduledSendStatus ==
         2 ||
       listRow.NextScheduledSendStatus ==
         3)
-  "
-  [target]="
+  '
+  [target]='
     listRow.NextScheduledSendStatus ==
       1 ||
     listRow.NextScheduledSendStatus ==
       2 ||
     listRow.NextScheduledSendStatus ==
       3
-  "
-  [target]="{
+  '
+  [target]='{
     longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: true,
-  }"
-  [error]="
+  }'
+  [error]='
     'We couldn\\\\\\'t find anything with that name.'
-  "
-  *ngIf="
+  '
+  *ngIf='
     form
       .controls
       .details
@@ -1333,8 +1333,8 @@ printWidth: 1
       .amount
       ?.errors
       .min
-  "
-  [ngClass]="{
+  '
+  [ngClass]='{
     'btn-success':
       (
         dialog$
@@ -1356,18 +1356,18 @@ printWidth: 1
       )
         .level ===
       dialogLevelEnum.DANGER,
-  }"
-  [stickout]="
+  }'
+  [stickout]='
     +toolAssembly.stickoutMm
-  "
-  test="{{
+  '
+  test='{{
     'test'
       | translate
-  }}"
-  test="foo {{       invalid invalid       }} bar {{
+  }}'
+  test='foo {{       invalid invalid       }} bar {{
     valid
-  }} baz"
-  test="foo
+  }} baz'
+  test='foo
 
     {{       invalid
              invalid       }}
@@ -1378,13 +1378,13 @@ printWidth: 1
     valid
   }}
 
-    baz"
-  i18n="
+    baz'
+  i18n='
     Normal
     i18n
     text
-  "
-  i18n="
+  '
+  i18n='
     This
     is
     a
@@ -1403,13 +1403,13 @@ printWidth: 1
     easily
     be
     formatted
-  "
-  i18n-test="
+  '
+  i18n-test='
     Attribute
     i18n
     text
-  "
-  i18n-test="
+  '
+  i18n-test='
     This
     is
     a
@@ -1428,8 +1428,8 @@ printWidth: 1
     easily
     be
     formatted
-  "
-  i18n="
+  '
+  i18n='
     This
     is
     a
@@ -1448,8 +1448,8 @@ printWidth: 1
     easily
     be
     formatted
-  "
-  i18n="
+  '
+  i18n='
     This
     is
     yet
@@ -1469,17 +1469,17 @@ printWidth: 1
     easily
     be
     formatted
-  "
-  i18n="
-    @@customId"
-  i18n="
+  '
+  i18n='
+    @@customId'
+  i18n='
     Some
-    description@@customIdWithDescription"
-  i18n="
+    description@@customIdWithDescription'
+  i18n='
     some
     meaning|Some
-    description@@customIdWithDescription"
-  i18n="
+    description@@customIdWithDescription'
+  i18n='
     some
     meaning|Some
     very
@@ -1491,7 +1491,7 @@ printWidth: 1
     the
     configured
     print
-    width@@customIdWithDescription"
+    width@@customIdWithDescription'
 ></div>
 
 ================================================================================
@@ -1621,123 +1621,123 @@ trailingComma: "es5"
 
 =====================================output=====================================
 <div
-  bindon-target="a | b: c : d : e"
-  [(target)]="a | b: c : d : e"
-  bind-target="a | b: c : d : e"
-  [target]="a | b: c : d : e"
-  [target]="a | pipe"
-  [target]="0 - 1"
-  [target]="-1"
-  [target]="a ? 1 : 2"
-  [target]=""
-  [target]="a(1)(2)"
-  [target]="a[b]"
-  [target]="[1]"
-  [target]="{ a: 1 }"
-  [target]="{ a: 1 }"
-  [target]="{
+  bindon-target='a | b: c : d : e'
+  [(target)]='a | b: c : d : e'
+  bind-target='a | b: c : d : e'
+  [target]='a | b: c : d : e'
+  [target]='a | pipe'
+  [target]='0 - 1'
+  [target]='-1'
+  [target]='a ? 1 : 2'
+  [target]=''
+  [target]='a(1)(2)'
+  [target]='a[b]'
+  [target]='[1]'
+  [target]='{ a: 1 }'
+  [target]='{ a: 1 }'
+  [target]='{
     trailingComma: 'notAllowed',
-  }"
-  [target]="[
+  }'
+  [target]='[
     longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
-  ]"
-  [target]="true"
-  [target]="undefined"
-  [target]="null"
-  [target]="1"
-  [target]="1"
-  [target]="'hello'"
-  [target]="a(1, 2)"
-  [target]="a.b(1, 2)"
-  [target]="x!"
-  [target]="!x"
-  [target]="a"
-  [target]="a"
-  [target]="a // hello"
-  [target]="a.b"
-  [target]="a?.b"
-  [target]="a?.[b]"
+  ]'
+  [target]='true'
+  [target]='undefined'
+  [target]='null'
+  [target]='1'
+  [target]='1'
+  [target]=''hello''
+  [target]='a(1, 2)'
+  [target]='a.b(1, 2)'
+  [target]='x!'
+  [target]='!x'
+  [target]='a'
+  [target]='a'
+  [target]='a // hello'
+  [target]='a.b'
+  [target]='a?.b'
+  [target]='a?.[b]'
   [target]=" javascript : 'hello world' "
-  [target]="a?.b()"
-  [target]="a?.b"
-  [target]="this.a"
-  on-target="a = 1"
-  (target)="a = 1"
-  (target)="a.b = 1"
-  (target)="a[b] = 1"
-  (target)="(a) // hello"
-  (target)="(a); (b)"
-  (event)="(0)"
-  (event)="(a.b)"
-  (event)="(a?.b)"
-  (event)="(a?.[b])"
-  (event)="(hello)"
-  (event)="hello()"
-  (event)="(a && b)"
-  (event)="a && b()"
-  (event)="foo = $event"
-  (event)="(foo == $event)"
-  *ngIf="something ? true : false"
-  *ngIf="a | pipe"
-  *ngFor="let hero of heroes"
-  *ngFor="
+  [target]='a?.b()'
+  [target]='a?.b'
+  [target]='this.a'
+  on-target='a = 1'
+  (target)='a = 1'
+  (target)='a.b = 1'
+  (target)='a[b] = 1'
+  (target)='(a) // hello'
+  (target)='(a); (b)'
+  (event)='(0)'
+  (event)='(a.b)'
+  (event)='(a?.b)'
+  (event)='(a?.[b])'
+  (event)='(hello)'
+  (event)='hello()'
+  (event)='(a && b)'
+  (event)='a && b()'
+  (event)='foo = $event'
+  (event)='(foo == $event)'
+  *ngIf='something ? true : false'
+  *ngIf='a | pipe'
+  *ngFor='let hero of heroes'
+  *ngFor='
     let hero of [1, 2, 3, 666666666666666666666666666666666666];
     let i = index
-  "
-  *ngFor="let hero of heroes; trackBy: trackByHeroes"
-  *ngFor="let item of items; index as i; trackBy: trackByFn"
-  *ngFor="let hero of heroes; let i = index"
-  *ngFor="let hero of heroes; value: myValue"
-  *ngIf="condition; else elseBlock"
-  *ngIf="condition; then thenBlock; else elseBlock"
-  *ngIf="condition as value; else elseBlock"
-  *directive="let hero"
-  *directive="let hero = hello"
-  *directive="let hero of heroes"
-  *directive="let hero of heroes"
-  *directive="a"
-  *directive="a as b"
-  *directive="a; b"
-  *directive="a; b"
-  *directive="a; b: c"
-  *directive="a; b: c"
-  *directive="a; b: c as d"
-  *directive="a; b as c"
-  *ngIf="
+  '
+  *ngFor='let hero of heroes; trackBy: trackByHeroes'
+  *ngFor='let item of items; index as i; trackBy: trackByFn'
+  *ngFor='let hero of heroes; let i = index'
+  *ngFor='let hero of heroes; value: myValue'
+  *ngIf='condition; else elseBlock'
+  *ngIf='condition; then thenBlock; else elseBlock'
+  *ngIf='condition as value; else elseBlock'
+  *directive='let hero'
+  *directive='let hero = hello'
+  *directive='let hero of heroes'
+  *directive='let hero of heroes'
+  *directive='a'
+  *directive='a as b'
+  *directive='a; b'
+  *directive='a; b'
+  *directive='a; b: c'
+  *directive='a; b: c'
+  *directive='a; b: c as d'
+  *directive='a; b as c'
+  *ngIf='
     listRow.NextScheduledSendStatus == 1 ||
     listRow.NextScheduledSendStatus == 2 ||
     listRow.NextScheduledSendStatus == 3
-  "
-  *ngIf="
+  '
+  *ngIf='
     listRow.NextScheduledSendStatus == 1 ||
       listRow.NextScheduledSendStatus == 2 ||
       listRow.NextScheduledSendStatus == 3;
     else hello
-  "
-  (target)="
+  '
+  (target)='
     (listRow.NextScheduledSendStatus == 1 ||
       listRow.NextScheduledSendStatus == 2 ||
       listRow.NextScheduledSendStatus == 3)
-  "
-  [target]="
+  '
+  [target]='
     listRow.NextScheduledSendStatus == 1 ||
     listRow.NextScheduledSendStatus == 2 ||
     listRow.NextScheduledSendStatus == 3
-  "
-  [target]="{
+  '
+  [target]='{
     longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: true,
-  }"
-  [error]="'We couldn\\\\\\'t find anything with that name.'"
-  *ngIf="form.controls.details?.controls.amount?.errors.min"
-  [ngClass]="{
+  }'
+  [error]=''We couldn\\\\\\'t find anything with that name.''
+  *ngIf='form.controls.details?.controls.amount?.errors.min'
+  [ngClass]='{
     'btn-success': (dialog$ | async).level === dialogLevelEnum.SUCCESS,
     'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
     'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER,
-  }"
-  [stickout]="+toolAssembly.stickoutMm"
-  test="{{ 'test' | translate }}"
-  test="foo {{       invalid invalid       }} bar {{ valid }} baz"
-  test="foo
+  }'
+  [stickout]='+toolAssembly.stickoutMm'
+  test='{{ 'test' | translate }}'
+  test='foo {{       invalid invalid       }} bar {{ valid }} baz'
+  test='foo
 
     {{       invalid
              invalid       }}
@@ -1746,31 +1746,31 @@ trailingComma: "es5"
 
           {{ valid }}
 
-    baz"
-  i18n="Normal i18n text"
-  i18n="
+    baz'
+  i18n='Normal i18n text'
+  i18n='
     This is a very long internationalization description text, exceeding the
     configured print width, but could easily be formatted
-  "
-  i18n-test="Attribute i18n text"
-  i18n-test="
+  '
+  i18n-test='Attribute i18n text'
+  i18n-test='
     This is a very long internationalization description text, exceeding the
     configured print width, but could easily be formatted
-  "
-  i18n="
+  '
+  i18n='
     This is a very long internationalization description text, exceeding the
     configured print width, but could easily be formatted
-  "
-  i18n="
+  '
+  i18n='
     This is yet another very long internationalization description text,
     exceeding the configured print width, but could easily be formatted
-  "
-  i18n="@@customId"
-  i18n="Some description@@customIdWithDescription"
-  i18n="some meaning|Some description@@customIdWithDescription"
-  i18n="
+  '
+  i18n='@@customId'
+  i18n='Some description@@customIdWithDescription'
+  i18n='some meaning|Some description@@customIdWithDescription'
+  i18n='
     some meaning|Some very long internationalization description text exceeding
-    the configured print width@@customIdWithDescription"
+    the configured print width@@customIdWithDescription'
 ></div>
 
 ================================================================================
@@ -1900,123 +1900,123 @@ trailingComma: "none"
 
 =====================================output=====================================
 <div
-  bindon-target="a | b: c : d : e"
-  [(target)]="a | b: c : d : e"
-  bind-target="a | b: c : d : e"
-  [target]="a | b: c : d : e"
-  [target]="a | pipe"
-  [target]="0 - 1"
-  [target]="-1"
-  [target]="a ? 1 : 2"
-  [target]=""
-  [target]="a(1)(2)"
-  [target]="a[b]"
-  [target]="[1]"
-  [target]="{ a: 1 }"
-  [target]="{ a: 1 }"
-  [target]="{
+  bindon-target='a | b: c : d : e'
+  [(target)]='a | b: c : d : e'
+  bind-target='a | b: c : d : e'
+  [target]='a | b: c : d : e'
+  [target]='a | pipe'
+  [target]='0 - 1'
+  [target]='-1'
+  [target]='a ? 1 : 2'
+  [target]=''
+  [target]='a(1)(2)'
+  [target]='a[b]'
+  [target]='[1]'
+  [target]='{ a: 1 }'
+  [target]='{ a: 1 }'
+  [target]='{
     trailingComma: 'notAllowed'
-  }"
-  [target]="[
+  }'
+  [target]='[
     longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
-  ]"
-  [target]="true"
-  [target]="undefined"
-  [target]="null"
-  [target]="1"
-  [target]="1"
-  [target]="'hello'"
-  [target]="a(1, 2)"
-  [target]="a.b(1, 2)"
-  [target]="x!"
-  [target]="!x"
-  [target]="a"
-  [target]="a"
-  [target]="a // hello"
-  [target]="a.b"
-  [target]="a?.b"
-  [target]="a?.[b]"
+  ]'
+  [target]='true'
+  [target]='undefined'
+  [target]='null'
+  [target]='1'
+  [target]='1'
+  [target]=''hello''
+  [target]='a(1, 2)'
+  [target]='a.b(1, 2)'
+  [target]='x!'
+  [target]='!x'
+  [target]='a'
+  [target]='a'
+  [target]='a // hello'
+  [target]='a.b'
+  [target]='a?.b'
+  [target]='a?.[b]'
   [target]=" javascript : 'hello world' "
-  [target]="a?.b()"
-  [target]="a?.b"
-  [target]="this.a"
-  on-target="a = 1"
-  (target)="a = 1"
-  (target)="a.b = 1"
-  (target)="a[b] = 1"
-  (target)="(a) // hello"
-  (target)="(a); (b)"
-  (event)="(0)"
-  (event)="(a.b)"
-  (event)="(a?.b)"
-  (event)="(a?.[b])"
-  (event)="(hello)"
-  (event)="hello()"
-  (event)="(a && b)"
-  (event)="a && b()"
-  (event)="foo = $event"
-  (event)="(foo == $event)"
-  *ngIf="something ? true : false"
-  *ngIf="a | pipe"
-  *ngFor="let hero of heroes"
-  *ngFor="
+  [target]='a?.b()'
+  [target]='a?.b'
+  [target]='this.a'
+  on-target='a = 1'
+  (target)='a = 1'
+  (target)='a.b = 1'
+  (target)='a[b] = 1'
+  (target)='(a) // hello'
+  (target)='(a); (b)'
+  (event)='(0)'
+  (event)='(a.b)'
+  (event)='(a?.b)'
+  (event)='(a?.[b])'
+  (event)='(hello)'
+  (event)='hello()'
+  (event)='(a && b)'
+  (event)='a && b()'
+  (event)='foo = $event'
+  (event)='(foo == $event)'
+  *ngIf='something ? true : false'
+  *ngIf='a | pipe'
+  *ngFor='let hero of heroes'
+  *ngFor='
     let hero of [1, 2, 3, 666666666666666666666666666666666666];
     let i = index
-  "
-  *ngFor="let hero of heroes; trackBy: trackByHeroes"
-  *ngFor="let item of items; index as i; trackBy: trackByFn"
-  *ngFor="let hero of heroes; let i = index"
-  *ngFor="let hero of heroes; value: myValue"
-  *ngIf="condition; else elseBlock"
-  *ngIf="condition; then thenBlock; else elseBlock"
-  *ngIf="condition as value; else elseBlock"
-  *directive="let hero"
-  *directive="let hero = hello"
-  *directive="let hero of heroes"
-  *directive="let hero of heroes"
-  *directive="a"
-  *directive="a as b"
-  *directive="a; b"
-  *directive="a; b"
-  *directive="a; b: c"
-  *directive="a; b: c"
-  *directive="a; b: c as d"
-  *directive="a; b as c"
-  *ngIf="
+  '
+  *ngFor='let hero of heroes; trackBy: trackByHeroes'
+  *ngFor='let item of items; index as i; trackBy: trackByFn'
+  *ngFor='let hero of heroes; let i = index'
+  *ngFor='let hero of heroes; value: myValue'
+  *ngIf='condition; else elseBlock'
+  *ngIf='condition; then thenBlock; else elseBlock'
+  *ngIf='condition as value; else elseBlock'
+  *directive='let hero'
+  *directive='let hero = hello'
+  *directive='let hero of heroes'
+  *directive='let hero of heroes'
+  *directive='a'
+  *directive='a as b'
+  *directive='a; b'
+  *directive='a; b'
+  *directive='a; b: c'
+  *directive='a; b: c'
+  *directive='a; b: c as d'
+  *directive='a; b as c'
+  *ngIf='
     listRow.NextScheduledSendStatus == 1 ||
     listRow.NextScheduledSendStatus == 2 ||
     listRow.NextScheduledSendStatus == 3
-  "
-  *ngIf="
+  '
+  *ngIf='
     listRow.NextScheduledSendStatus == 1 ||
       listRow.NextScheduledSendStatus == 2 ||
       listRow.NextScheduledSendStatus == 3;
     else hello
-  "
-  (target)="
+  '
+  (target)='
     (listRow.NextScheduledSendStatus == 1 ||
       listRow.NextScheduledSendStatus == 2 ||
       listRow.NextScheduledSendStatus == 3)
-  "
-  [target]="
+  '
+  [target]='
     listRow.NextScheduledSendStatus == 1 ||
     listRow.NextScheduledSendStatus == 2 ||
     listRow.NextScheduledSendStatus == 3
-  "
-  [target]="{
+  '
+  [target]='{
     longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: true
-  }"
-  [error]="'We couldn\\\\\\'t find anything with that name.'"
-  *ngIf="form.controls.details?.controls.amount?.errors.min"
-  [ngClass]="{
+  }'
+  [error]=''We couldn\\\\\\'t find anything with that name.''
+  *ngIf='form.controls.details?.controls.amount?.errors.min'
+  [ngClass]='{
     'btn-success': (dialog$ | async).level === dialogLevelEnum.SUCCESS,
     'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
     'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER
-  }"
-  [stickout]="+toolAssembly.stickoutMm"
-  test="{{ 'test' | translate }}"
-  test="foo {{       invalid invalid       }} bar {{ valid }} baz"
-  test="foo
+  }'
+  [stickout]='+toolAssembly.stickoutMm'
+  test='{{ 'test' | translate }}'
+  test='foo {{       invalid invalid       }} bar {{ valid }} baz'
+  test='foo
 
     {{       invalid
              invalid       }}
@@ -2025,31 +2025,31 @@ trailingComma: "none"
 
           {{ valid }}
 
-    baz"
-  i18n="Normal i18n text"
-  i18n="
+    baz'
+  i18n='Normal i18n text'
+  i18n='
     This is a very long internationalization description text, exceeding the
     configured print width, but could easily be formatted
-  "
-  i18n-test="Attribute i18n text"
-  i18n-test="
+  '
+  i18n-test='Attribute i18n text'
+  i18n-test='
     This is a very long internationalization description text, exceeding the
     configured print width, but could easily be formatted
-  "
-  i18n="
+  '
+  i18n='
     This is a very long internationalization description text, exceeding the
     configured print width, but could easily be formatted
-  "
-  i18n="
+  '
+  i18n='
     This is yet another very long internationalization description text,
     exceeding the configured print width, but could easily be formatted
-  "
-  i18n="@@customId"
-  i18n="Some description@@customIdWithDescription"
-  i18n="some meaning|Some description@@customIdWithDescription"
-  i18n="
+  '
+  i18n='@@customId'
+  i18n='Some description@@customIdWithDescription'
+  i18n='some meaning|Some description@@customIdWithDescription'
+  i18n='
     some meaning|Some very long internationalization description text exceeding
-    the configured print width@@customIdWithDescription"
+    the configured print width@@customIdWithDescription'
 ></div>
 
 ================================================================================
@@ -2632,9 +2632,9 @@ printWidth: 80
 
 =====================================output=====================================
 <div
-  bindon-target="a | b: c : d : e"
-  [(target)]="a | b: c : d : e"
-  bind-target="a | b: c : d : e"
+  bindon-target='a | b: c : d : e'
+  [(target)]='a | b: c : d : e'
+  bind-target='a | b: c : d : e'
 ></div>
 <!--  prettier-ignore-attribute -->
 <div
@@ -2644,13 +2644,13 @@ printWidth: 80
 ></div>
 <!--  prettier-ignore-attribute bind-target -->
 <div
-  bindon-target="a | b: c : d : e"
-  [(target)]="a | b: c : d : e"
+  bindon-target='a | b: c : d : e'
+  [(target)]='a | b: c : d : e'
   bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute [(target)] bind-target -->
 <div
-  bindon-target="a | b: c : d : e"
+  bindon-target='a | b: c : d : e'
   [(target)]=" a | b : c:d :e "
   bind-target=" a | b : c:d :e "
 ></div>
@@ -2691,9 +2691,9 @@ printWidth: 80
 
 =====================================output=====================================
 <div
-  bindon-target="a | b: c : d : e"
-  [(target)]="a | b: c : d : e"
-  bind-target="a | b: c : d : e"
+  bindon-target='a | b: c : d : e'
+  [(target)]='a | b: c : d : e'
+  bind-target='a | b: c : d : e'
 ></div>
 <!--  prettier-ignore-attribute -->
 <div
@@ -2703,13 +2703,13 @@ printWidth: 80
 ></div>
 <!--  prettier-ignore-attribute bind-target -->
 <div
-  bindon-target="a | b: c : d : e"
-  [(target)]="a | b: c : d : e"
+  bindon-target='a | b: c : d : e'
+  [(target)]='a | b: c : d : e'
   bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute [(target)] bind-target -->
 <div
-  bindon-target="a | b: c : d : e"
+  bindon-target='a | b: c : d : e'
   [(target)]=" a | b : c:d :e "
   bind-target=" a | b : c:d :e "
 ></div>
@@ -2749,27 +2749,27 @@ printWidth: 1
 
 =====================================output=====================================
 <div
-  bindon-target="
+  bindon-target='
     a
       | b
         : c
         : d
         : e
-  "
-  [(target)]="
+  '
+  [(target)]='
     a
       | b
         : c
         : d
         : e
-  "
-  bind-target="
+  '
+  bind-target='
     a
       | b
         : c
         : d
         : e
-  "
+  '
 ></div>
 <!--  prettier-ignore-attribute -->
 <div
@@ -2779,31 +2779,31 @@ printWidth: 1
 ></div>
 <!--  prettier-ignore-attribute bind-target -->
 <div
-  bindon-target="
+  bindon-target='
     a
       | b
         : c
         : d
         : e
-  "
-  [(target)]="
+  '
+  [(target)]='
     a
       | b
         : c
         : d
         : e
-  "
+  '
   bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute [(target)] bind-target -->
 <div
-  bindon-target="
+  bindon-target='
     a
       | b
         : c
         : d
         : e
-  "
+  '
   [(target)]=" a | b : c:d :e "
   bind-target=" a | b : c:d :e "
 ></div>
@@ -2844,9 +2844,9 @@ trailingComma: "es5"
 
 =====================================output=====================================
 <div
-  bindon-target="a | b: c : d : e"
-  [(target)]="a | b: c : d : e"
-  bind-target="a | b: c : d : e"
+  bindon-target='a | b: c : d : e'
+  [(target)]='a | b: c : d : e'
+  bind-target='a | b: c : d : e'
 ></div>
 <!--  prettier-ignore-attribute -->
 <div
@@ -2856,13 +2856,13 @@ trailingComma: "es5"
 ></div>
 <!--  prettier-ignore-attribute bind-target -->
 <div
-  bindon-target="a | b: c : d : e"
-  [(target)]="a | b: c : d : e"
+  bindon-target='a | b: c : d : e'
+  [(target)]='a | b: c : d : e'
   bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute [(target)] bind-target -->
 <div
-  bindon-target="a | b: c : d : e"
+  bindon-target='a | b: c : d : e'
   [(target)]=" a | b : c:d :e "
   bind-target=" a | b : c:d :e "
 ></div>
@@ -2903,9 +2903,9 @@ trailingComma: "none"
 
 =====================================output=====================================
 <div
-  bindon-target="a | b: c : d : e"
-  [(target)]="a | b: c : d : e"
-  bind-target="a | b: c : d : e"
+  bindon-target='a | b: c : d : e'
+  [(target)]='a | b: c : d : e'
+  bind-target='a | b: c : d : e'
 ></div>
 <!--  prettier-ignore-attribute -->
 <div
@@ -2915,13 +2915,13 @@ trailingComma: "none"
 ></div>
 <!--  prettier-ignore-attribute bind-target -->
 <div
-  bindon-target="a | b: c : d : e"
-  [(target)]="a | b: c : d : e"
+  bindon-target='a | b: c : d : e'
+  [(target)]='a | b: c : d : e'
   bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute [(target)] bind-target -->
 <div
-  bindon-target="a | b: c : d : e"
+  bindon-target='a | b: c : d : e'
   [(target)]=" a | b : c:d :e "
   bind-target=" a | b : c:d :e "
 ></div>
@@ -3061,7 +3061,7 @@ printWidth: 80
       | localize: localizationSection
   }}
 </label>
-<div class="Nemo possimus non voluptates dicta accusamus id quia">
+<div class='Nemo possimus non voluptates dicta accusamus id quia'>
   {{ copyTypes[options.copyType] }}
 </div>
 {{
@@ -3231,7 +3231,7 @@ printWidth: 80
       | localize: localizationSection
   }}
 </label>
-<div class="Nemo possimus non voluptates dicta accusamus id quia">
+<div class='Nemo possimus non voluptates dicta accusamus id quia'>
   {{ copyTypes[options.copyType] }}
 </div>
 {{
@@ -3547,7 +3547,7 @@ printWidth: 1
   }}
 </label>
 <div
-  class="Nemo possimus non voluptates dicta accusamus id quia"
+  class='Nemo possimus non voluptates dicta accusamus id quia'
 >
   {{
     copyTypes[
@@ -3774,7 +3774,7 @@ trailingComma: "es5"
       | localize: localizationSection
   }}
 </label>
-<div class="Nemo possimus non voluptates dicta accusamus id quia">
+<div class='Nemo possimus non voluptates dicta accusamus id quia'>
   {{ copyTypes[options.copyType] }}
 </div>
 {{
@@ -3941,7 +3941,7 @@ trailingComma: "none"
       | localize: localizationSection
   }}
 </label>
-<div class="Nemo possimus non voluptates dicta accusamus id quia">
+<div class='Nemo possimus non voluptates dicta accusamus id quia'>
   {{ copyTypes[options.copyType] }}
 </div>
 {{
@@ -4715,7 +4715,7 @@ can be found in the LICENSE file at http://angular.io/license
 <a href="#prop-vs-attrib">Properties vs. Attributes</a><br />
 <br />
 <a href="#property-binding">Property Binding</a><br />
-<div style="margin-left: 8px">
+<div style='margin-left: 8px'>
   <a href="#attribute-binding">Attribute Binding</a><br />
   <a href="#class-binding">Class Binding</a><br />
   <a href="#style-binding">Style Binding</a><br />
@@ -4725,13 +4725,13 @@ can be found in the LICENSE file at http://angular.io/license
 <a href="#two-way">Two-way Binding</a><br />
 <br />
 <div>Directives</div>
-<div style="margin-left: 8px">
+<div style='margin-left: 8px'>
   <a href="#ngModel">NgModel (two-way) Binding</a><br />
   <a href="#ngClass">NgClass Binding</a><br />
   <a href="#ngStyle">NgStyle Binding</a><br />
   <a href="#ngIf">NgIf</a><br />
   <a href="#ngFor">NgFor</a><br />
-  <div style="margin-left: 8px">
+  <div style='margin-left: 8px'>
     <a href="#ngFor-index">NgFor with index</a><br />
     <a href="#ngFor-trackBy">NgFor with trackBy</a><br />
   </div>
@@ -4755,7 +4755,7 @@ can be found in the LICENSE file at http://angular.io/license
 
 <h3>
   {{ title }}
-  <img src="{{ heroImageUrl }}" style="height: 30px" />
+  <img src='{{ heroImageUrl }}' style='height: 30px' />
 </h3>
 
 <!-- "The sum of 1 + 1 is 2" -->
@@ -4764,7 +4764,7 @@ can be found in the LICENSE file at http://angular.io/license
 <!-- "The sum of 1 + 1 is not 4" -->
 <p>The sum of 1 + 1 is not {{ 1 + 1 + getVal() }}</p>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <hr />
 <h2 id="expression-context">Expression context</h2>
@@ -4773,52 +4773,52 @@ can be found in the LICENSE file at http://angular.io/license
   Component expression context (&#123;&#123;title&#125;&#125;,
   [hidden]="isUnchanged")
 </p>
-<div class="context">
+<div class='context'>
   {{ title }}
-  <span [hidden]="isUnchanged">changed</span>
+  <span [hidden]='isUnchanged'>changed</span>
 </div>
 
 <p>Template input variable expression context (let hero)</p>
 <!-- template hides the following; plenty of examples later -->
 <ng-template>
-  <div *ngFor="let hero of heroes">{{ hero.name }}</div>
+  <div *ngFor='let hero of heroes'>{{ hero.name }}</div>
 </ng-template>
 
 <p>Template reference variable expression context (#heroInput)</p>
-<div (keyup)="(0)" class="context">
+<div (keyup)='(0)' class='context'>
   Type something:
   <input #heroInput /> {{ heroInput.value }}
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <hr />
 <h2 id="statement-context">Statement context</h2>
 
 <p>Component statement context ( (click)="onSave() )</p>
-<div class="context">
-  <button (click)="deleteHero()">Delete hero</button>
+<div class='context'>
+  <button (click)='deleteHero()'>Delete hero</button>
 </div>
 
 <p>Template $event statement context</p>
-<div class="context">
-  <button (click)="onSave($event)">Save</button>
+<div class='context'>
+  <button (click)='onSave($event)'>Save</button>
 </div>
 
 <p>Template input variable statement context (let hero)</p>
 <!-- template hides the following; plenty of examples later -->
-<div class="context">
-  <button *ngFor="let hero of heroes" (click)="deleteHero(hero)">
+<div class='context'>
+  <button *ngFor='let hero of heroes' (click)='deleteHero(hero)'>
     {{ hero.name }}
   </button>
 </div>
 
 <p>Template reference variable statement context (#heroForm)</p>
-<div class="context">
-  <form #heroForm (ngSubmit)="onSubmit(heroForm)">...</form>
+<div class='context'>
+  <form #heroForm (ngSubmit)='onSubmit(heroForm)'>...</form>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- New Mental Model -->
 <hr />
@@ -4826,14 +4826,14 @@ can be found in the LICENSE file at http://angular.io/license
 
 <!--<img src="http://www.wpclipart.com/cartoon/people/hero/hero_silhoutte_T.png">-->
 <!-- Public Domain terms of use: http://www.wpclipart.com/terms.html -->
-<div class="special">Mental Model</div>
+<div class='special'>Mental Model</div>
 <img src="assets/images/hero.png" />
 <button disabled>Save</button>
 <br /><br />
 
 <div>
   <!-- Normal HTML -->
-  <div class="special">Mental Model</div>
+  <div class='special'>Mental Model</div>
   <!-- Wow! A new element! -->
   <app-hero-detail></app-hero-detail>
 </div>
@@ -4841,53 +4841,53 @@ can be found in the LICENSE file at http://angular.io/license
 
 <div>
   <!-- Bind button disabled state to \`isUnchanged\` property -->
-  <button [disabled]="isUnchanged">Save</button>
+  <button [disabled]='isUnchanged'>Save</button>
 </div>
 <br /><br />
 
 <div>
-  <img [src]="heroImageUrl" />
-  <app-hero-detail [hero]="currentHero"></app-hero-detail>
-  <div [ngClass]="{special: isSpecial}"></div>
+  <img [src]='heroImageUrl' />
+  <app-hero-detail [hero]='currentHero'></app-hero-detail>
+  <div [ngClass]='{special: isSpecial}'></div>
 </div>
 <br /><br />
 
-<button (click)="onSave()">Save</button>
-<app-hero-detail (deleteRequest)="deleteHero()"></app-hero-detail>
-<div (myClick)="clicked = $event" clickable>click me</div>
+<button (click)='onSave()'>Save</button>
+<app-hero-detail (deleteRequest)='deleteHero()'></app-hero-detail>
+<div (myClick)='clicked = $event' clickable>click me</div>
 {{ clicked }}
 <br /><br />
 
 <div>
   Hero Name:
-  <input [(ngModel)]="name" />
+  <input [(ngModel)]='name' />
   {{ name }}
 </div>
 <br /><br />
 
-<button [attr.aria-label]="help">help</button>
+<button [attr.aria-label]='help'>help</button>
 <br /><br />
 
-<div [class.special]="isSpecial">Special</div>
+<div [class.special]='isSpecial'>Special</div>
 <br /><br />
 
-<button [style.color]="isSpecial ? 'red' : 'green'">button</button>
+<button [style.color]='isSpecial ? 'red' : 'green''>button</button>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- property vs. attribute -->
 <hr />
 <h2 id="prop-vs-attrib">Property vs. Attribute (img examples)</h2>
 <!-- examine the following <img> tag in the browser tools -->
-<img src="images/ng-logo.png" [src]="heroImageUrl" />
+<img src="images/ng-logo.png" [src]='heroImageUrl' />
 
 <br /><br />
 
-<img [src]="iconUrl" />
-<img bind-src="heroImageUrl" />
-<img [attr.src]="villainImageUrl" />
+<img [src]='iconUrl' />
+<img bind-src='heroImageUrl' />
+<img [attr.src]='villainImageUrl' />
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- buttons -->
 <hr />
@@ -4898,39 +4898,39 @@ can be found in the LICENSE file at http://angular.io/license
 <button disabled="false">Still disabled</button>
 <br /><br />
 <button disabled>disabled by attribute</button>
-<button [disabled]="isUnchanged">disabled by property binding</button>
+<button [disabled]='isUnchanged'>disabled by property binding</button>
 <br /><br />
-<button bind-disabled="isUnchanged" on-click="onSave($event)">
+<button bind-disabled='isUnchanged' on-click='onSave($event)'>
   Disabled Cancel
 </button>
-<button [disabled]="!canSave" (click)="onSave($event)">Enabled Save</button>
+<button [disabled]='!canSave' (click)='onSave($event)'>Enabled Save</button>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- property binding -->
 <hr />
 <h2 id="property-binding">Property Binding</h2>
 
-<img [src]="heroImageUrl" />
-<button [disabled]="isUnchanged">Cancel is disabled</button>
-<div [ngClass]="classes">[ngClass] binding to the classes property</div>
-<app-hero-detail [hero]="currentHero"></app-hero-detail>
-<img bind-src="heroImageUrl" />
+<img [src]='heroImageUrl' />
+<button [disabled]='isUnchanged'>Cancel is disabled</button>
+<div [ngClass]='classes'>[ngClass] binding to the classes property</div>
+<app-hero-detail [hero]='currentHero'></app-hero-detail>
+<img bind-src='heroImageUrl' />
 
 <!-- ERROR: HeroDetailComponent.hero expects a
      Hero object, not the string "currentHero" -->
-<div *ngIf="false">
+<div *ngIf='false'>
   <app-hero-detail hero="currentHero"></app-hero-detail>
 </div>
-<app-hero-detail prefix="You are my" [hero]="currentHero"></app-hero-detail>
+<app-hero-detail prefix="You are my" [hero]='currentHero'></app-hero-detail>
 
-<p><img src="{{ heroImageUrl }}" /> is the <i>interpolated</i> image.</p>
-<p><img [src]="heroImageUrl" /> is the <i>property bound</i> image.</p>
+<p><img src='{{ heroImageUrl }}' /> is the <i>interpolated</i> image.</p>
+<p><img [src]='heroImageUrl' /> is the <i>property bound</i> image.</p>
 
 <p>
   <span>"{{ title }}" is the <i>interpolated</i> title.</span>
 </p>
-<p>"<span [innerHTML]="title"></span>" is the <i>property bound</i> title.</p>
+<p>"<span [innerHTML]='title'></span>" is the <i>property bound</i> title.</p>
 
 <!--
   Angular generates warnings for these two lines as it sanitizes them
@@ -4940,11 +4940,11 @@ can be found in the LICENSE file at http://angular.io/license
   <span>"{{ evilTitle }}" is the <i>interpolated</i> evil title.</span>
 </p>
 <p>
-  "<span [innerHTML]="evilTitle"></span>" is the <i>property bound</i> evil
+  "<span [innerHTML]='evilTitle'></span>" is the <i>property bound</i> evil
   title.
 </p>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- attribute binding -->
 <hr />
@@ -4954,7 +4954,7 @@ can be found in the LICENSE file at http://angular.io/license
 <table border="1">
   <!--  expression calculates colspan=2 -->
   <tr>
-    <td [attr.colspan]="1 + 1">One-Two</td>
+    <td [attr.colspan]='1 + 1'>One-Two</td>
   </tr>
 
   <!-- ERROR: There is no \`colspan\` property to set!
@@ -4969,111 +4969,111 @@ can be found in the LICENSE file at http://angular.io/license
 
 <br />
 <!-- create and set an aria attribute for assistive technology -->
-<button [attr.aria-label]="actionName">{{ actionName }} with Aria</button>
+<button [attr.aria-label]='actionName'>{{ actionName }} with Aria</button>
 <br /><br />
 
 <!-- The following effects are not discussed in the chapter -->
 <div>
   <!-- any use of [attr.disabled] creates the disabled attribute -->
-  <button [attr.disabled]="isUnchanged">Disabled</button>
+  <button [attr.disabled]='isUnchanged'>Disabled</button>
 
-  <button [attr.disabled]="!isUnchanged">Disabled as well</button>
+  <button [attr.disabled]='!isUnchanged'>Disabled as well</button>
 
   <!-- we'd have to remove it with property binding -->
-  <button disabled [disabled]="false">Enabled (but inert)</button>
+  <button disabled [disabled]='false'>Enabled (but inert)</button>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- class binding -->
 <hr />
 <h2 id="class-binding">Class Binding</h2>
 
 <!-- standard class attribute setting  -->
-<div class="bad curly special">Bad curly special</div>
+<div class='bad curly special'>Bad curly special</div>
 
 <!-- reset/override all class names with a binding  -->
-<div class="bad curly special" [class]="badCurly">Bad curly</div>
+<div class='bad curly special' [class]='badCurly'>Bad curly</div>
 
 <!-- toggle the "special" class on/off with a property -->
-<div [class.special]="isSpecial">The class binding is special</div>
+<div [class.special]='isSpecial'>The class binding is special</div>
 
 <!-- binding to \`class.special\` trumps the class attribute -->
-<div class="special" [class.special]="!isSpecial">
+<div class='special' [class.special]='!isSpecial'>
   This one is not so special
 </div>
 
-<div bind-class.special="isSpecial">This class binding is special too</div>
+<div bind-class.special='isSpecial'>This class binding is special too</div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!--style binding -->
 <hr />
 <h2 id="style-binding">Style Binding</h2>
 
-<button [style.color]="isSpecial ? 'red' : 'green'">Red</button>
-<button [style.background-color]="canSave ? 'cyan' : 'grey'">Save</button>
+<button [style.color]='isSpecial ? 'red' : 'green''>Red</button>
+<button [style.background-color]='canSave ? 'cyan' : 'grey''>Save</button>
 
-<button [style.font-size.em]="isSpecial ? 3 : 1">Big</button>
-<button [style.font-size.%]="!isSpecial ? 150 : 50">Small</button>
+<button [style.font-size.em]='isSpecial ? 3 : 1'>Big</button>
+<button [style.font-size.%]='!isSpecial ? 150 : 50'>Small</button>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- event binding -->
 <hr />
 <h2 id="event-binding">Event Binding</h2>
 
-<button (click)="onSave()">Save</button>
+<button (click)='onSave()'>Save</button>
 
-<button on-click="onSave()">On Save</button>
+<button on-click='onSave()'>On Save</button>
 
 <div>
   <!-- \`myClick\` is an event on the custom \`ClickDirective\` -->
-  <div (myClick)="clickMessage = $event" clickable>click with myClick</div>
+  <div (myClick)='clickMessage = $event' clickable>click with myClick</div>
   {{ clickMessage }}
 </div>
 
 <!-- binding to a nested component -->
 <app-hero-detail
-  (deleteRequest)="deleteHero($event)"
-  [hero]="currentHero"
+  (deleteRequest)='deleteHero($event)'
+  [hero]='currentHero'
 ></app-hero-detail>
 <br />
 
-<app-big-hero-detail (deleteRequest)="deleteHero($event)" [hero]="currentHero">
+<app-big-hero-detail (deleteRequest)='deleteHero($event)' [hero]='currentHero'>
 </app-big-hero-detail>
 
-<div class="parent-div" (click)="onClickMe($event)" clickable>
+<div class='parent-div' (click)='onClickMe($event)' clickable>
   Click me
-  <div class="child-div">Click me too!</div>
+  <div class='child-div'>Click me too!</div>
 </div>
 
 <!-- Will save only once -->
-<div (click)="onSave()" clickable>
-  <button (click)="onSave($event)">Save, no propagation</button>
+<div (click)='onSave()' clickable>
+  <button (click)='onSave($event)'>Save, no propagation</button>
 </div>
 
 <!-- Will save twice -->
-<div (click)="onSave()" clickable>
-  <button (click)="onSave()">Save w/ propagation</button>
+<div (click)='onSave()' clickable>
+  <button (click)='onSave()'>Save w/ propagation</button>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <hr />
 <h2 id="two-way">Two-way Binding</h2>
 <div id="two-way-1">
-  <app-sizer [(size)]="fontSizePx"></app-sizer>
-  <div [style.font-size.px]="fontSizePx">Resizable Text</div>
-  <label>FontSize (px): <input [(ngModel)]="fontSizePx" /></label>
+  <app-sizer [(size)]='fontSizePx'></app-sizer>
+  <div [style.font-size.px]='fontSizePx'>Resizable Text</div>
+  <label>FontSize (px): <input [(ngModel)]='fontSizePx' /></label>
 </div>
 <br />
 <div id="two-way-2">
   <h3>De-sugared two-way binding</h3>
-  <app-sizer [size]="fontSizePx" (sizeChange)="fontSizePx = $event"></app-sizer>
+  <app-sizer [size]='fontSizePx' (sizeChange)='fontSizePx = $event'></app-sizer>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- Two way data binding unwound;
     passing the changed display value to the event handler via \`$event\` -->
@@ -5083,187 +5083,187 @@ can be found in the LICENSE file at http://angular.io/license
 <h3>Result: {{ currentHero.name }}</h3>
 
 <input
-  [value]="currentHero.name"
-  (input)="currentHero.name = $event.target.value"
+  [value]='currentHero.name'
+  (input)='currentHero.name = $event.target.value'
 />
 without NgModel
 <br />
-<input [(ngModel)]="currentHero.name" />
+<input [(ngModel)]='currentHero.name' />
 [(ngModel)]
 <br />
-<input bindon-ngModel="currentHero.name" />
+<input bindon-ngModel='currentHero.name' />
 bindon-ngModel
 <br />
 <input
-  [ngModel]="currentHero.name"
-  (ngModelChange)="currentHero.name = $event"
+  [ngModel]='currentHero.name'
+  (ngModelChange)='currentHero.name = $event'
 />
 (ngModelChange)="...name=$event"
 <br />
 <input
-  [ngModel]="currentHero.name"
-  (ngModelChange)="setUppercaseName($event)"
+  [ngModel]='currentHero.name'
+  (ngModelChange)='setUppercaseName($event)'
 />
 (ngModelChange)="setUppercaseName($event)"
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- NgClass binding -->
 <hr />
 <h2 id="ngClass">NgClass Binding</h2>
 
 <p>currentClasses is {{ currentClasses | json }}</p>
-<div [ngClass]="currentClasses">
+<div [ngClass]='currentClasses'>
   This div is initially saveable, unchanged, and special
 </div>
 
 <!-- not used in chapter -->
 <br />
-<label>saveable <input type="checkbox" [(ngModel)]="canSave" /></label> |
+<label>saveable <input type="checkbox" [(ngModel)]='canSave' /></label> |
 <label
   >modified:
   <input
     type="checkbox"
-    [value]="!isUnchanged"
-    (change)="isUnchanged = !isUnchanged"
+    [value]='!isUnchanged'
+    (change)='isUnchanged = !isUnchanged'
 /></label>
 |
-<label>special: <input type="checkbox" [(ngModel)]="isSpecial" /></label>
-<button (click)="setCurrentClasses()">Refresh currentClasses</button>
+<label>special: <input type="checkbox" [(ngModel)]='isSpecial' /></label>
+<button (click)='setCurrentClasses()'>Refresh currentClasses</button>
 <br /><br />
-<div [ngClass]="currentClasses">
+<div [ngClass]='currentClasses'>
   This div should be {{ canSave ? "" : "not" }} saveable,
   {{ isUnchanged ? "unchanged" : "modified" }} and,
   {{ isSpecial ? "" : "not" }} special after clicking "Refresh".
 </div>
 <br /><br />
 
-<div [ngClass]="isSpecial ? 'special' : ''">This div is special</div>
+<div [ngClass]='isSpecial ? 'special' : '''>This div is special</div>
 
-<div class="bad curly special">Bad curly special</div>
-<div [ngClass]="{bad: false, curly: true, special: true}">Curly special</div>
+<div class='bad curly special'>Bad curly special</div>
+<div [ngClass]='{bad: false, curly: true, special: true}'>Curly special</div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- NgStyle binding -->
 <hr />
 <h2 id="ngStyle">NgStyle Binding</h2>
 
-<div [style.font-size]="isSpecial ? 'x-large' : 'smaller'">
+<div [style.font-size]='isSpecial ? 'x-large' : 'smaller''>
   This div is x-large or smaller.
 </div>
 
 <h3>[ngStyle] binding to currentStyles - CSS property names</h3>
 <p>currentStyles is {{ currentStyles | json }}</p>
-<div [ngStyle]="currentStyles">
+<div [ngStyle]='currentStyles'>
   This div is initially italic, normal weight, and extra large (24px).
 </div>
 
 <!-- not used in chapter -->
 <br />
-<label>italic: <input type="checkbox" [(ngModel)]="canSave" /></label> |
-<label>normal: <input type="checkbox" [(ngModel)]="isUnchanged" /></label> |
-<label>xlarge: <input type="checkbox" [(ngModel)]="isSpecial" /></label>
-<button (click)="setCurrentStyles()">Refresh currentStyles</button>
+<label>italic: <input type="checkbox" [(ngModel)]='canSave' /></label> |
+<label>normal: <input type="checkbox" [(ngModel)]='isUnchanged' /></label> |
+<label>xlarge: <input type="checkbox" [(ngModel)]='isSpecial' /></label>
+<button (click)='setCurrentStyles()'>Refresh currentStyles</button>
 <br /><br />
-<div [ngStyle]="currentStyles">
+<div [ngStyle]='currentStyles'>
   This div should be {{ canSave ? "italic" : "plain" }},
   {{ isUnchanged ? "normal weight" : "bold" }} and,
   {{ isSpecial ? "extra large" : "normal size" }} after clicking "Refresh".
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- NgIf binding -->
 <hr />
 <h2 id="ngIf">NgIf Binding</h2>
 
-<app-hero-detail *ngIf="isActive"></app-hero-detail>
+<app-hero-detail *ngIf='isActive'></app-hero-detail>
 
-<div *ngIf="currentHero">Hello, {{ currentHero.name }}</div>
-<div *ngIf="nullHero">Hello, {{ nullHero.name }}</div>
+<div *ngIf='currentHero'>Hello, {{ currentHero.name }}</div>
+<div *ngIf='nullHero'>Hello, {{ nullHero.name }}</div>
 
 <!-- NgIf binding with template (no *) -->
 
-<ng-template [ngIf]="currentHero"
+<ng-template [ngIf]='currentHero'
   >Add {{ currentHero.name }} with template</ng-template
 >
 
 <!-- Does not show because isActive is false! -->
 <div>Hero Detail removed from DOM (via template) because isActive is false</div>
-<ng-template [ngIf]="isActive">
+<ng-template [ngIf]='isActive'>
   <app-hero-detail></app-hero-detail>
 </ng-template>
 
 <!-- isSpecial is true -->
-<div [class.hidden]="!isSpecial">Show with class</div>
-<div [class.hidden]="isSpecial">Hide with class</div>
+<div [class.hidden]='!isSpecial'>Show with class</div>
+<div [class.hidden]='isSpecial'>Hide with class</div>
 
 <!-- HeroDetail is in the DOM but hidden -->
-<app-hero-detail [class.hidden]="isSpecial"></app-hero-detail>
+<app-hero-detail [class.hidden]='isSpecial'></app-hero-detail>
 
-<div [style.display]="isSpecial ? 'block' : 'none'">Show with style</div>
-<div [style.display]="isSpecial ? 'none' : 'block'">Hide with style</div>
+<div [style.display]='isSpecial ? 'block' : 'none''>Show with style</div>
+<div [style.display]='isSpecial ? 'none' : 'block''>Hide with style</div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- NgFor binding -->
 <hr />
 <h2 id="ngFor">NgFor Binding</h2>
 
-<div class="box">
-  <div *ngFor="let hero of heroes">{{ hero.name }}</div>
+<div class='box'>
+  <div *ngFor='let hero of heroes'>{{ hero.name }}</div>
 </div>
 <br />
 
-<div class="box">
+<div class='box'>
   <!-- *ngFor w/ hero-detail Component -->
-  <app-hero-detail *ngFor="let hero of heroes" [hero]="hero"></app-hero-detail>
+  <app-hero-detail *ngFor='let hero of heroes' [hero]='hero'></app-hero-detail>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <h4 id="ngFor-index">*ngFor with index</h4>
 <p>with <i>semi-colon</i> separator</p>
-<div class="box">
-  <div *ngFor="let hero of heroes; let i = index">
+<div class='box'>
+  <div *ngFor='let hero of heroes; let i = index'>
     {{ i + 1 }} - {{ hero.name }}
   </div>
 </div>
 
 <p>with <i>comma</i> separator</p>
-<div class="box">
+<div class='box'>
   <!-- Ex: "1 - Hercules" -->
-  <div *ngFor="let hero of heroes; let i = index">
+  <div *ngFor='let hero of heroes; let i = index'>
     {{ i + 1 }} - {{ hero.name }}
   </div>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <h4 id="ngFor-trackBy">*ngFor trackBy</h4>
-<button (click)="resetHeroes()">Reset heroes</button>
-<button (click)="changeIds()">Change ids</button>
-<button (click)="clearTrackByCounts()">Clear counts</button>
+<button (click)='resetHeroes()'>Reset heroes</button>
+<button (click)='changeIds()'>Change ids</button>
+<button (click)='clearTrackByCounts()'>Clear counts</button>
 
 <p><i>without</i> trackBy</p>
-<div class="box">
-  <div #noTrackBy *ngFor="let hero of heroes">
+<div class='box'>
+  <div #noTrackBy *ngFor='let hero of heroes'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 
-  <div id="noTrackByCnt" *ngIf="heroesNoTrackByCount">
+  <div id="noTrackByCnt" *ngIf='heroesNoTrackByCount'>
     Hero DOM elements change #{{ heroesNoTrackByCount }} without trackBy
   </div>
 </div>
 
 <p>with trackBy</p>
-<div class="box">
-  <div #withTrackBy *ngFor="let hero of heroes; trackBy: trackByHeroes">
+<div class='box'>
+  <div #withTrackBy *ngFor='let hero of heroes; trackBy: trackByHeroes'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 
-  <div id="withTrackByCnt" *ngIf="heroesWithTrackByCount">
+  <div id="withTrackByCnt" *ngIf='heroesWithTrackByCount'>
     Hero DOM elements change #{{ heroesWithTrackByCount }} with trackBy
   </div>
 </div>
@@ -5271,34 +5271,34 @@ bindon-ngModel
 <br /><br /><br />
 
 <p>with trackBy and <i>semi-colon</i> separator</p>
-<div class="box">
-  <div *ngFor="let hero of heroes; trackBy: trackByHeroes">
+<div class='box'>
+  <div *ngFor='let hero of heroes; trackBy: trackByHeroes'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 </div>
 
 <p>with trackBy and <i>comma</i> separator</p>
-<div class="box">
-  <div *ngFor="let hero of heroes; trackBy: trackByHeroes">
+<div class='box'>
+  <div *ngFor='let hero of heroes; trackBy: trackByHeroes'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 </div>
 
 <p>with trackBy and <i>space</i> separator</p>
-<div class="box">
-  <div *ngFor="let hero of heroes; trackBy: trackByHeroes">
+<div class='box'>
+  <div *ngFor='let hero of heroes; trackBy: trackByHeroes'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 </div>
 
 <p>with <i>generic</i> trackById function</p>
-<div class="box">
-  <div *ngFor="let hero of heroes; trackBy: trackById">
+<div class='box'>
+  <div *ngFor='let hero of heroes; trackBy: trackById'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- NgSwitch binding -->
 <hr />
@@ -5306,27 +5306,27 @@ bindon-ngModel
 
 <p>Pick your favorite hero</p>
 <div>
-  <label *ngFor="let h of heroes">
-    <input type="radio" name="heroes" [(ngModel)]="currentHero" [value]="h" />{{
+  <label *ngFor='let h of heroes'>
+    <input type="radio" name="heroes" [(ngModel)]='currentHero' [value]='h' />{{
       h.name
     }}
   </label>
 </div>
 
-<div [ngSwitch]="currentHero.emotion">
-  <app-happy-hero *ngSwitchCase="'happy'" [hero]="currentHero"></app-happy-hero>
-  <app-sad-hero *ngSwitchCase="'sad'" [hero]="currentHero"></app-sad-hero>
+<div [ngSwitch]='currentHero.emotion'>
+  <app-happy-hero *ngSwitchCase=''happy'' [hero]='currentHero'></app-happy-hero>
+  <app-sad-hero *ngSwitchCase=''sad'' [hero]='currentHero'></app-sad-hero>
   <app-confused-hero
-    *ngSwitchCase="'confused'"
-    [hero]="currentHero"
+    *ngSwitchCase=''confused''
+    [hero]='currentHero'
   ></app-confused-hero>
-  <div *ngSwitchCase="'confused'">
+  <div *ngSwitchCase=''confused''>
     Are you as confused as {{ currentHero.name }}?
   </div>
-  <app-unknown-hero *ngSwitchDefault [hero]="currentHero"></app-unknown-hero>
+  <app-unknown-hero *ngSwitchDefault [hero]='currentHero'></app-unknown-hero>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- template reference variable -->
 <hr />
@@ -5337,37 +5337,37 @@ bindon-ngModel
 <!-- lots of other elements -->
 
 <!-- phone refers to the input element; pass its \`value\` to an event handler -->
-<button (click)="callPhone(phone.value)">Call</button>
+<button (click)='callPhone(phone.value)'>Call</button>
 
 <input ref-fax placeholder="fax number" />
-<button (click)="callFax(fax.value)">Fax</button>
+<button (click)='callFax(fax.value)'>Fax</button>
 
 <!-- btn refers to the button element; show its disabled state -->
 <button
   #btn
   disabled
-  [innerHTML]="'disabled by attribute: ' + btn.disabled"
+  [innerHTML]=''disabled by attribute: ' + btn.disabled'
 ></button>
 
 <h4>Example Form</h4>
-<app-hero-form [hero]="currentHero"></app-hero-form>
+<app-hero-form [hero]='currentHero'></app-hero-form>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- inputs and output -->
 <hr />
 <h2 id="inputs-and-outputs">Inputs and Outputs</h2>
 
-<img [src]="iconUrl" />
-<button (click)="onSave()">Save</button>
+<img [src]='iconUrl' />
+<button (click)='onSave()'>Save</button>
 
-<app-hero-detail [hero]="currentHero" (deleteRequest)="deleteHero($event)">
+<app-hero-detail [hero]='currentHero' (deleteRequest)='deleteHero($event)'>
 </app-hero-detail>
 
-<div (myClick)="clickMessage2 = $event" clickable>myClick2</div>
+<div (myClick)='clickMessage2 = $event' clickable>myClick2</div>
 {{ clickMessage2 }}
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- Pipes -->
 <hr />
@@ -5395,7 +5395,7 @@ bindon-ngModel
   <label>Price: </label>{{ product.price | currency: "USD" : true }}
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- Null values and the safe navigation operator -->
 <hr />
@@ -5415,7 +5415,7 @@ See console log:
 -->
 
 <!--No hero, div not displayed, no error -->
-<div *ngIf="nullHero">The null hero's name is {{ nullHero.name }}</div>
+<div *ngIf='nullHero'>The null hero's name is {{ nullHero.name }}</div>
 
 <div>The null hero's name is {{ nullHero && nullHero.name }}</div>
 
@@ -5424,7 +5424,7 @@ See console log:
   The null hero's name is {{ nullHero?.name }}
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- non-null assertion operator -->
 <hr />
@@ -5432,10 +5432,10 @@ See console log:
 
 <div>
   <!--No hero, no text -->
-  <div *ngIf="hero">The hero's name is {{ hero!.name }}</div>
+  <div *ngIf='hero'>The hero's name is {{ hero!.name }}</div>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- non-null assertion operator -->
 <hr />
@@ -5451,7 +5451,7 @@ See console log:
   <div>Undeclared members is {{ $any(this).member }}</div>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- TODO: discuss this in the Style binding section -->
 <!-- enums in bindings -->
@@ -5461,12 +5461,12 @@ See console log:
 <p>
   The name of the Color.Red enum is {{ Color[Color.Red] }}.<br />
   The current color is {{ Color[color] }} and its number is {{ color }}.<br />
-  <button [style.color]="Color[color]" (click)="colorToggle()">
+  <button [style.color]='Color[color]' (click)='colorToggle()'>
     Enum Toggle
   </button>
 </p>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- 
 Copyright 2017-2018 Google Inc. All Rights Reserved.
@@ -5475,21 +5475,21 @@ can be found in the LICENSE file at http://angular.io/license
 -->
 
 <div id="heroForm">
-  <form (ngSubmit)="onSubmit(heroForm)" #heroForm="ngForm">
-    <div class="form-group">
+  <form (ngSubmit)='onSubmit(heroForm)' #heroForm="ngForm">
+    <div class='form-group'>
       <label for="name"
         >Name
         <input
-          class="form-control"
+          class='form-control'
           name="name"
           required
-          [(ngModel)]="hero.name"
+          [(ngModel)]='hero.name'
         />
       </label>
     </div>
-    <button type="submit" [disabled]="!heroForm.form.valid">Submit</button>
+    <button type="submit" [disabled]='!heroForm.form.valid'>Submit</button>
   </form>
-  <div [hidden]="!heroForm.form.valid">
+  <div [hidden]='!heroForm.form.valid'>
     {{ submitMessage }}
   </div>
 </div>
@@ -6249,7 +6249,7 @@ can be found in the LICENSE file at http://angular.io/license
 <br />
 <a href="#property-binding">Property Binding</a>
 <br />
-<div style="margin-left: 8px">
+<div style='margin-left: 8px'>
   <a href="#attribute-binding">Attribute Binding</a>
   <br />
   <a href="#class-binding">Class Binding</a>
@@ -6264,7 +6264,7 @@ can be found in the LICENSE file at http://angular.io/license
 <br />
 <br />
 <div>Directives</div>
-<div style="margin-left: 8px">
+<div style='margin-left: 8px'>
   <a href="#ngModel">NgModel (two-way) Binding</a>
   <br />
   <a href="#ngClass">NgClass Binding</a>
@@ -6275,7 +6275,7 @@ can be found in the LICENSE file at http://angular.io/license
   <br />
   <a href="#ngFor">NgFor</a>
   <br />
-  <div style="margin-left: 8px">
+  <div style='margin-left: 8px'>
     <a href="#ngFor-index">NgFor with index</a>
     <br />
     <a href="#ngFor-trackBy">NgFor with trackBy</a>
@@ -6312,7 +6312,7 @@ can be found in the LICENSE file at http://angular.io/license
 
 <h3>
   {{ title }}
-  <img src="{{ heroImageUrl }}" style="height: 30px" />
+  <img src='{{ heroImageUrl }}' style='height: 30px' />
 </h3>
 
 <!-- "The sum of 1 + 1 is 2" -->
@@ -6321,7 +6321,7 @@ can be found in the LICENSE file at http://angular.io/license
 <!-- "The sum of 1 + 1 is not 4" -->
 <p>The sum of 1 + 1 is not {{ 1 + 1 + getVal() }}</p>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <hr />
 <h2 id="expression-context">Expression context</h2>
@@ -6330,53 +6330,53 @@ can be found in the LICENSE file at http://angular.io/license
   Component expression context (&#123;&#123;title&#125;&#125;,
   [hidden]="isUnchanged")
 </p>
-<div class="context">
+<div class='context'>
   {{ title }}
-  <span [hidden]="isUnchanged">changed</span>
+  <span [hidden]='isUnchanged'>changed</span>
 </div>
 
 <p>Template input variable expression context (let hero)</p>
 <!-- template hides the following; plenty of examples later -->
 <ng-template>
-  <div *ngFor="let hero of heroes">{{ hero.name }}</div>
+  <div *ngFor='let hero of heroes'>{{ hero.name }}</div>
 </ng-template>
 
 <p>Template reference variable expression context (#heroInput)</p>
-<div (keyup)="(0)" class="context">
+<div (keyup)='(0)' class='context'>
   Type something:
   <input #heroInput />
   {{ heroInput.value }}
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <hr />
 <h2 id="statement-context">Statement context</h2>
 
 <p>Component statement context ( (click)="onSave() )</p>
-<div class="context">
-  <button (click)="deleteHero()">Delete hero</button>
+<div class='context'>
+  <button (click)='deleteHero()'>Delete hero</button>
 </div>
 
 <p>Template $event statement context</p>
-<div class="context">
-  <button (click)="onSave($event)">Save</button>
+<div class='context'>
+  <button (click)='onSave($event)'>Save</button>
 </div>
 
 <p>Template input variable statement context (let hero)</p>
 <!-- template hides the following; plenty of examples later -->
-<div class="context">
-  <button *ngFor="let hero of heroes" (click)="deleteHero(hero)">
+<div class='context'>
+  <button *ngFor='let hero of heroes' (click)='deleteHero(hero)'>
     {{ hero.name }}
   </button>
 </div>
 
 <p>Template reference variable statement context (#heroForm)</p>
-<div class="context">
-  <form #heroForm (ngSubmit)="onSubmit(heroForm)">...</form>
+<div class='context'>
+  <form #heroForm (ngSubmit)='onSubmit(heroForm)'>...</form>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- New Mental Model -->
 <hr />
@@ -6384,7 +6384,7 @@ can be found in the LICENSE file at http://angular.io/license
 
 <!--<img src="http://www.wpclipart.com/cartoon/people/hero/hero_silhoutte_T.png">-->
 <!-- Public Domain terms of use: http://www.wpclipart.com/terms.html -->
-<div class="special">Mental Model</div>
+<div class='special'>Mental Model</div>
 <img src="assets/images/hero.png" />
 <button disabled>Save</button>
 <br />
@@ -6392,7 +6392,7 @@ can be found in the LICENSE file at http://angular.io/license
 
 <div>
   <!-- Normal HTML -->
-  <div class="special">Mental Model</div>
+  <div class='special'>Mental Model</div>
   <!-- Wow! A new element! -->
   <app-hero-detail></app-hero-detail>
 </div>
@@ -6401,60 +6401,60 @@ can be found in the LICENSE file at http://angular.io/license
 
 <div>
   <!-- Bind button disabled state to \`isUnchanged\` property -->
-  <button [disabled]="isUnchanged">Save</button>
+  <button [disabled]='isUnchanged'>Save</button>
 </div>
 <br />
 <br />
 
 <div>
-  <img [src]="heroImageUrl" />
-  <app-hero-detail [hero]="currentHero"></app-hero-detail>
-  <div [ngClass]="{ special: isSpecial }"></div>
+  <img [src]='heroImageUrl' />
+  <app-hero-detail [hero]='currentHero'></app-hero-detail>
+  <div [ngClass]='{ special: isSpecial }'></div>
 </div>
 <br />
 <br />
 
-<button (click)="onSave()">Save</button>
-<app-hero-detail (deleteRequest)="deleteHero()"></app-hero-detail>
-<div (myClick)="clicked = $event" clickable>click me</div>
+<button (click)='onSave()'>Save</button>
+<app-hero-detail (deleteRequest)='deleteHero()'></app-hero-detail>
+<div (myClick)='clicked = $event' clickable>click me</div>
 {{ clicked }}
 <br />
 <br />
 
 <div>
   Hero Name:
-  <input [(ngModel)]="name" />
+  <input [(ngModel)]='name' />
   {{ name }}
 </div>
 <br />
 <br />
 
-<button [attr.aria-label]="help">help</button>
+<button [attr.aria-label]='help'>help</button>
 <br />
 <br />
 
-<div [class.special]="isSpecial">Special</div>
+<div [class.special]='isSpecial'>Special</div>
 <br />
 <br />
 
-<button [style.color]="isSpecial ? 'red' : 'green'">button</button>
+<button [style.color]='isSpecial ? 'red' : 'green''>button</button>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- property vs. attribute -->
 <hr />
 <h2 id="prop-vs-attrib">Property vs. Attribute (img examples)</h2>
 <!-- examine the following <img> tag in the browser tools -->
-<img src="images/ng-logo.png" [src]="heroImageUrl" />
+<img src="images/ng-logo.png" [src]='heroImageUrl' />
 
 <br />
 <br />
 
-<img [src]="iconUrl" />
-<img bind-src="heroImageUrl" />
-<img [attr.src]="villainImageUrl" />
+<img [src]='iconUrl' />
+<img bind-src='heroImageUrl' />
+<img [attr.src]='villainImageUrl' />
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- buttons -->
 <hr />
@@ -6466,41 +6466,41 @@ can be found in the LICENSE file at http://angular.io/license
 <br />
 <br />
 <button disabled>disabled by attribute</button>
-<button [disabled]="isUnchanged">disabled by property binding</button>
+<button [disabled]='isUnchanged'>disabled by property binding</button>
 <br />
 <br />
-<button bind-disabled="isUnchanged" on-click="onSave($event)">
+<button bind-disabled='isUnchanged' on-click='onSave($event)'>
   Disabled Cancel
 </button>
-<button [disabled]="!canSave" (click)="onSave($event)">Enabled Save</button>
+<button [disabled]='!canSave' (click)='onSave($event)'>Enabled Save</button>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- property binding -->
 <hr />
 <h2 id="property-binding">Property Binding</h2>
 
-<img [src]="heroImageUrl" />
-<button [disabled]="isUnchanged">Cancel is disabled</button>
-<div [ngClass]="classes">[ngClass] binding to the classes property</div>
-<app-hero-detail [hero]="currentHero"></app-hero-detail>
-<img bind-src="heroImageUrl" />
+<img [src]='heroImageUrl' />
+<button [disabled]='isUnchanged'>Cancel is disabled</button>
+<div [ngClass]='classes'>[ngClass] binding to the classes property</div>
+<app-hero-detail [hero]='currentHero'></app-hero-detail>
+<img bind-src='heroImageUrl' />
 
 <!-- ERROR: HeroDetailComponent.hero expects a
      Hero object, not the string "currentHero" -->
-<div *ngIf="false">
+<div *ngIf='false'>
   <app-hero-detail hero="currentHero"></app-hero-detail>
 </div>
-<app-hero-detail prefix="You are my" [hero]="currentHero"></app-hero-detail>
+<app-hero-detail prefix="You are my" [hero]='currentHero'></app-hero-detail>
 
 <p>
-  <img src="{{ heroImageUrl }}" />
+  <img src='{{ heroImageUrl }}' />
   is the
   <i>interpolated</i>
   image.
 </p>
 <p>
-  <img [src]="heroImageUrl" />
+  <img [src]='heroImageUrl' />
   is the
   <i>property bound</i>
   image.
@@ -6515,7 +6515,7 @@ can be found in the LICENSE file at http://angular.io/license
 </p>
 <p>
   "
-  <span [innerHTML]="title"></span>
+  <span [innerHTML]='title'></span>
   " is the
   <i>property bound</i>
   title.
@@ -6534,13 +6534,13 @@ can be found in the LICENSE file at http://angular.io/license
 </p>
 <p>
   "
-  <span [innerHTML]="evilTitle"></span>
+  <span [innerHTML]='evilTitle'></span>
   " is the
   <i>property bound</i>
   evil title.
 </p>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- attribute binding -->
 <hr />
@@ -6549,7 +6549,7 @@ can be found in the LICENSE file at http://angular.io/license
 <!--  create and set a colspan attribute -->
 <table border="1">
   <!--  expression calculates colspan=2 -->
-  <tr><td [attr.colspan]="1 + 1">One-Two</td></tr>
+  <tr><td [attr.colspan]='1 + 1'>One-Two</td></tr>
 
   <!-- ERROR: There is no \`colspan\` property to set!
     <tr><td colspan="{{1 + 1}}">Three-Four</td></tr>
@@ -6563,117 +6563,117 @@ can be found in the LICENSE file at http://angular.io/license
 
 <br />
 <!-- create and set an aria attribute for assistive technology -->
-<button [attr.aria-label]="actionName">{{ actionName }} with Aria</button>
+<button [attr.aria-label]='actionName'>{{ actionName }} with Aria</button>
 <br />
 <br />
 
 <!-- The following effects are not discussed in the chapter -->
 <div>
   <!-- any use of [attr.disabled] creates the disabled attribute -->
-  <button [attr.disabled]="isUnchanged">Disabled</button>
+  <button [attr.disabled]='isUnchanged'>Disabled</button>
 
-  <button [attr.disabled]="!isUnchanged">Disabled as well</button>
+  <button [attr.disabled]='!isUnchanged'>Disabled as well</button>
 
   <!-- we'd have to remove it with property binding -->
-  <button disabled [disabled]="false">Enabled (but inert)</button>
+  <button disabled [disabled]='false'>Enabled (but inert)</button>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- class binding -->
 <hr />
 <h2 id="class-binding">Class Binding</h2>
 
 <!-- standard class attribute setting  -->
-<div class="bad curly special">Bad curly special</div>
+<div class='bad curly special'>Bad curly special</div>
 
 <!-- reset/override all class names with a binding  -->
-<div class="bad curly special" [class]="badCurly">Bad curly</div>
+<div class='bad curly special' [class]='badCurly'>Bad curly</div>
 
 <!-- toggle the "special" class on/off with a property -->
-<div [class.special]="isSpecial">The class binding is special</div>
+<div [class.special]='isSpecial'>The class binding is special</div>
 
 <!-- binding to \`class.special\` trumps the class attribute -->
-<div class="special" [class.special]="!isSpecial">
+<div class='special' [class.special]='!isSpecial'>
   This one is not so special
 </div>
 
-<div bind-class.special="isSpecial">This class binding is special too</div>
+<div bind-class.special='isSpecial'>This class binding is special too</div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!--style binding -->
 <hr />
 <h2 id="style-binding">Style Binding</h2>
 
-<button [style.color]="isSpecial ? 'red' : 'green'">Red</button>
-<button [style.background-color]="canSave ? 'cyan' : 'grey'">Save</button>
+<button [style.color]='isSpecial ? 'red' : 'green''>Red</button>
+<button [style.background-color]='canSave ? 'cyan' : 'grey''>Save</button>
 
-<button [style.font-size.em]="isSpecial ? 3 : 1">Big</button>
-<button [style.font-size.%]="!isSpecial ? 150 : 50">Small</button>
+<button [style.font-size.em]='isSpecial ? 3 : 1'>Big</button>
+<button [style.font-size.%]='!isSpecial ? 150 : 50'>Small</button>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- event binding -->
 <hr />
 <h2 id="event-binding">Event Binding</h2>
 
-<button (click)="onSave()">Save</button>
+<button (click)='onSave()'>Save</button>
 
-<button on-click="onSave()">On Save</button>
+<button on-click='onSave()'>On Save</button>
 
 <div>
   <!-- \`myClick\` is an event on the custom \`ClickDirective\` -->
-  <div (myClick)="clickMessage = $event" clickable>click with myClick</div>
+  <div (myClick)='clickMessage = $event' clickable>click with myClick</div>
   {{ clickMessage }}
 </div>
 
 <!-- binding to a nested component -->
 <app-hero-detail
-  (deleteRequest)="deleteHero($event)"
-  [hero]="currentHero"
+  (deleteRequest)='deleteHero($event)'
+  [hero]='currentHero'
 ></app-hero-detail>
 <br />
 
 <app-big-hero-detail
-  (deleteRequest)="deleteHero($event)"
-  [hero]="currentHero"
+  (deleteRequest)='deleteHero($event)'
+  [hero]='currentHero'
 ></app-big-hero-detail>
 
-<div class="parent-div" (click)="onClickMe($event)" clickable>
+<div class='parent-div' (click)='onClickMe($event)' clickable>
   Click me
-  <div class="child-div">Click me too!</div>
+  <div class='child-div'>Click me too!</div>
 </div>
 
 <!-- Will save only once -->
-<div (click)="onSave()" clickable>
-  <button (click)="onSave($event)">Save, no propagation</button>
+<div (click)='onSave()' clickable>
+  <button (click)='onSave($event)'>Save, no propagation</button>
 </div>
 
 <!-- Will save twice -->
-<div (click)="onSave()" clickable>
-  <button (click)="onSave()">Save w/ propagation</button>
+<div (click)='onSave()' clickable>
+  <button (click)='onSave()'>Save w/ propagation</button>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <hr />
 <h2 id="two-way">Two-way Binding</h2>
 <div id="two-way-1">
-  <app-sizer [(size)]="fontSizePx"></app-sizer>
-  <div [style.font-size.px]="fontSizePx">Resizable Text</div>
+  <app-sizer [(size)]='fontSizePx'></app-sizer>
+  <div [style.font-size.px]='fontSizePx'>Resizable Text</div>
   <label>
     FontSize (px):
-    <input [(ngModel)]="fontSizePx" />
+    <input [(ngModel)]='fontSizePx' />
   </label>
 </div>
 <br />
 <div id="two-way-2">
   <h3>De-sugared two-way binding</h3>
-  <app-sizer [size]="fontSizePx" (sizeChange)="fontSizePx = $event"></app-sizer>
+  <app-sizer [size]='fontSizePx' (sizeChange)='fontSizePx = $event'></app-sizer>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- Two way data binding unwound;
     passing the changed display value to the event handler via \`$event\` -->
@@ -6683,37 +6683,37 @@ can be found in the LICENSE file at http://angular.io/license
 <h3>Result: {{ currentHero.name }}</h3>
 
 <input
-  [value]="currentHero.name"
-  (input)="currentHero.name = $event.target.value"
+  [value]='currentHero.name'
+  (input)='currentHero.name = $event.target.value'
 />
 without NgModel
 <br />
-<input [(ngModel)]="currentHero.name" />
+<input [(ngModel)]='currentHero.name' />
 [(ngModel)]
 <br />
-<input bindon-ngModel="currentHero.name" />
+<input bindon-ngModel='currentHero.name' />
 bindon-ngModel
 <br />
 <input
-  [ngModel]="currentHero.name"
-  (ngModelChange)="currentHero.name = $event"
+  [ngModel]='currentHero.name'
+  (ngModelChange)='currentHero.name = $event'
 />
 (ngModelChange)="...name=$event"
 <br />
 <input
-  [ngModel]="currentHero.name"
-  (ngModelChange)="setUppercaseName($event)"
+  [ngModel]='currentHero.name'
+  (ngModelChange)='setUppercaseName($event)'
 />
 (ngModelChange)="setUppercaseName($event)"
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- NgClass binding -->
 <hr />
 <h2 id="ngClass">NgClass Binding</h2>
 
 <p>currentClasses is {{ currentClasses | json }}</p>
-<div [ngClass]="currentClasses">
+<div [ngClass]='currentClasses'>
   This div is initially saveable, unchanged, and special
 </div>
 
@@ -6721,26 +6721,26 @@ bindon-ngModel
 <br />
 <label>
   saveable
-  <input type="checkbox" [(ngModel)]="canSave" />
+  <input type="checkbox" [(ngModel)]='canSave' />
 </label>
 |
 <label>
   modified:
   <input
     type="checkbox"
-    [value]="!isUnchanged"
-    (change)="isUnchanged = !isUnchanged"
+    [value]='!isUnchanged'
+    (change)='isUnchanged = !isUnchanged'
   />
 </label>
 |
 <label>
   special:
-  <input type="checkbox" [(ngModel)]="isSpecial" />
+  <input type="checkbox" [(ngModel)]='isSpecial' />
 </label>
-<button (click)="setCurrentClasses()">Refresh currentClasses</button>
+<button (click)='setCurrentClasses()'>Refresh currentClasses</button>
 <br />
 <br />
-<div [ngClass]="currentClasses">
+<div [ngClass]='currentClasses'>
   This div should be {{ canSave ? "" : "not" }} saveable,
   {{ isUnchanged ? "unchanged" : "modified" }} and,
   {{ isSpecial ? "" : "not" }} special after clicking "Refresh".
@@ -6748,24 +6748,24 @@ bindon-ngModel
 <br />
 <br />
 
-<div [ngClass]="isSpecial ? 'special' : ''">This div is special</div>
+<div [ngClass]='isSpecial ? 'special' : '''>This div is special</div>
 
-<div class="bad curly special">Bad curly special</div>
-<div [ngClass]="{ bad: false, curly: true, special: true }">Curly special</div>
+<div class='bad curly special'>Bad curly special</div>
+<div [ngClass]='{ bad: false, curly: true, special: true }'>Curly special</div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- NgStyle binding -->
 <hr />
 <h2 id="ngStyle">NgStyle Binding</h2>
 
-<div [style.font-size]="isSpecial ? 'x-large' : 'smaller'">
+<div [style.font-size]='isSpecial ? 'x-large' : 'smaller''>
   This div is x-large or smaller.
 </div>
 
 <h3>[ngStyle] binding to currentStyles - CSS property names</h3>
 <p>currentStyles is {{ currentStyles | json }}</p>
-<div [ngStyle]="currentStyles">
+<div [ngStyle]='currentStyles'>
   This div is initially italic, normal weight, and extra large (24px).
 </div>
 
@@ -6773,77 +6773,77 @@ bindon-ngModel
 <br />
 <label>
   italic:
-  <input type="checkbox" [(ngModel)]="canSave" />
+  <input type="checkbox" [(ngModel)]='canSave' />
 </label>
 |
 <label>
   normal:
-  <input type="checkbox" [(ngModel)]="isUnchanged" />
+  <input type="checkbox" [(ngModel)]='isUnchanged' />
 </label>
 |
 <label>
   xlarge:
-  <input type="checkbox" [(ngModel)]="isSpecial" />
+  <input type="checkbox" [(ngModel)]='isSpecial' />
 </label>
-<button (click)="setCurrentStyles()">Refresh currentStyles</button>
+<button (click)='setCurrentStyles()'>Refresh currentStyles</button>
 <br />
 <br />
-<div [ngStyle]="currentStyles">
+<div [ngStyle]='currentStyles'>
   This div should be {{ canSave ? "italic" : "plain" }},
   {{ isUnchanged ? "normal weight" : "bold" }} and,
   {{ isSpecial ? "extra large" : "normal size" }} after clicking "Refresh".
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- NgIf binding -->
 <hr />
 <h2 id="ngIf">NgIf Binding</h2>
 
-<app-hero-detail *ngIf="isActive"></app-hero-detail>
+<app-hero-detail *ngIf='isActive'></app-hero-detail>
 
-<div *ngIf="currentHero">Hello, {{ currentHero.name }}</div>
-<div *ngIf="nullHero">Hello, {{ nullHero.name }}</div>
+<div *ngIf='currentHero'>Hello, {{ currentHero.name }}</div>
+<div *ngIf='nullHero'>Hello, {{ nullHero.name }}</div>
 
 <!-- NgIf binding with template (no *) -->
 
-<ng-template [ngIf]="currentHero">
+<ng-template [ngIf]='currentHero'>
   Add {{ currentHero.name }} with template
 </ng-template>
 
 <!-- Does not show because isActive is false! -->
 <div>Hero Detail removed from DOM (via template) because isActive is false</div>
-<ng-template [ngIf]="isActive">
+<ng-template [ngIf]='isActive'>
   <app-hero-detail></app-hero-detail>
 </ng-template>
 
 <!-- isSpecial is true -->
-<div [class.hidden]="!isSpecial">Show with class</div>
-<div [class.hidden]="isSpecial">Hide with class</div>
+<div [class.hidden]='!isSpecial'>Show with class</div>
+<div [class.hidden]='isSpecial'>Hide with class</div>
 
 <!-- HeroDetail is in the DOM but hidden -->
-<app-hero-detail [class.hidden]="isSpecial"></app-hero-detail>
+<app-hero-detail [class.hidden]='isSpecial'></app-hero-detail>
 
-<div [style.display]="isSpecial ? 'block' : 'none'">Show with style</div>
-<div [style.display]="isSpecial ? 'none' : 'block'">Hide with style</div>
+<div [style.display]='isSpecial ? 'block' : 'none''>Show with style</div>
+<div [style.display]='isSpecial ? 'none' : 'block''>Hide with style</div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- NgFor binding -->
 <hr />
 <h2 id="ngFor">NgFor Binding</h2>
 
-<div class="box">
-  <div *ngFor="let hero of heroes">{{ hero.name }}</div>
+<div class='box'>
+  <div *ngFor='let hero of heroes'>{{ hero.name }}</div>
 </div>
 <br />
 
-<div class="box">
+<div class='box'>
   <!-- *ngFor w/ hero-detail Component -->
-  <app-hero-detail *ngFor="let hero of heroes" [hero]="hero"></app-hero-detail>
+  <app-hero-detail *ngFor='let hero of heroes' [hero]='hero'></app-hero-detail>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <h4 id="ngFor-index">*ngFor with index</h4>
 <p>
@@ -6851,8 +6851,8 @@ bindon-ngModel
   <i>semi-colon</i>
   separator
 </p>
-<div class="box">
-  <div *ngFor="let hero of heroes; let i = index">
+<div class='box'>
+  <div *ngFor='let hero of heroes; let i = index'>
     {{ i + 1 }} - {{ hero.name }}
   </div>
 </div>
@@ -6862,41 +6862,41 @@ bindon-ngModel
   <i>comma</i>
   separator
 </p>
-<div class="box">
+<div class='box'>
   <!-- Ex: "1 - Hercules" -->
-  <div *ngFor="let hero of heroes; let i = index">
+  <div *ngFor='let hero of heroes; let i = index'>
     {{ i + 1 }} - {{ hero.name }}
   </div>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <h4 id="ngFor-trackBy">*ngFor trackBy</h4>
-<button (click)="resetHeroes()">Reset heroes</button>
-<button (click)="changeIds()">Change ids</button>
-<button (click)="clearTrackByCounts()">Clear counts</button>
+<button (click)='resetHeroes()'>Reset heroes</button>
+<button (click)='changeIds()'>Change ids</button>
+<button (click)='clearTrackByCounts()'>Clear counts</button>
 
 <p>
   <i>without</i>
   trackBy
 </p>
-<div class="box">
-  <div #noTrackBy *ngFor="let hero of heroes">
+<div class='box'>
+  <div #noTrackBy *ngFor='let hero of heroes'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 
-  <div id="noTrackByCnt" *ngIf="heroesNoTrackByCount">
+  <div id="noTrackByCnt" *ngIf='heroesNoTrackByCount'>
     Hero DOM elements change #{{ heroesNoTrackByCount }} without trackBy
   </div>
 </div>
 
 <p>with trackBy</p>
-<div class="box">
-  <div #withTrackBy *ngFor="let hero of heroes; trackBy: trackByHeroes">
+<div class='box'>
+  <div #withTrackBy *ngFor='let hero of heroes; trackBy: trackByHeroes'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 
-  <div id="withTrackByCnt" *ngIf="heroesWithTrackByCount">
+  <div id="withTrackByCnt" *ngIf='heroesWithTrackByCount'>
     Hero DOM elements change #{{ heroesWithTrackByCount }} with trackBy
   </div>
 </div>
@@ -6910,8 +6910,8 @@ bindon-ngModel
   <i>semi-colon</i>
   separator
 </p>
-<div class="box">
-  <div *ngFor="let hero of heroes; trackBy: trackByHeroes">
+<div class='box'>
+  <div *ngFor='let hero of heroes; trackBy: trackByHeroes'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 </div>
@@ -6921,8 +6921,8 @@ bindon-ngModel
   <i>comma</i>
   separator
 </p>
-<div class="box">
-  <div *ngFor="let hero of heroes; trackBy: trackByHeroes">
+<div class='box'>
+  <div *ngFor='let hero of heroes; trackBy: trackByHeroes'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 </div>
@@ -6932,8 +6932,8 @@ bindon-ngModel
   <i>space</i>
   separator
 </p>
-<div class="box">
-  <div *ngFor="let hero of heroes; trackBy: trackByHeroes">
+<div class='box'>
+  <div *ngFor='let hero of heroes; trackBy: trackByHeroes'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 </div>
@@ -6943,13 +6943,13 @@ bindon-ngModel
   <i>generic</i>
   trackById function
 </p>
-<div class="box">
-  <div *ngFor="let hero of heroes; trackBy: trackById">
+<div class='box'>
+  <div *ngFor='let hero of heroes; trackBy: trackById'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- NgSwitch binding -->
 <hr />
@@ -6957,26 +6957,26 @@ bindon-ngModel
 
 <p>Pick your favorite hero</p>
 <div>
-  <label *ngFor="let h of heroes">
-    <input type="radio" name="heroes" [(ngModel)]="currentHero" [value]="h" />
+  <label *ngFor='let h of heroes'>
+    <input type="radio" name="heroes" [(ngModel)]='currentHero' [value]='h' />
     {{ h.name }}
   </label>
 </div>
 
-<div [ngSwitch]="currentHero.emotion">
-  <app-happy-hero *ngSwitchCase="'happy'" [hero]="currentHero"></app-happy-hero>
-  <app-sad-hero *ngSwitchCase="'sad'" [hero]="currentHero"></app-sad-hero>
+<div [ngSwitch]='currentHero.emotion'>
+  <app-happy-hero *ngSwitchCase=''happy'' [hero]='currentHero'></app-happy-hero>
+  <app-sad-hero *ngSwitchCase=''sad'' [hero]='currentHero'></app-sad-hero>
   <app-confused-hero
-    *ngSwitchCase="'confused'"
-    [hero]="currentHero"
+    *ngSwitchCase=''confused''
+    [hero]='currentHero'
   ></app-confused-hero>
-  <div *ngSwitchCase="'confused'">
+  <div *ngSwitchCase=''confused''>
     Are you as confused as {{ currentHero.name }}?
   </div>
-  <app-unknown-hero *ngSwitchDefault [hero]="currentHero"></app-unknown-hero>
+  <app-unknown-hero *ngSwitchDefault [hero]='currentHero'></app-unknown-hero>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- template reference variable -->
 <hr />
@@ -6987,39 +6987,39 @@ bindon-ngModel
 <!-- lots of other elements -->
 
 <!-- phone refers to the input element; pass its \`value\` to an event handler -->
-<button (click)="callPhone(phone.value)">Call</button>
+<button (click)='callPhone(phone.value)'>Call</button>
 
 <input ref-fax placeholder="fax number" />
-<button (click)="callFax(fax.value)">Fax</button>
+<button (click)='callFax(fax.value)'>Fax</button>
 
 <!-- btn refers to the button element; show its disabled state -->
 <button
   #btn
   disabled
-  [innerHTML]="'disabled by attribute: ' + btn.disabled"
+  [innerHTML]=''disabled by attribute: ' + btn.disabled'
 ></button>
 
 <h4>Example Form</h4>
-<app-hero-form [hero]="currentHero"></app-hero-form>
+<app-hero-form [hero]='currentHero'></app-hero-form>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- inputs and output -->
 <hr />
 <h2 id="inputs-and-outputs">Inputs and Outputs</h2>
 
-<img [src]="iconUrl" />
-<button (click)="onSave()">Save</button>
+<img [src]='iconUrl' />
+<button (click)='onSave()'>Save</button>
 
 <app-hero-detail
-  [hero]="currentHero"
-  (deleteRequest)="deleteHero($event)"
+  [hero]='currentHero'
+  (deleteRequest)='deleteHero($event)'
 ></app-hero-detail>
 
-<div (myClick)="clickMessage2 = $event" clickable>myClick2</div>
+<div (myClick)='clickMessage2 = $event' clickable>myClick2</div>
 {{ clickMessage2 }}
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- Pipes -->
 <hr />
@@ -7048,7 +7048,7 @@ bindon-ngModel
   {{ product.price | currency: "USD" : true }}
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- Null values and the safe navigation operator -->
 <hr />
@@ -7071,7 +7071,7 @@ See console log:
 -->
 
 <!--No hero, div not displayed, no error -->
-<div *ngIf="nullHero">The null hero's name is {{ nullHero.name }}</div>
+<div *ngIf='nullHero'>The null hero's name is {{ nullHero.name }}</div>
 
 <div>The null hero's name is {{ nullHero && nullHero.name }}</div>
 
@@ -7080,7 +7080,7 @@ See console log:
   The null hero's name is {{ nullHero?.name }}
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- non-null assertion operator -->
 <hr />
@@ -7091,10 +7091,10 @@ See console log:
 
 <div>
   <!--No hero, no text -->
-  <div *ngIf="hero">The hero's name is {{ hero!.name }}</div>
+  <div *ngIf='hero'>The hero's name is {{ hero!.name }}</div>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- non-null assertion operator -->
 <hr />
@@ -7114,7 +7114,7 @@ See console log:
   <div>Undeclared members is {{ $any(this).member }}</div>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- TODO: discuss this in the Style binding section -->
 <!-- enums in bindings -->
@@ -7126,12 +7126,12 @@ See console log:
   <br />
   The current color is {{ Color[color] }} and its number is {{ color }}.
   <br />
-  <button [style.color]="Color[color]" (click)="colorToggle()">
+  <button [style.color]='Color[color]' (click)='colorToggle()'>
     Enum Toggle
   </button>
 </p>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- 
 Copyright 2017-2018 Google Inc. All Rights Reserved.
@@ -7140,21 +7140,21 @@ can be found in the LICENSE file at http://angular.io/license
 -->
 
 <div id="heroForm">
-  <form (ngSubmit)="onSubmit(heroForm)" #heroForm="ngForm">
-    <div class="form-group">
+  <form (ngSubmit)='onSubmit(heroForm)' #heroForm="ngForm">
+    <div class='form-group'>
       <label for="name">
         Name
         <input
-          class="form-control"
+          class='form-control'
           name="name"
           required
-          [(ngModel)]="hero.name"
+          [(ngModel)]='hero.name'
         />
       </label>
     </div>
-    <button type="submit" [disabled]="!heroForm.form.valid">Submit</button>
+    <button type="submit" [disabled]='!heroForm.form.valid'>Submit</button>
   </form>
-  <div [hidden]="!heroForm.form.valid">
+  <div [hidden]='!heroForm.form.valid'>
     {{ submitMessage }}
   </div>
 </div>
@@ -7939,9 +7939,9 @@ can be found in the LICENSE file at http://angular.io/license
   Binding</a
 ><br />
 <div
-  style="
+  style='
     margin-left: 8px;
-  "
+  '
 >
   <a
     href="#attribute-binding"
@@ -7975,9 +7975,9 @@ can be found in the LICENSE file at http://angular.io/license
   Directives
 </div>
 <div
-  style="
+  style='
     margin-left: 8px;
-  "
+  '
 >
   <a
     href="#ngModel"
@@ -8004,9 +8004,9 @@ can be found in the LICENSE file at http://angular.io/license
     >NgFor</a
   ><br />
   <div
-    style="
+    style='
       margin-left: 8px;
-    "
+    '
   >
     <a
       href="#ngFor-index"
@@ -8089,12 +8089,12 @@ can be found in the LICENSE file at http://angular.io/license
     title
   }}
   <img
-    src="{{
+    src='{{
       heroImageUrl
-    }}"
-    style="
+    }}'
+    style='
       height: 30px;
-    "
+    '
   />
 </h3>
 
@@ -8131,7 +8131,7 @@ can be found in the LICENSE file at http://angular.io/license
 </p>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -8152,15 +8152,15 @@ can be found in the LICENSE file at http://angular.io/license
   [hidden]="isUnchanged")
 </p>
 <div
-  class="context"
+  class='context'
 >
   {{
     title
   }}
   <span
-    [hidden]="
+    [hidden]='
       isUnchanged
-    "
+    '
     >changed</span
   >
 </div>
@@ -8177,9 +8177,9 @@ can be found in the LICENSE file at http://angular.io/license
 <!-- template hides the following; plenty of examples later -->
 <ng-template>
   <div
-    *ngFor="
+    *ngFor='
       let hero of heroes
-    "
+    '
   >
     {{
       hero.name
@@ -8196,10 +8196,10 @@ can be found in the LICENSE file at http://angular.io/license
   (#heroInput)
 </p>
 <div
-  (keyup)="
+  (keyup)='
     (0)
-  "
-  class="context"
+  '
+  class='context'
 >
   Type
   something:
@@ -8212,7 +8212,7 @@ can be found in the LICENSE file at http://angular.io/license
 </div>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -8234,12 +8234,12 @@ can be found in the LICENSE file at http://angular.io/license
   )
 </p>
 <div
-  class="context"
+  class='context'
 >
   <button
-    (click)="
+    (click)='
       deleteHero()
-    "
+    '
   >
     Delete
     hero
@@ -8253,14 +8253,14 @@ can be found in the LICENSE file at http://angular.io/license
   context
 </p>
 <div
-  class="context"
+  class='context'
 >
   <button
-    (click)="
+    (click)='
       onSave(
         $event
       )
-    "
+    '
   >
     Save
   </button>
@@ -8277,17 +8277,17 @@ can be found in the LICENSE file at http://angular.io/license
 </p>
 <!-- template hides the following; plenty of examples later -->
 <div
-  class="context"
+  class='context'
 >
   <button
-    *ngFor="
+    *ngFor='
       let hero of heroes
-    "
-    (click)="
+    '
+    (click)='
       deleteHero(
         hero
       )
-    "
+    '
   >
     {{
       hero.name
@@ -8304,22 +8304,22 @@ can be found in the LICENSE file at http://angular.io/license
   (#heroForm)
 </p>
 <div
-  class="context"
+  class='context'
 >
   <form
     #heroForm
-    (ngSubmit)="
+    (ngSubmit)='
       onSubmit(
         heroForm
       )
-    "
+    '
   >
     ...
   </form>
 </div>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -8337,7 +8337,7 @@ can be found in the LICENSE file at http://angular.io/license
 <!--<img src="http://www.wpclipart.com/cartoon/people/hero/hero_silhoutte_T.png">-->
 <!-- Public Domain terms of use: http://www.wpclipart.com/terms.html -->
 <div
-  class="special"
+  class='special'
 >
   Mental
   Model
@@ -8355,7 +8355,7 @@ can be found in the LICENSE file at http://angular.io/license
 <div>
   <!-- Normal HTML -->
   <div
-    class="special"
+    class='special'
   >
     Mental
     Model
@@ -8368,9 +8368,9 @@ can be found in the LICENSE file at http://angular.io/license
 <div>
   <!-- Bind button disabled state to \`isUnchanged\` property -->
   <button
-    [disabled]="
+    [disabled]='
       isUnchanged
-    "
+    '
   >
     Save
   </button>
@@ -8379,41 +8379,41 @@ can be found in the LICENSE file at http://angular.io/license
 
 <div>
   <img
-    [src]="
+    [src]='
       heroImageUrl
-    "
+    '
   />
   <app-hero-detail
-    [hero]="
+    [hero]='
       currentHero
-    "
+    '
   ></app-hero-detail>
   <div
-    [ngClass]="{
+    [ngClass]='{
       special:
         isSpecial,
-    }"
+    }'
   ></div>
 </div>
 <br /><br />
 
 <button
-  (click)="
+  (click)='
     onSave()
-  "
+  '
 >
   Save
 </button>
 <app-hero-detail
-  (deleteRequest)="
+  (deleteRequest)='
     deleteHero()
-  "
+  '
 ></app-hero-detail>
 <div
-  (myClick)="
+  (myClick)='
     clicked =
       $event
-  "
+  '
   clickable
 >
   click
@@ -8428,9 +8428,9 @@ can be found in the LICENSE file at http://angular.io/license
   Hero
   Name:
   <input
-    [(ngModel)]="
+    [(ngModel)]='
       name
-    "
+    '
   />
   {{
     name
@@ -8439,35 +8439,35 @@ can be found in the LICENSE file at http://angular.io/license
 <br /><br />
 
 <button
-  [attr.aria-label]="
+  [attr.aria-label]='
     help
-  "
+  '
 >
   help
 </button>
 <br /><br />
 
 <div
-  [class.special]="
+  [class.special]='
     isSpecial
-  "
+  '
 >
   Special
 </div>
 <br /><br />
 
 <button
-  [style.color]="
+  [style.color]='
     isSpecial
       ? 'red'
       : 'green'
-  "
+  '
 >
   button
 </button>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -8486,31 +8486,31 @@ can be found in the LICENSE file at http://angular.io/license
 <!-- examine the following <img> tag in the browser tools -->
 <img
   src="images/ng-logo.png"
-  [src]="
+  [src]='
     heroImageUrl
-  "
+  '
 />
 
 <br /><br />
 
 <img
-  [src]="
+  [src]='
     iconUrl
-  "
+  '
 />
 <img
-  bind-src="
+  bind-src='
     heroImageUrl
-  "
+  '
 />
 <img
-  [attr.src]="
+  [attr.src]='
     villainImageUrl
-  "
+  '
 />
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -8549,9 +8549,9 @@ can be found in the LICENSE file at http://angular.io/license
   attribute
 </button>
 <button
-  [disabled]="
+  [disabled]='
     isUnchanged
-  "
+  '
 >
   disabled
   by
@@ -8560,34 +8560,34 @@ can be found in the LICENSE file at http://angular.io/license
 </button>
 <br /><br />
 <button
-  bind-disabled="
+  bind-disabled='
     isUnchanged
-  "
-  on-click="
+  '
+  on-click='
     onSave(
       $event
     )
-  "
+  '
 >
   Disabled
   Cancel
 </button>
 <button
-  [disabled]="
+  [disabled]='
     !canSave
-  "
-  (click)="
+  '
+  (click)='
     onSave(
       $event
     )
-  "
+  '
 >
   Enabled
   Save
 </button>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -8602,23 +8602,23 @@ can be found in the LICENSE file at http://angular.io/license
 </h2>
 
 <img
-  [src]="
+  [src]='
     heroImageUrl
-  "
+  '
 />
 <button
-  [disabled]="
+  [disabled]='
     isUnchanged
-  "
+  '
 >
   Cancel
   is
   disabled
 </button>
 <div
-  [ngClass]="
+  [ngClass]='
     classes
-  "
+  '
 >
   [ngClass]
   binding
@@ -8628,22 +8628,22 @@ can be found in the LICENSE file at http://angular.io/license
   property
 </div>
 <app-hero-detail
-  [hero]="
+  [hero]='
     currentHero
-  "
+  '
 ></app-hero-detail>
 <img
-  bind-src="
+  bind-src='
     heroImageUrl
-  "
+  '
 />
 
 <!-- ERROR: HeroDetailComponent.hero expects a
      Hero object, not the string "currentHero" -->
 <div
-  *ngIf="
+  *ngIf='
     false
-  "
+  '
 >
   <app-hero-detail
     hero="currentHero"
@@ -8651,16 +8651,16 @@ can be found in the LICENSE file at http://angular.io/license
 </div>
 <app-hero-detail
   prefix="You are my"
-  [hero]="
+  [hero]='
     currentHero
-  "
+  '
 ></app-hero-detail>
 
 <p>
   <img
-    src="{{
+    src='{{
       heroImageUrl
-    }}"
+    }}'
   />
   is
   the
@@ -8671,9 +8671,9 @@ can be found in the LICENSE file at http://angular.io/license
 </p>
 <p>
   <img
-    [src]="
+    [src]='
       heroImageUrl
-    "
+    '
   />
   is
   the
@@ -8699,9 +8699,9 @@ can be found in the LICENSE file at http://angular.io/license
 </p>
 <p>
   "<span
-    [innerHTML]="
+    [innerHTML]='
       title
-    "
+    '
   ></span
   >"
   is
@@ -8733,9 +8733,9 @@ can be found in the LICENSE file at http://angular.io/license
 </p>
 <p>
   "<span
-    [innerHTML]="
+    [innerHTML]='
       evilTitle
-    "
+    '
   ></span
   >"
   is
@@ -8749,7 +8749,7 @@ can be found in the LICENSE file at http://angular.io/license
 </p>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -8770,10 +8770,10 @@ can be found in the LICENSE file at http://angular.io/license
   <!--  expression calculates colspan=2 -->
   <tr>
     <td
-      [attr.colspan]="
+      [attr.colspan]='
         1 +
         1
-      "
+      '
     >
       One-Two
     </td>
@@ -8796,9 +8796,9 @@ can be found in the LICENSE file at http://angular.io/license
 <br />
 <!-- create and set an aria attribute for assistive technology -->
 <button
-  [attr.aria-label]="
+  [attr.aria-label]='
     actionName
-  "
+  '
 >
   {{
     actionName
@@ -8812,17 +8812,17 @@ can be found in the LICENSE file at http://angular.io/license
 <div>
   <!-- any use of [attr.disabled] creates the disabled attribute -->
   <button
-    [attr.disabled]="
+    [attr.disabled]='
       isUnchanged
-    "
+    '
   >
     Disabled
   </button>
 
   <button
-    [attr.disabled]="
+    [attr.disabled]='
       !isUnchanged
-    "
+    '
   >
     Disabled
     as
@@ -8832,9 +8832,9 @@ can be found in the LICENSE file at http://angular.io/license
   <!-- we'd have to remove it with property binding -->
   <button
     disabled
-    [disabled]="
+    [disabled]='
       false
-    "
+    '
   >
     Enabled
     (but
@@ -8843,7 +8843,7 @@ can be found in the LICENSE file at http://angular.io/license
 </div>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -8859,7 +8859,7 @@ can be found in the LICENSE file at http://angular.io/license
 
 <!-- standard class attribute setting  -->
 <div
-  class="bad curly special"
+  class='bad curly special'
 >
   Bad
   curly
@@ -8868,10 +8868,10 @@ can be found in the LICENSE file at http://angular.io/license
 
 <!-- reset/override all class names with a binding  -->
 <div
-  class="bad curly special"
-  [class]="
+  class='bad curly special'
+  [class]='
     badCurly
-  "
+  '
 >
   Bad
   curly
@@ -8879,9 +8879,9 @@ can be found in the LICENSE file at http://angular.io/license
 
 <!-- toggle the "special" class on/off with a property -->
 <div
-  [class.special]="
+  [class.special]='
     isSpecial
-  "
+  '
 >
   The
   class
@@ -8892,10 +8892,10 @@ can be found in the LICENSE file at http://angular.io/license
 
 <!-- binding to \`class.special\` trumps the class attribute -->
 <div
-  class="special"
-  [class.special]="
+  class='special'
+  [class.special]='
     !isSpecial
-  "
+  '
 >
   This
   one
@@ -8906,9 +8906,9 @@ can be found in the LICENSE file at http://angular.io/license
 </div>
 
 <div
-  bind-class.special="
+  bind-class.special='
     isSpecial
-  "
+  '
 >
   This
   class
@@ -8919,7 +8919,7 @@ can be found in the LICENSE file at http://angular.io/license
 </div>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -8934,45 +8934,45 @@ can be found in the LICENSE file at http://angular.io/license
 </h2>
 
 <button
-  [style.color]="
+  [style.color]='
     isSpecial
       ? 'red'
       : 'green'
-  "
+  '
 >
   Red
 </button>
 <button
-  [style.background-color]="
+  [style.background-color]='
     canSave
       ? 'cyan'
       : 'grey'
-  "
+  '
 >
   Save
 </button>
 
 <button
-  [style.font-size.em]="
+  [style.font-size.em]='
     isSpecial
       ? 3
       : 1
-  "
+  '
 >
   Big
 </button>
 <button
-  [style.font-size.%]="
+  [style.font-size.%]='
     !isSpecial
       ? 150
       : 50
-  "
+  '
 >
   Small
 </button>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -8987,17 +8987,17 @@ can be found in the LICENSE file at http://angular.io/license
 </h2>
 
 <button
-  (click)="
+  (click)='
     onSave()
-  "
+  '
 >
   Save
 </button>
 
 <button
-  on-click="
+  on-click='
     onSave()
-  "
+  '
 >
   On
   Save
@@ -9006,10 +9006,10 @@ can be found in the LICENSE file at http://angular.io/license
 <div>
   <!-- \`myClick\` is an event on the custom \`ClickDirective\` -->
   <div
-    (myClick)="
+    (myClick)='
       clickMessage =
         $event
-    "
+    '
     clickable
   >
     click
@@ -9023,42 +9023,42 @@ can be found in the LICENSE file at http://angular.io/license
 
 <!-- binding to a nested component -->
 <app-hero-detail
-  (deleteRequest)="
+  (deleteRequest)='
     deleteHero(
       $event
     )
-  "
-  [hero]="
+  '
+  [hero]='
     currentHero
-  "
+  '
 ></app-hero-detail>
 <br />
 
 <app-big-hero-detail
-  (deleteRequest)="
+  (deleteRequest)='
     deleteHero(
       $event
     )
-  "
-  [hero]="
+  '
+  [hero]='
     currentHero
-  "
+  '
 >
 </app-big-hero-detail>
 
 <div
-  class="parent-div"
-  (click)="
+  class='parent-div'
+  (click)='
     onClickMe(
       $event
     )
-  "
+  '
   clickable
 >
   Click
   me
   <div
-    class="child-div"
+    class='child-div'
   >
     Click
     me
@@ -9068,17 +9068,17 @@ can be found in the LICENSE file at http://angular.io/license
 
 <!-- Will save only once -->
 <div
-  (click)="
+  (click)='
     onSave()
-  "
+  '
   clickable
 >
   <button
-    (click)="
+    (click)='
       onSave(
         $event
       )
-    "
+    '
   >
     Save,
     no
@@ -9088,15 +9088,15 @@ can be found in the LICENSE file at http://angular.io/license
 
 <!-- Will save twice -->
 <div
-  (click)="
+  (click)='
     onSave()
-  "
+  '
   clickable
 >
   <button
-    (click)="
+    (click)='
       onSave()
-    "
+    '
   >
     Save
     w/
@@ -9105,7 +9105,7 @@ can be found in the LICENSE file at http://angular.io/license
 </div>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -9121,14 +9121,14 @@ can be found in the LICENSE file at http://angular.io/license
   id="two-way-1"
 >
   <app-sizer
-    [(size)]="
+    [(size)]='
       fontSizePx
-    "
+    '
   ></app-sizer>
   <div
-    [style.font-size.px]="
+    [style.font-size.px]='
       fontSizePx
-    "
+    '
   >
     Resizable
     Text
@@ -9137,9 +9137,9 @@ can be found in the LICENSE file at http://angular.io/license
     >FontSize
     (px):
     <input
-      [(ngModel)]="
+      [(ngModel)]='
         fontSizePx
-      "
+      '
   /></label>
 </div>
 <br />
@@ -9152,18 +9152,18 @@ can be found in the LICENSE file at http://angular.io/license
     binding
   </h3>
   <app-sizer
-    [size]="
+    [size]='
       fontSizePx
-    "
-    (sizeChange)="
+    '
+    (sizeChange)='
       fontSizePx =
         $event
-    "
+    '
   ></app-sizer>
 </div>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -9187,56 +9187,56 @@ can be found in the LICENSE file at http://angular.io/license
 </h3>
 
 <input
-  [value]="
+  [value]='
     currentHero.name
-  "
-  (input)="
+  '
+  (input)='
     currentHero.name =
       $event.target.value
-  "
+  '
 />
 without
 NgModel
 <br />
 <input
-  [(ngModel)]="
+  [(ngModel)]='
     currentHero.name
-  "
+  '
 />
 [(ngModel)]
 <br />
 <input
-  bindon-ngModel="
+  bindon-ngModel='
     currentHero.name
-  "
+  '
 />
 bindon-ngModel
 <br />
 <input
-  [ngModel]="
+  [ngModel]='
     currentHero.name
-  "
-  (ngModelChange)="
+  '
+  (ngModelChange)='
     currentHero.name =
       $event
-  "
+  '
 />
 (ngModelChange)="...name=$event"
 <br />
 <input
-  [ngModel]="
+  [ngModel]='
     currentHero.name
-  "
-  (ngModelChange)="
+  '
+  (ngModelChange)='
     setUppercaseName(
       $event
     )
-  "
+  '
 />
 (ngModelChange)="setUppercaseName($event)"
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -9259,9 +9259,9 @@ bindon-ngModel
   }}
 </p>
 <div
-  [ngClass]="
+  [ngClass]='
     currentClasses
-  "
+  '
 >
   This
   div
@@ -9279,45 +9279,45 @@ bindon-ngModel
   >saveable
   <input
     type="checkbox"
-    [(ngModel)]="
+    [(ngModel)]='
       canSave
-    "
+    '
 /></label>
 |
 <label
   >modified:
   <input
     type="checkbox"
-    [value]="
+    [value]='
       !isUnchanged
-    "
-    (change)="
+    '
+    (change)='
       isUnchanged =
         !isUnchanged
-    "
+    '
 /></label>
 |
 <label
   >special:
   <input
     type="checkbox"
-    [(ngModel)]="
+    [(ngModel)]='
       isSpecial
-    "
+    '
 /></label>
 <button
-  (click)="
+  (click)='
     setCurrentClasses()
-  "
+  '
 >
   Refresh
   currentClasses
 </button>
 <br /><br />
 <div
-  [ngClass]="
+  [ngClass]='
     currentClasses
-  "
+  '
 >
   This
   div
@@ -9348,11 +9348,11 @@ bindon-ngModel
 <br /><br />
 
 <div
-  [ngClass]="
+  [ngClass]='
     isSpecial
       ? 'special'
       : ''
-  "
+  '
 >
   This
   div
@@ -9361,25 +9361,25 @@ bindon-ngModel
 </div>
 
 <div
-  class="bad curly special"
+  class='bad curly special'
 >
   Bad
   curly
   special
 </div>
 <div
-  [ngClass]="{
+  [ngClass]='{
     bad: false,
     curly: true,
     special: true,
-  }"
+  }'
 >
   Curly
   special
 </div>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -9394,11 +9394,11 @@ bindon-ngModel
 </h2>
 
 <div
-  [style.font-size]="
+  [style.font-size]='
     isSpecial
       ? 'x-large'
       : 'smaller'
-  "
+  '
 >
   This
   div
@@ -9427,9 +9427,9 @@ bindon-ngModel
   }}
 </p>
 <div
-  [ngStyle]="
+  [ngStyle]='
     currentStyles
-  "
+  '
 >
   This
   div
@@ -9450,41 +9450,41 @@ bindon-ngModel
   >italic:
   <input
     type="checkbox"
-    [(ngModel)]="
+    [(ngModel)]='
       canSave
-    "
+    '
 /></label>
 |
 <label
   >normal:
   <input
     type="checkbox"
-    [(ngModel)]="
+    [(ngModel)]='
       isUnchanged
-    "
+    '
 /></label>
 |
 <label
   >xlarge:
   <input
     type="checkbox"
-    [(ngModel)]="
+    [(ngModel)]='
       isSpecial
-    "
+    '
 /></label>
 <button
-  (click)="
+  (click)='
     setCurrentStyles()
-  "
+  '
 >
   Refresh
   currentStyles
 </button>
 <br /><br />
 <div
-  [ngStyle]="
+  [ngStyle]='
     currentStyles
-  "
+  '
 >
   This
   div
@@ -9512,7 +9512,7 @@ bindon-ngModel
 </div>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -9527,15 +9527,15 @@ bindon-ngModel
 </h2>
 
 <app-hero-detail
-  *ngIf="
+  *ngIf='
     isActive
-  "
+  '
 ></app-hero-detail>
 
 <div
-  *ngIf="
+  *ngIf='
     currentHero
-  "
+  '
 >
   Hello,
   {{
@@ -9543,9 +9543,9 @@ bindon-ngModel
   }}
 </div>
 <div
-  *ngIf="
+  *ngIf='
     nullHero
-  "
+  '
 >
   Hello,
   {{
@@ -9556,9 +9556,9 @@ bindon-ngModel
 <!-- NgIf binding with template (no *) -->
 
 <ng-template
-  [ngIf]="
+  [ngIf]='
     currentHero
-  "
+  '
   >Add
   {{
     currentHero.name
@@ -9582,27 +9582,27 @@ bindon-ngModel
   false
 </div>
 <ng-template
-  [ngIf]="
+  [ngIf]='
     isActive
-  "
+  '
 >
   <app-hero-detail></app-hero-detail>
 </ng-template>
 
 <!-- isSpecial is true -->
 <div
-  [class.hidden]="
+  [class.hidden]='
     !isSpecial
-  "
+  '
 >
   Show
   with
   class
 </div>
 <div
-  [class.hidden]="
+  [class.hidden]='
     isSpecial
-  "
+  '
 >
   Hide
   with
@@ -9611,28 +9611,28 @@ bindon-ngModel
 
 <!-- HeroDetail is in the DOM but hidden -->
 <app-hero-detail
-  [class.hidden]="
+  [class.hidden]='
     isSpecial
-  "
+  '
 ></app-hero-detail>
 
 <div
-  [style.display]="
+  [style.display]='
     isSpecial
       ? 'block'
       : 'none'
-  "
+  '
 >
   Show
   with
   style
 </div>
 <div
-  [style.display]="
+  [style.display]='
     isSpecial
       ? 'none'
       : 'block'
-  "
+  '
 >
   Hide
   with
@@ -9640,7 +9640,7 @@ bindon-ngModel
 </div>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -9655,12 +9655,12 @@ bindon-ngModel
 </h2>
 
 <div
-  class="box"
+  class='box'
 >
   <div
-    *ngFor="
+    *ngFor='
       let hero of heroes
-    "
+    '
   >
     {{
       hero.name
@@ -9670,21 +9670,21 @@ bindon-ngModel
 <br />
 
 <div
-  class="box"
+  class='box'
 >
   <!-- *ngFor w/ hero-detail Component -->
   <app-hero-detail
-    *ngFor="
+    *ngFor='
       let hero of heroes
-    "
-    [hero]="
+    '
+    [hero]='
       hero
-    "
+    '
   ></app-hero-detail>
 </div>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -9704,13 +9704,13 @@ bindon-ngModel
   separator
 </p>
 <div
-  class="box"
+  class='box'
 >
   <div
-    *ngFor="
+    *ngFor='
       let hero of heroes;
       let i = index
-    "
+    '
   >
     {{
       i +
@@ -9731,14 +9731,14 @@ bindon-ngModel
   separator
 </p>
 <div
-  class="box"
+  class='box'
 >
   <!-- Ex: "1 - Hercules" -->
   <div
-    *ngFor="
+    *ngFor='
       let hero of heroes;
       let i = index
-    "
+    '
   >
     {{
       i +
@@ -9752,7 +9752,7 @@ bindon-ngModel
 </div>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -9764,25 +9764,25 @@ bindon-ngModel
   trackBy
 </h4>
 <button
-  (click)="
+  (click)='
     resetHeroes()
-  "
+  '
 >
   Reset
   heroes
 </button>
 <button
-  (click)="
+  (click)='
     changeIds()
-  "
+  '
 >
   Change
   ids
 </button>
 <button
-  (click)="
+  (click)='
     clearTrackByCounts()
-  "
+  '
 >
   Clear
   counts
@@ -9795,13 +9795,13 @@ bindon-ngModel
   trackBy
 </p>
 <div
-  class="box"
+  class='box'
 >
   <div
     #noTrackBy
-    *ngFor="
+    *ngFor='
       let hero of heroes
-    "
+    '
   >
     ({{
       hero.id
@@ -9813,9 +9813,9 @@ bindon-ngModel
 
   <div
     id="noTrackByCnt"
-    *ngIf="
+    *ngIf='
       heroesNoTrackByCount
-    "
+    '
   >
     Hero
     DOM
@@ -9834,14 +9834,14 @@ bindon-ngModel
   trackBy
 </p>
 <div
-  class="box"
+  class='box'
 >
   <div
     #withTrackBy
-    *ngFor="
+    *ngFor='
       let hero of heroes;
       trackBy: trackByHeroes
-    "
+    '
   >
     ({{
       hero.id
@@ -9853,9 +9853,9 @@ bindon-ngModel
 
   <div
     id="withTrackByCnt"
-    *ngIf="
+    *ngIf='
       heroesWithTrackByCount
-    "
+    '
   >
     Hero
     DOM
@@ -9881,13 +9881,13 @@ bindon-ngModel
   separator
 </p>
 <div
-  class="box"
+  class='box'
 >
   <div
-    *ngFor="
+    *ngFor='
       let hero of heroes;
       trackBy: trackByHeroes
-    "
+    '
   >
     ({{
       hero.id
@@ -9908,13 +9908,13 @@ bindon-ngModel
   separator
 </p>
 <div
-  class="box"
+  class='box'
 >
   <div
-    *ngFor="
+    *ngFor='
       let hero of heroes;
       trackBy: trackByHeroes
-    "
+    '
   >
     ({{
       hero.id
@@ -9935,13 +9935,13 @@ bindon-ngModel
   separator
 </p>
 <div
-  class="box"
+  class='box'
 >
   <div
-    *ngFor="
+    *ngFor='
       let hero of heroes;
       trackBy: trackByHeroes
-    "
+    '
   >
     ({{
       hero.id
@@ -9961,13 +9961,13 @@ bindon-ngModel
   function
 </p>
 <div
-  class="box"
+  class='box'
 >
   <div
-    *ngFor="
+    *ngFor='
       let hero of heroes;
       trackBy: trackById
-    "
+    '
   >
     ({{
       hero.id
@@ -9979,7 +9979,7 @@ bindon-ngModel
 </div>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -10001,19 +10001,19 @@ bindon-ngModel
 </p>
 <div>
   <label
-    *ngFor="
+    *ngFor='
       let h of heroes
-    "
+    '
   >
     <input
       type="radio"
       name="heroes"
-      [(ngModel)]="
+      [(ngModel)]='
         currentHero
-      "
-      [value]="
+      '
+      [value]='
         h
-      "
+      '
     />{{
       h.name
     }}
@@ -10021,38 +10021,38 @@ bindon-ngModel
 </div>
 
 <div
-  [ngSwitch]="
+  [ngSwitch]='
     currentHero.emotion
-  "
+  '
 >
   <app-happy-hero
-    *ngSwitchCase="
+    *ngSwitchCase='
       'happy'
-    "
-    [hero]="
+    '
+    [hero]='
       currentHero
-    "
+    '
   ></app-happy-hero>
   <app-sad-hero
-    *ngSwitchCase="
+    *ngSwitchCase='
       'sad'
-    "
-    [hero]="
+    '
+    [hero]='
       currentHero
-    "
+    '
   ></app-sad-hero>
   <app-confused-hero
-    *ngSwitchCase="
+    *ngSwitchCase='
       'confused'
-    "
-    [hero]="
+    '
+    [hero]='
       currentHero
-    "
+    '
   ></app-confused-hero>
   <div
-    *ngSwitchCase="
+    *ngSwitchCase='
       'confused'
-    "
+    '
   >
     Are
     you
@@ -10065,14 +10065,14 @@ bindon-ngModel
   </div>
   <app-unknown-hero
     *ngSwitchDefault
-    [hero]="
+    [hero]='
       currentHero
-    "
+    '
   ></app-unknown-hero>
 </div>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -10096,11 +10096,11 @@ bindon-ngModel
 
 <!-- phone refers to the input element; pass its \`value\` to an event handler -->
 <button
-  (click)="
+  (click)='
     callPhone(
       phone.value
     )
-  "
+  '
 >
   Call
 </button>
@@ -10110,11 +10110,11 @@ bindon-ngModel
   placeholder="fax number"
 />
 <button
-  (click)="
+  (click)='
     callFax(
       fax.value
     )
-  "
+  '
 >
   Fax
 </button>
@@ -10123,10 +10123,10 @@ bindon-ngModel
 <button
   #btn
   disabled
-  [innerHTML]="
+  [innerHTML]='
     'disabled by attribute: ' +
     btn.disabled
-  "
+  '
 ></button>
 
 <h4>
@@ -10134,13 +10134,13 @@ bindon-ngModel
   Form
 </h4>
 <app-hero-form
-  [hero]="
+  [hero]='
     currentHero
-  "
+  '
 ></app-hero-form>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -10156,35 +10156,35 @@ bindon-ngModel
 </h2>
 
 <img
-  [src]="
+  [src]='
     iconUrl
-  "
+  '
 />
 <button
-  (click)="
+  (click)='
     onSave()
-  "
+  '
 >
   Save
 </button>
 
 <app-hero-detail
-  [hero]="
+  [hero]='
     currentHero
-  "
-  (deleteRequest)="
+  '
+  (deleteRequest)='
     deleteHero(
       $event
     )
-  "
+  '
 >
 </app-hero-detail>
 
 <div
-  (myClick)="
+  (myClick)='
     clickMessage2 =
       $event
-  "
+  '
   clickable
 >
   myClick2
@@ -10194,7 +10194,7 @@ bindon-ngModel
 }}
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -10272,7 +10272,7 @@ bindon-ngModel
 </div>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -10330,9 +10330,9 @@ See console log:
 
 <!--No hero, div not displayed, no error -->
 <div
-  *ngIf="
+  *ngIf='
     nullHero
-  "
+  '
 >
   The
   null
@@ -10369,7 +10369,7 @@ See console log:
 </div>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -10390,9 +10390,9 @@ See console log:
 <div>
   <!--No hero, no text -->
   <div
-    *ngIf="
+    *ngIf='
       hero
-    "
+    '
   >
     The
     hero's
@@ -10406,7 +10406,7 @@ See console log:
 </div>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -10458,7 +10458,7 @@ See console log:
 </div>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -10505,14 +10505,14 @@ See console log:
     color
   }}.<br />
   <button
-    [style.color]="
+    [style.color]='
       Color[
         color
       ]
-    "
-    (click)="
+    '
+    (click)='
       colorToggle()
-    "
+    '
   >
     Enum
     Toggle
@@ -10520,7 +10520,7 @@ See console log:
 </p>
 
 <a
-  class="to-toc"
+  class='to-toc'
   href="#toc"
   >top</a
 >
@@ -10535,46 +10535,46 @@ can be found in the LICENSE file at http://angular.io/license
   id="heroForm"
 >
   <form
-    (ngSubmit)="
+    (ngSubmit)='
       onSubmit(
         heroForm
       )
-    "
+    '
     #heroForm="ngForm"
   >
     <div
-      class="form-group"
+      class='form-group'
     >
       <label
         for="name"
         >Name
         <input
-          class="form-control"
+          class='form-control'
           name="name"
           required
-          [(ngModel)]="
+          [(ngModel)]='
             hero.name
-          "
+          '
         />
       </label>
     </div>
     <button
       type="submit"
-      [disabled]="
+      [disabled]='
         !heroForm
           .form
           .valid
-      "
+      '
     >
       Submit
     </button>
   </form>
   <div
-    [hidden]="
+    [hidden]='
       !heroForm
         .form
         .valid
-    "
+    '
   >
     {{
       submitMessage
@@ -11330,7 +11330,7 @@ can be found in the LICENSE file at http://angular.io/license
 <a href="#prop-vs-attrib">Properties vs. Attributes</a><br />
 <br />
 <a href="#property-binding">Property Binding</a><br />
-<div style="margin-left: 8px">
+<div style='margin-left: 8px'>
   <a href="#attribute-binding">Attribute Binding</a><br />
   <a href="#class-binding">Class Binding</a><br />
   <a href="#style-binding">Style Binding</a><br />
@@ -11340,13 +11340,13 @@ can be found in the LICENSE file at http://angular.io/license
 <a href="#two-way">Two-way Binding</a><br />
 <br />
 <div>Directives</div>
-<div style="margin-left: 8px">
+<div style='margin-left: 8px'>
   <a href="#ngModel">NgModel (two-way) Binding</a><br />
   <a href="#ngClass">NgClass Binding</a><br />
   <a href="#ngStyle">NgStyle Binding</a><br />
   <a href="#ngIf">NgIf</a><br />
   <a href="#ngFor">NgFor</a><br />
-  <div style="margin-left: 8px">
+  <div style='margin-left: 8px'>
     <a href="#ngFor-index">NgFor with index</a><br />
     <a href="#ngFor-trackBy">NgFor with trackBy</a><br />
   </div>
@@ -11370,7 +11370,7 @@ can be found in the LICENSE file at http://angular.io/license
 
 <h3>
   {{ title }}
-  <img src="{{ heroImageUrl }}" style="height: 30px" />
+  <img src='{{ heroImageUrl }}' style='height: 30px' />
 </h3>
 
 <!-- "The sum of 1 + 1 is 2" -->
@@ -11379,7 +11379,7 @@ can be found in the LICENSE file at http://angular.io/license
 <!-- "The sum of 1 + 1 is not 4" -->
 <p>The sum of 1 + 1 is not {{ 1 + 1 + getVal() }}</p>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <hr />
 <h2 id="expression-context">Expression context</h2>
@@ -11388,52 +11388,52 @@ can be found in the LICENSE file at http://angular.io/license
   Component expression context (&#123;&#123;title&#125;&#125;,
   [hidden]="isUnchanged")
 </p>
-<div class="context">
+<div class='context'>
   {{ title }}
-  <span [hidden]="isUnchanged">changed</span>
+  <span [hidden]='isUnchanged'>changed</span>
 </div>
 
 <p>Template input variable expression context (let hero)</p>
 <!-- template hides the following; plenty of examples later -->
 <ng-template>
-  <div *ngFor="let hero of heroes">{{ hero.name }}</div>
+  <div *ngFor='let hero of heroes'>{{ hero.name }}</div>
 </ng-template>
 
 <p>Template reference variable expression context (#heroInput)</p>
-<div (keyup)="(0)" class="context">
+<div (keyup)='(0)' class='context'>
   Type something:
   <input #heroInput /> {{ heroInput.value }}
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <hr />
 <h2 id="statement-context">Statement context</h2>
 
 <p>Component statement context ( (click)="onSave() )</p>
-<div class="context">
-  <button (click)="deleteHero()">Delete hero</button>
+<div class='context'>
+  <button (click)='deleteHero()'>Delete hero</button>
 </div>
 
 <p>Template $event statement context</p>
-<div class="context">
-  <button (click)="onSave($event)">Save</button>
+<div class='context'>
+  <button (click)='onSave($event)'>Save</button>
 </div>
 
 <p>Template input variable statement context (let hero)</p>
 <!-- template hides the following; plenty of examples later -->
-<div class="context">
-  <button *ngFor="let hero of heroes" (click)="deleteHero(hero)">
+<div class='context'>
+  <button *ngFor='let hero of heroes' (click)='deleteHero(hero)'>
     {{ hero.name }}
   </button>
 </div>
 
 <p>Template reference variable statement context (#heroForm)</p>
-<div class="context">
-  <form #heroForm (ngSubmit)="onSubmit(heroForm)">...</form>
+<div class='context'>
+  <form #heroForm (ngSubmit)='onSubmit(heroForm)'>...</form>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- New Mental Model -->
 <hr />
@@ -11441,14 +11441,14 @@ can be found in the LICENSE file at http://angular.io/license
 
 <!--<img src="http://www.wpclipart.com/cartoon/people/hero/hero_silhoutte_T.png">-->
 <!-- Public Domain terms of use: http://www.wpclipart.com/terms.html -->
-<div class="special">Mental Model</div>
+<div class='special'>Mental Model</div>
 <img src="assets/images/hero.png" />
 <button disabled>Save</button>
 <br /><br />
 
 <div>
   <!-- Normal HTML -->
-  <div class="special">Mental Model</div>
+  <div class='special'>Mental Model</div>
   <!-- Wow! A new element! -->
   <app-hero-detail></app-hero-detail>
 </div>
@@ -11456,53 +11456,53 @@ can be found in the LICENSE file at http://angular.io/license
 
 <div>
   <!-- Bind button disabled state to \`isUnchanged\` property -->
-  <button [disabled]="isUnchanged">Save</button>
+  <button [disabled]='isUnchanged'>Save</button>
 </div>
 <br /><br />
 
 <div>
-  <img [src]="heroImageUrl" />
-  <app-hero-detail [hero]="currentHero"></app-hero-detail>
-  <div [ngClass]="{ special: isSpecial }"></div>
+  <img [src]='heroImageUrl' />
+  <app-hero-detail [hero]='currentHero'></app-hero-detail>
+  <div [ngClass]='{ special: isSpecial }'></div>
 </div>
 <br /><br />
 
-<button (click)="onSave()">Save</button>
-<app-hero-detail (deleteRequest)="deleteHero()"></app-hero-detail>
-<div (myClick)="clicked = $event" clickable>click me</div>
+<button (click)='onSave()'>Save</button>
+<app-hero-detail (deleteRequest)='deleteHero()'></app-hero-detail>
+<div (myClick)='clicked = $event' clickable>click me</div>
 {{ clicked }}
 <br /><br />
 
 <div>
   Hero Name:
-  <input [(ngModel)]="name" />
+  <input [(ngModel)]='name' />
   {{ name }}
 </div>
 <br /><br />
 
-<button [attr.aria-label]="help">help</button>
+<button [attr.aria-label]='help'>help</button>
 <br /><br />
 
-<div [class.special]="isSpecial">Special</div>
+<div [class.special]='isSpecial'>Special</div>
 <br /><br />
 
-<button [style.color]="isSpecial ? 'red' : 'green'">button</button>
+<button [style.color]='isSpecial ? 'red' : 'green''>button</button>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- property vs. attribute -->
 <hr />
 <h2 id="prop-vs-attrib">Property vs. Attribute (img examples)</h2>
 <!-- examine the following <img> tag in the browser tools -->
-<img src="images/ng-logo.png" [src]="heroImageUrl" />
+<img src="images/ng-logo.png" [src]='heroImageUrl' />
 
 <br /><br />
 
-<img [src]="iconUrl" />
-<img bind-src="heroImageUrl" />
-<img [attr.src]="villainImageUrl" />
+<img [src]='iconUrl' />
+<img bind-src='heroImageUrl' />
+<img [attr.src]='villainImageUrl' />
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- buttons -->
 <hr />
@@ -11513,39 +11513,39 @@ can be found in the LICENSE file at http://angular.io/license
 <button disabled="false">Still disabled</button>
 <br /><br />
 <button disabled>disabled by attribute</button>
-<button [disabled]="isUnchanged">disabled by property binding</button>
+<button [disabled]='isUnchanged'>disabled by property binding</button>
 <br /><br />
-<button bind-disabled="isUnchanged" on-click="onSave($event)">
+<button bind-disabled='isUnchanged' on-click='onSave($event)'>
   Disabled Cancel
 </button>
-<button [disabled]="!canSave" (click)="onSave($event)">Enabled Save</button>
+<button [disabled]='!canSave' (click)='onSave($event)'>Enabled Save</button>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- property binding -->
 <hr />
 <h2 id="property-binding">Property Binding</h2>
 
-<img [src]="heroImageUrl" />
-<button [disabled]="isUnchanged">Cancel is disabled</button>
-<div [ngClass]="classes">[ngClass] binding to the classes property</div>
-<app-hero-detail [hero]="currentHero"></app-hero-detail>
-<img bind-src="heroImageUrl" />
+<img [src]='heroImageUrl' />
+<button [disabled]='isUnchanged'>Cancel is disabled</button>
+<div [ngClass]='classes'>[ngClass] binding to the classes property</div>
+<app-hero-detail [hero]='currentHero'></app-hero-detail>
+<img bind-src='heroImageUrl' />
 
 <!-- ERROR: HeroDetailComponent.hero expects a
      Hero object, not the string "currentHero" -->
-<div *ngIf="false">
+<div *ngIf='false'>
   <app-hero-detail hero="currentHero"></app-hero-detail>
 </div>
-<app-hero-detail prefix="You are my" [hero]="currentHero"></app-hero-detail>
+<app-hero-detail prefix="You are my" [hero]='currentHero'></app-hero-detail>
 
-<p><img src="{{ heroImageUrl }}" /> is the <i>interpolated</i> image.</p>
-<p><img [src]="heroImageUrl" /> is the <i>property bound</i> image.</p>
+<p><img src='{{ heroImageUrl }}' /> is the <i>interpolated</i> image.</p>
+<p><img [src]='heroImageUrl' /> is the <i>property bound</i> image.</p>
 
 <p>
   <span>"{{ title }}" is the <i>interpolated</i> title.</span>
 </p>
-<p>"<span [innerHTML]="title"></span>" is the <i>property bound</i> title.</p>
+<p>"<span [innerHTML]='title'></span>" is the <i>property bound</i> title.</p>
 
 <!--
   Angular generates warnings for these two lines as it sanitizes them
@@ -11555,11 +11555,11 @@ can be found in the LICENSE file at http://angular.io/license
   <span>"{{ evilTitle }}" is the <i>interpolated</i> evil title.</span>
 </p>
 <p>
-  "<span [innerHTML]="evilTitle"></span>" is the <i>property bound</i> evil
+  "<span [innerHTML]='evilTitle'></span>" is the <i>property bound</i> evil
   title.
 </p>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- attribute binding -->
 <hr />
@@ -11569,7 +11569,7 @@ can be found in the LICENSE file at http://angular.io/license
 <table border="1">
   <!--  expression calculates colspan=2 -->
   <tr>
-    <td [attr.colspan]="1 + 1">One-Two</td>
+    <td [attr.colspan]='1 + 1'>One-Two</td>
   </tr>
 
   <!-- ERROR: There is no \`colspan\` property to set!
@@ -11584,111 +11584,111 @@ can be found in the LICENSE file at http://angular.io/license
 
 <br />
 <!-- create and set an aria attribute for assistive technology -->
-<button [attr.aria-label]="actionName">{{ actionName }} with Aria</button>
+<button [attr.aria-label]='actionName'>{{ actionName }} with Aria</button>
 <br /><br />
 
 <!-- The following effects are not discussed in the chapter -->
 <div>
   <!-- any use of [attr.disabled] creates the disabled attribute -->
-  <button [attr.disabled]="isUnchanged">Disabled</button>
+  <button [attr.disabled]='isUnchanged'>Disabled</button>
 
-  <button [attr.disabled]="!isUnchanged">Disabled as well</button>
+  <button [attr.disabled]='!isUnchanged'>Disabled as well</button>
 
   <!-- we'd have to remove it with property binding -->
-  <button disabled [disabled]="false">Enabled (but inert)</button>
+  <button disabled [disabled]='false'>Enabled (but inert)</button>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- class binding -->
 <hr />
 <h2 id="class-binding">Class Binding</h2>
 
 <!-- standard class attribute setting  -->
-<div class="bad curly special">Bad curly special</div>
+<div class='bad curly special'>Bad curly special</div>
 
 <!-- reset/override all class names with a binding  -->
-<div class="bad curly special" [class]="badCurly">Bad curly</div>
+<div class='bad curly special' [class]='badCurly'>Bad curly</div>
 
 <!-- toggle the "special" class on/off with a property -->
-<div [class.special]="isSpecial">The class binding is special</div>
+<div [class.special]='isSpecial'>The class binding is special</div>
 
 <!-- binding to \`class.special\` trumps the class attribute -->
-<div class="special" [class.special]="!isSpecial">
+<div class='special' [class.special]='!isSpecial'>
   This one is not so special
 </div>
 
-<div bind-class.special="isSpecial">This class binding is special too</div>
+<div bind-class.special='isSpecial'>This class binding is special too</div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!--style binding -->
 <hr />
 <h2 id="style-binding">Style Binding</h2>
 
-<button [style.color]="isSpecial ? 'red' : 'green'">Red</button>
-<button [style.background-color]="canSave ? 'cyan' : 'grey'">Save</button>
+<button [style.color]='isSpecial ? 'red' : 'green''>Red</button>
+<button [style.background-color]='canSave ? 'cyan' : 'grey''>Save</button>
 
-<button [style.font-size.em]="isSpecial ? 3 : 1">Big</button>
-<button [style.font-size.%]="!isSpecial ? 150 : 50">Small</button>
+<button [style.font-size.em]='isSpecial ? 3 : 1'>Big</button>
+<button [style.font-size.%]='!isSpecial ? 150 : 50'>Small</button>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- event binding -->
 <hr />
 <h2 id="event-binding">Event Binding</h2>
 
-<button (click)="onSave()">Save</button>
+<button (click)='onSave()'>Save</button>
 
-<button on-click="onSave()">On Save</button>
+<button on-click='onSave()'>On Save</button>
 
 <div>
   <!-- \`myClick\` is an event on the custom \`ClickDirective\` -->
-  <div (myClick)="clickMessage = $event" clickable>click with myClick</div>
+  <div (myClick)='clickMessage = $event' clickable>click with myClick</div>
   {{ clickMessage }}
 </div>
 
 <!-- binding to a nested component -->
 <app-hero-detail
-  (deleteRequest)="deleteHero($event)"
-  [hero]="currentHero"
+  (deleteRequest)='deleteHero($event)'
+  [hero]='currentHero'
 ></app-hero-detail>
 <br />
 
-<app-big-hero-detail (deleteRequest)="deleteHero($event)" [hero]="currentHero">
+<app-big-hero-detail (deleteRequest)='deleteHero($event)' [hero]='currentHero'>
 </app-big-hero-detail>
 
-<div class="parent-div" (click)="onClickMe($event)" clickable>
+<div class='parent-div' (click)='onClickMe($event)' clickable>
   Click me
-  <div class="child-div">Click me too!</div>
+  <div class='child-div'>Click me too!</div>
 </div>
 
 <!-- Will save only once -->
-<div (click)="onSave()" clickable>
-  <button (click)="onSave($event)">Save, no propagation</button>
+<div (click)='onSave()' clickable>
+  <button (click)='onSave($event)'>Save, no propagation</button>
 </div>
 
 <!-- Will save twice -->
-<div (click)="onSave()" clickable>
-  <button (click)="onSave()">Save w/ propagation</button>
+<div (click)='onSave()' clickable>
+  <button (click)='onSave()'>Save w/ propagation</button>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <hr />
 <h2 id="two-way">Two-way Binding</h2>
 <div id="two-way-1">
-  <app-sizer [(size)]="fontSizePx"></app-sizer>
-  <div [style.font-size.px]="fontSizePx">Resizable Text</div>
-  <label>FontSize (px): <input [(ngModel)]="fontSizePx" /></label>
+  <app-sizer [(size)]='fontSizePx'></app-sizer>
+  <div [style.font-size.px]='fontSizePx'>Resizable Text</div>
+  <label>FontSize (px): <input [(ngModel)]='fontSizePx' /></label>
 </div>
 <br />
 <div id="two-way-2">
   <h3>De-sugared two-way binding</h3>
-  <app-sizer [size]="fontSizePx" (sizeChange)="fontSizePx = $event"></app-sizer>
+  <app-sizer [size]='fontSizePx' (sizeChange)='fontSizePx = $event'></app-sizer>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- Two way data binding unwound;
     passing the changed display value to the event handler via \`$event\` -->
@@ -11698,187 +11698,187 @@ can be found in the LICENSE file at http://angular.io/license
 <h3>Result: {{ currentHero.name }}</h3>
 
 <input
-  [value]="currentHero.name"
-  (input)="currentHero.name = $event.target.value"
+  [value]='currentHero.name'
+  (input)='currentHero.name = $event.target.value'
 />
 without NgModel
 <br />
-<input [(ngModel)]="currentHero.name" />
+<input [(ngModel)]='currentHero.name' />
 [(ngModel)]
 <br />
-<input bindon-ngModel="currentHero.name" />
+<input bindon-ngModel='currentHero.name' />
 bindon-ngModel
 <br />
 <input
-  [ngModel]="currentHero.name"
-  (ngModelChange)="currentHero.name = $event"
+  [ngModel]='currentHero.name'
+  (ngModelChange)='currentHero.name = $event'
 />
 (ngModelChange)="...name=$event"
 <br />
 <input
-  [ngModel]="currentHero.name"
-  (ngModelChange)="setUppercaseName($event)"
+  [ngModel]='currentHero.name'
+  (ngModelChange)='setUppercaseName($event)'
 />
 (ngModelChange)="setUppercaseName($event)"
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- NgClass binding -->
 <hr />
 <h2 id="ngClass">NgClass Binding</h2>
 
 <p>currentClasses is {{ currentClasses | json }}</p>
-<div [ngClass]="currentClasses">
+<div [ngClass]='currentClasses'>
   This div is initially saveable, unchanged, and special
 </div>
 
 <!-- not used in chapter -->
 <br />
-<label>saveable <input type="checkbox" [(ngModel)]="canSave" /></label> |
+<label>saveable <input type="checkbox" [(ngModel)]='canSave' /></label> |
 <label
   >modified:
   <input
     type="checkbox"
-    [value]="!isUnchanged"
-    (change)="isUnchanged = !isUnchanged"
+    [value]='!isUnchanged'
+    (change)='isUnchanged = !isUnchanged'
 /></label>
 |
-<label>special: <input type="checkbox" [(ngModel)]="isSpecial" /></label>
-<button (click)="setCurrentClasses()">Refresh currentClasses</button>
+<label>special: <input type="checkbox" [(ngModel)]='isSpecial' /></label>
+<button (click)='setCurrentClasses()'>Refresh currentClasses</button>
 <br /><br />
-<div [ngClass]="currentClasses">
+<div [ngClass]='currentClasses'>
   This div should be {{ canSave ? "" : "not" }} saveable,
   {{ isUnchanged ? "unchanged" : "modified" }} and,
   {{ isSpecial ? "" : "not" }} special after clicking "Refresh".
 </div>
 <br /><br />
 
-<div [ngClass]="isSpecial ? 'special' : ''">This div is special</div>
+<div [ngClass]='isSpecial ? 'special' : '''>This div is special</div>
 
-<div class="bad curly special">Bad curly special</div>
-<div [ngClass]="{ bad: false, curly: true, special: true }">Curly special</div>
+<div class='bad curly special'>Bad curly special</div>
+<div [ngClass]='{ bad: false, curly: true, special: true }'>Curly special</div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- NgStyle binding -->
 <hr />
 <h2 id="ngStyle">NgStyle Binding</h2>
 
-<div [style.font-size]="isSpecial ? 'x-large' : 'smaller'">
+<div [style.font-size]='isSpecial ? 'x-large' : 'smaller''>
   This div is x-large or smaller.
 </div>
 
 <h3>[ngStyle] binding to currentStyles - CSS property names</h3>
 <p>currentStyles is {{ currentStyles | json }}</p>
-<div [ngStyle]="currentStyles">
+<div [ngStyle]='currentStyles'>
   This div is initially italic, normal weight, and extra large (24px).
 </div>
 
 <!-- not used in chapter -->
 <br />
-<label>italic: <input type="checkbox" [(ngModel)]="canSave" /></label> |
-<label>normal: <input type="checkbox" [(ngModel)]="isUnchanged" /></label> |
-<label>xlarge: <input type="checkbox" [(ngModel)]="isSpecial" /></label>
-<button (click)="setCurrentStyles()">Refresh currentStyles</button>
+<label>italic: <input type="checkbox" [(ngModel)]='canSave' /></label> |
+<label>normal: <input type="checkbox" [(ngModel)]='isUnchanged' /></label> |
+<label>xlarge: <input type="checkbox" [(ngModel)]='isSpecial' /></label>
+<button (click)='setCurrentStyles()'>Refresh currentStyles</button>
 <br /><br />
-<div [ngStyle]="currentStyles">
+<div [ngStyle]='currentStyles'>
   This div should be {{ canSave ? "italic" : "plain" }},
   {{ isUnchanged ? "normal weight" : "bold" }} and,
   {{ isSpecial ? "extra large" : "normal size" }} after clicking "Refresh".
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- NgIf binding -->
 <hr />
 <h2 id="ngIf">NgIf Binding</h2>
 
-<app-hero-detail *ngIf="isActive"></app-hero-detail>
+<app-hero-detail *ngIf='isActive'></app-hero-detail>
 
-<div *ngIf="currentHero">Hello, {{ currentHero.name }}</div>
-<div *ngIf="nullHero">Hello, {{ nullHero.name }}</div>
+<div *ngIf='currentHero'>Hello, {{ currentHero.name }}</div>
+<div *ngIf='nullHero'>Hello, {{ nullHero.name }}</div>
 
 <!-- NgIf binding with template (no *) -->
 
-<ng-template [ngIf]="currentHero"
+<ng-template [ngIf]='currentHero'
   >Add {{ currentHero.name }} with template</ng-template
 >
 
 <!-- Does not show because isActive is false! -->
 <div>Hero Detail removed from DOM (via template) because isActive is false</div>
-<ng-template [ngIf]="isActive">
+<ng-template [ngIf]='isActive'>
   <app-hero-detail></app-hero-detail>
 </ng-template>
 
 <!-- isSpecial is true -->
-<div [class.hidden]="!isSpecial">Show with class</div>
-<div [class.hidden]="isSpecial">Hide with class</div>
+<div [class.hidden]='!isSpecial'>Show with class</div>
+<div [class.hidden]='isSpecial'>Hide with class</div>
 
 <!-- HeroDetail is in the DOM but hidden -->
-<app-hero-detail [class.hidden]="isSpecial"></app-hero-detail>
+<app-hero-detail [class.hidden]='isSpecial'></app-hero-detail>
 
-<div [style.display]="isSpecial ? 'block' : 'none'">Show with style</div>
-<div [style.display]="isSpecial ? 'none' : 'block'">Hide with style</div>
+<div [style.display]='isSpecial ? 'block' : 'none''>Show with style</div>
+<div [style.display]='isSpecial ? 'none' : 'block''>Hide with style</div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- NgFor binding -->
 <hr />
 <h2 id="ngFor">NgFor Binding</h2>
 
-<div class="box">
-  <div *ngFor="let hero of heroes">{{ hero.name }}</div>
+<div class='box'>
+  <div *ngFor='let hero of heroes'>{{ hero.name }}</div>
 </div>
 <br />
 
-<div class="box">
+<div class='box'>
   <!-- *ngFor w/ hero-detail Component -->
-  <app-hero-detail *ngFor="let hero of heroes" [hero]="hero"></app-hero-detail>
+  <app-hero-detail *ngFor='let hero of heroes' [hero]='hero'></app-hero-detail>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <h4 id="ngFor-index">*ngFor with index</h4>
 <p>with <i>semi-colon</i> separator</p>
-<div class="box">
-  <div *ngFor="let hero of heroes; let i = index">
+<div class='box'>
+  <div *ngFor='let hero of heroes; let i = index'>
     {{ i + 1 }} - {{ hero.name }}
   </div>
 </div>
 
 <p>with <i>comma</i> separator</p>
-<div class="box">
+<div class='box'>
   <!-- Ex: "1 - Hercules" -->
-  <div *ngFor="let hero of heroes; let i = index">
+  <div *ngFor='let hero of heroes; let i = index'>
     {{ i + 1 }} - {{ hero.name }}
   </div>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <h4 id="ngFor-trackBy">*ngFor trackBy</h4>
-<button (click)="resetHeroes()">Reset heroes</button>
-<button (click)="changeIds()">Change ids</button>
-<button (click)="clearTrackByCounts()">Clear counts</button>
+<button (click)='resetHeroes()'>Reset heroes</button>
+<button (click)='changeIds()'>Change ids</button>
+<button (click)='clearTrackByCounts()'>Clear counts</button>
 
 <p><i>without</i> trackBy</p>
-<div class="box">
-  <div #noTrackBy *ngFor="let hero of heroes">
+<div class='box'>
+  <div #noTrackBy *ngFor='let hero of heroes'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 
-  <div id="noTrackByCnt" *ngIf="heroesNoTrackByCount">
+  <div id="noTrackByCnt" *ngIf='heroesNoTrackByCount'>
     Hero DOM elements change #{{ heroesNoTrackByCount }} without trackBy
   </div>
 </div>
 
 <p>with trackBy</p>
-<div class="box">
-  <div #withTrackBy *ngFor="let hero of heroes; trackBy: trackByHeroes">
+<div class='box'>
+  <div #withTrackBy *ngFor='let hero of heroes; trackBy: trackByHeroes'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 
-  <div id="withTrackByCnt" *ngIf="heroesWithTrackByCount">
+  <div id="withTrackByCnt" *ngIf='heroesWithTrackByCount'>
     Hero DOM elements change #{{ heroesWithTrackByCount }} with trackBy
   </div>
 </div>
@@ -11886,34 +11886,34 @@ bindon-ngModel
 <br /><br /><br />
 
 <p>with trackBy and <i>semi-colon</i> separator</p>
-<div class="box">
-  <div *ngFor="let hero of heroes; trackBy: trackByHeroes">
+<div class='box'>
+  <div *ngFor='let hero of heroes; trackBy: trackByHeroes'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 </div>
 
 <p>with trackBy and <i>comma</i> separator</p>
-<div class="box">
-  <div *ngFor="let hero of heroes; trackBy: trackByHeroes">
+<div class='box'>
+  <div *ngFor='let hero of heroes; trackBy: trackByHeroes'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 </div>
 
 <p>with trackBy and <i>space</i> separator</p>
-<div class="box">
-  <div *ngFor="let hero of heroes; trackBy: trackByHeroes">
+<div class='box'>
+  <div *ngFor='let hero of heroes; trackBy: trackByHeroes'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 </div>
 
 <p>with <i>generic</i> trackById function</p>
-<div class="box">
-  <div *ngFor="let hero of heroes; trackBy: trackById">
+<div class='box'>
+  <div *ngFor='let hero of heroes; trackBy: trackById'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- NgSwitch binding -->
 <hr />
@@ -11921,27 +11921,27 @@ bindon-ngModel
 
 <p>Pick your favorite hero</p>
 <div>
-  <label *ngFor="let h of heroes">
-    <input type="radio" name="heroes" [(ngModel)]="currentHero" [value]="h" />{{
+  <label *ngFor='let h of heroes'>
+    <input type="radio" name="heroes" [(ngModel)]='currentHero' [value]='h' />{{
       h.name
     }}
   </label>
 </div>
 
-<div [ngSwitch]="currentHero.emotion">
-  <app-happy-hero *ngSwitchCase="'happy'" [hero]="currentHero"></app-happy-hero>
-  <app-sad-hero *ngSwitchCase="'sad'" [hero]="currentHero"></app-sad-hero>
+<div [ngSwitch]='currentHero.emotion'>
+  <app-happy-hero *ngSwitchCase=''happy'' [hero]='currentHero'></app-happy-hero>
+  <app-sad-hero *ngSwitchCase=''sad'' [hero]='currentHero'></app-sad-hero>
   <app-confused-hero
-    *ngSwitchCase="'confused'"
-    [hero]="currentHero"
+    *ngSwitchCase=''confused''
+    [hero]='currentHero'
   ></app-confused-hero>
-  <div *ngSwitchCase="'confused'">
+  <div *ngSwitchCase=''confused''>
     Are you as confused as {{ currentHero.name }}?
   </div>
-  <app-unknown-hero *ngSwitchDefault [hero]="currentHero"></app-unknown-hero>
+  <app-unknown-hero *ngSwitchDefault [hero]='currentHero'></app-unknown-hero>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- template reference variable -->
 <hr />
@@ -11952,37 +11952,37 @@ bindon-ngModel
 <!-- lots of other elements -->
 
 <!-- phone refers to the input element; pass its \`value\` to an event handler -->
-<button (click)="callPhone(phone.value)">Call</button>
+<button (click)='callPhone(phone.value)'>Call</button>
 
 <input ref-fax placeholder="fax number" />
-<button (click)="callFax(fax.value)">Fax</button>
+<button (click)='callFax(fax.value)'>Fax</button>
 
 <!-- btn refers to the button element; show its disabled state -->
 <button
   #btn
   disabled
-  [innerHTML]="'disabled by attribute: ' + btn.disabled"
+  [innerHTML]=''disabled by attribute: ' + btn.disabled'
 ></button>
 
 <h4>Example Form</h4>
-<app-hero-form [hero]="currentHero"></app-hero-form>
+<app-hero-form [hero]='currentHero'></app-hero-form>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- inputs and output -->
 <hr />
 <h2 id="inputs-and-outputs">Inputs and Outputs</h2>
 
-<img [src]="iconUrl" />
-<button (click)="onSave()">Save</button>
+<img [src]='iconUrl' />
+<button (click)='onSave()'>Save</button>
 
-<app-hero-detail [hero]="currentHero" (deleteRequest)="deleteHero($event)">
+<app-hero-detail [hero]='currentHero' (deleteRequest)='deleteHero($event)'>
 </app-hero-detail>
 
-<div (myClick)="clickMessage2 = $event" clickable>myClick2</div>
+<div (myClick)='clickMessage2 = $event' clickable>myClick2</div>
 {{ clickMessage2 }}
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- Pipes -->
 <hr />
@@ -12010,7 +12010,7 @@ bindon-ngModel
   <label>Price: </label>{{ product.price | currency: "USD" : true }}
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- Null values and the safe navigation operator -->
 <hr />
@@ -12030,7 +12030,7 @@ See console log:
 -->
 
 <!--No hero, div not displayed, no error -->
-<div *ngIf="nullHero">The null hero's name is {{ nullHero.name }}</div>
+<div *ngIf='nullHero'>The null hero's name is {{ nullHero.name }}</div>
 
 <div>The null hero's name is {{ nullHero && nullHero.name }}</div>
 
@@ -12039,7 +12039,7 @@ See console log:
   The null hero's name is {{ nullHero?.name }}
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- non-null assertion operator -->
 <hr />
@@ -12047,10 +12047,10 @@ See console log:
 
 <div>
   <!--No hero, no text -->
-  <div *ngIf="hero">The hero's name is {{ hero!.name }}</div>
+  <div *ngIf='hero'>The hero's name is {{ hero!.name }}</div>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- non-null assertion operator -->
 <hr />
@@ -12066,7 +12066,7 @@ See console log:
   <div>Undeclared members is {{ $any(this).member }}</div>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- TODO: discuss this in the Style binding section -->
 <!-- enums in bindings -->
@@ -12076,12 +12076,12 @@ See console log:
 <p>
   The name of the Color.Red enum is {{ Color[Color.Red] }}.<br />
   The current color is {{ Color[color] }} and its number is {{ color }}.<br />
-  <button [style.color]="Color[color]" (click)="colorToggle()">
+  <button [style.color]='Color[color]' (click)='colorToggle()'>
     Enum Toggle
   </button>
 </p>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- 
 Copyright 2017-2018 Google Inc. All Rights Reserved.
@@ -12090,21 +12090,21 @@ can be found in the LICENSE file at http://angular.io/license
 -->
 
 <div id="heroForm">
-  <form (ngSubmit)="onSubmit(heroForm)" #heroForm="ngForm">
-    <div class="form-group">
+  <form (ngSubmit)='onSubmit(heroForm)' #heroForm="ngForm">
+    <div class='form-group'>
       <label for="name"
         >Name
         <input
-          class="form-control"
+          class='form-control'
           name="name"
           required
-          [(ngModel)]="hero.name"
+          [(ngModel)]='hero.name'
         />
       </label>
     </div>
-    <button type="submit" [disabled]="!heroForm.form.valid">Submit</button>
+    <button type="submit" [disabled]='!heroForm.form.valid'>Submit</button>
   </form>
-  <div [hidden]="!heroForm.form.valid">
+  <div [hidden]='!heroForm.form.valid'>
     {{ submitMessage }}
   </div>
 </div>
@@ -12857,7 +12857,7 @@ can be found in the LICENSE file at http://angular.io/license
 <a href="#prop-vs-attrib">Properties vs. Attributes</a><br />
 <br />
 <a href="#property-binding">Property Binding</a><br />
-<div style="margin-left: 8px">
+<div style='margin-left: 8px'>
   <a href="#attribute-binding">Attribute Binding</a><br />
   <a href="#class-binding">Class Binding</a><br />
   <a href="#style-binding">Style Binding</a><br />
@@ -12867,13 +12867,13 @@ can be found in the LICENSE file at http://angular.io/license
 <a href="#two-way">Two-way Binding</a><br />
 <br />
 <div>Directives</div>
-<div style="margin-left: 8px">
+<div style='margin-left: 8px'>
   <a href="#ngModel">NgModel (two-way) Binding</a><br />
   <a href="#ngClass">NgClass Binding</a><br />
   <a href="#ngStyle">NgStyle Binding</a><br />
   <a href="#ngIf">NgIf</a><br />
   <a href="#ngFor">NgFor</a><br />
-  <div style="margin-left: 8px">
+  <div style='margin-left: 8px'>
     <a href="#ngFor-index">NgFor with index</a><br />
     <a href="#ngFor-trackBy">NgFor with trackBy</a><br />
   </div>
@@ -12897,7 +12897,7 @@ can be found in the LICENSE file at http://angular.io/license
 
 <h3>
   {{ title }}
-  <img src="{{ heroImageUrl }}" style="height: 30px" />
+  <img src='{{ heroImageUrl }}' style='height: 30px' />
 </h3>
 
 <!-- "The sum of 1 + 1 is 2" -->
@@ -12906,7 +12906,7 @@ can be found in the LICENSE file at http://angular.io/license
 <!-- "The sum of 1 + 1 is not 4" -->
 <p>The sum of 1 + 1 is not {{ 1 + 1 + getVal() }}</p>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <hr />
 <h2 id="expression-context">Expression context</h2>
@@ -12915,52 +12915,52 @@ can be found in the LICENSE file at http://angular.io/license
   Component expression context (&#123;&#123;title&#125;&#125;,
   [hidden]="isUnchanged")
 </p>
-<div class="context">
+<div class='context'>
   {{ title }}
-  <span [hidden]="isUnchanged">changed</span>
+  <span [hidden]='isUnchanged'>changed</span>
 </div>
 
 <p>Template input variable expression context (let hero)</p>
 <!-- template hides the following; plenty of examples later -->
 <ng-template>
-  <div *ngFor="let hero of heroes">{{ hero.name }}</div>
+  <div *ngFor='let hero of heroes'>{{ hero.name }}</div>
 </ng-template>
 
 <p>Template reference variable expression context (#heroInput)</p>
-<div (keyup)="(0)" class="context">
+<div (keyup)='(0)' class='context'>
   Type something:
   <input #heroInput /> {{ heroInput.value }}
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <hr />
 <h2 id="statement-context">Statement context</h2>
 
 <p>Component statement context ( (click)="onSave() )</p>
-<div class="context">
-  <button (click)="deleteHero()">Delete hero</button>
+<div class='context'>
+  <button (click)='deleteHero()'>Delete hero</button>
 </div>
 
 <p>Template $event statement context</p>
-<div class="context">
-  <button (click)="onSave($event)">Save</button>
+<div class='context'>
+  <button (click)='onSave($event)'>Save</button>
 </div>
 
 <p>Template input variable statement context (let hero)</p>
 <!-- template hides the following; plenty of examples later -->
-<div class="context">
-  <button *ngFor="let hero of heroes" (click)="deleteHero(hero)">
+<div class='context'>
+  <button *ngFor='let hero of heroes' (click)='deleteHero(hero)'>
     {{ hero.name }}
   </button>
 </div>
 
 <p>Template reference variable statement context (#heroForm)</p>
-<div class="context">
-  <form #heroForm (ngSubmit)="onSubmit(heroForm)">...</form>
+<div class='context'>
+  <form #heroForm (ngSubmit)='onSubmit(heroForm)'>...</form>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- New Mental Model -->
 <hr />
@@ -12968,14 +12968,14 @@ can be found in the LICENSE file at http://angular.io/license
 
 <!--<img src="http://www.wpclipart.com/cartoon/people/hero/hero_silhoutte_T.png">-->
 <!-- Public Domain terms of use: http://www.wpclipart.com/terms.html -->
-<div class="special">Mental Model</div>
+<div class='special'>Mental Model</div>
 <img src="assets/images/hero.png" />
 <button disabled>Save</button>
 <br /><br />
 
 <div>
   <!-- Normal HTML -->
-  <div class="special">Mental Model</div>
+  <div class='special'>Mental Model</div>
   <!-- Wow! A new element! -->
   <app-hero-detail></app-hero-detail>
 </div>
@@ -12983,53 +12983,53 @@ can be found in the LICENSE file at http://angular.io/license
 
 <div>
   <!-- Bind button disabled state to \`isUnchanged\` property -->
-  <button [disabled]="isUnchanged">Save</button>
+  <button [disabled]='isUnchanged'>Save</button>
 </div>
 <br /><br />
 
 <div>
-  <img [src]="heroImageUrl" />
-  <app-hero-detail [hero]="currentHero"></app-hero-detail>
-  <div [ngClass]="{ special: isSpecial }"></div>
+  <img [src]='heroImageUrl' />
+  <app-hero-detail [hero]='currentHero'></app-hero-detail>
+  <div [ngClass]='{ special: isSpecial }'></div>
 </div>
 <br /><br />
 
-<button (click)="onSave()">Save</button>
-<app-hero-detail (deleteRequest)="deleteHero()"></app-hero-detail>
-<div (myClick)="clicked = $event" clickable>click me</div>
+<button (click)='onSave()'>Save</button>
+<app-hero-detail (deleteRequest)='deleteHero()'></app-hero-detail>
+<div (myClick)='clicked = $event' clickable>click me</div>
 {{ clicked }}
 <br /><br />
 
 <div>
   Hero Name:
-  <input [(ngModel)]="name" />
+  <input [(ngModel)]='name' />
   {{ name }}
 </div>
 <br /><br />
 
-<button [attr.aria-label]="help">help</button>
+<button [attr.aria-label]='help'>help</button>
 <br /><br />
 
-<div [class.special]="isSpecial">Special</div>
+<div [class.special]='isSpecial'>Special</div>
 <br /><br />
 
-<button [style.color]="isSpecial ? 'red' : 'green'">button</button>
+<button [style.color]='isSpecial ? 'red' : 'green''>button</button>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- property vs. attribute -->
 <hr />
 <h2 id="prop-vs-attrib">Property vs. Attribute (img examples)</h2>
 <!-- examine the following <img> tag in the browser tools -->
-<img src="images/ng-logo.png" [src]="heroImageUrl" />
+<img src="images/ng-logo.png" [src]='heroImageUrl' />
 
 <br /><br />
 
-<img [src]="iconUrl" />
-<img bind-src="heroImageUrl" />
-<img [attr.src]="villainImageUrl" />
+<img [src]='iconUrl' />
+<img bind-src='heroImageUrl' />
+<img [attr.src]='villainImageUrl' />
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- buttons -->
 <hr />
@@ -13040,39 +13040,39 @@ can be found in the LICENSE file at http://angular.io/license
 <button disabled="false">Still disabled</button>
 <br /><br />
 <button disabled>disabled by attribute</button>
-<button [disabled]="isUnchanged">disabled by property binding</button>
+<button [disabled]='isUnchanged'>disabled by property binding</button>
 <br /><br />
-<button bind-disabled="isUnchanged" on-click="onSave($event)">
+<button bind-disabled='isUnchanged' on-click='onSave($event)'>
   Disabled Cancel
 </button>
-<button [disabled]="!canSave" (click)="onSave($event)">Enabled Save</button>
+<button [disabled]='!canSave' (click)='onSave($event)'>Enabled Save</button>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- property binding -->
 <hr />
 <h2 id="property-binding">Property Binding</h2>
 
-<img [src]="heroImageUrl" />
-<button [disabled]="isUnchanged">Cancel is disabled</button>
-<div [ngClass]="classes">[ngClass] binding to the classes property</div>
-<app-hero-detail [hero]="currentHero"></app-hero-detail>
-<img bind-src="heroImageUrl" />
+<img [src]='heroImageUrl' />
+<button [disabled]='isUnchanged'>Cancel is disabled</button>
+<div [ngClass]='classes'>[ngClass] binding to the classes property</div>
+<app-hero-detail [hero]='currentHero'></app-hero-detail>
+<img bind-src='heroImageUrl' />
 
 <!-- ERROR: HeroDetailComponent.hero expects a
      Hero object, not the string "currentHero" -->
-<div *ngIf="false">
+<div *ngIf='false'>
   <app-hero-detail hero="currentHero"></app-hero-detail>
 </div>
-<app-hero-detail prefix="You are my" [hero]="currentHero"></app-hero-detail>
+<app-hero-detail prefix="You are my" [hero]='currentHero'></app-hero-detail>
 
-<p><img src="{{ heroImageUrl }}" /> is the <i>interpolated</i> image.</p>
-<p><img [src]="heroImageUrl" /> is the <i>property bound</i> image.</p>
+<p><img src='{{ heroImageUrl }}' /> is the <i>interpolated</i> image.</p>
+<p><img [src]='heroImageUrl' /> is the <i>property bound</i> image.</p>
 
 <p>
   <span>"{{ title }}" is the <i>interpolated</i> title.</span>
 </p>
-<p>"<span [innerHTML]="title"></span>" is the <i>property bound</i> title.</p>
+<p>"<span [innerHTML]='title'></span>" is the <i>property bound</i> title.</p>
 
 <!--
   Angular generates warnings for these two lines as it sanitizes them
@@ -13082,11 +13082,11 @@ can be found in the LICENSE file at http://angular.io/license
   <span>"{{ evilTitle }}" is the <i>interpolated</i> evil title.</span>
 </p>
 <p>
-  "<span [innerHTML]="evilTitle"></span>" is the <i>property bound</i> evil
+  "<span [innerHTML]='evilTitle'></span>" is the <i>property bound</i> evil
   title.
 </p>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- attribute binding -->
 <hr />
@@ -13096,7 +13096,7 @@ can be found in the LICENSE file at http://angular.io/license
 <table border="1">
   <!--  expression calculates colspan=2 -->
   <tr>
-    <td [attr.colspan]="1 + 1">One-Two</td>
+    <td [attr.colspan]='1 + 1'>One-Two</td>
   </tr>
 
   <!-- ERROR: There is no \`colspan\` property to set!
@@ -13111,111 +13111,111 @@ can be found in the LICENSE file at http://angular.io/license
 
 <br />
 <!-- create and set an aria attribute for assistive technology -->
-<button [attr.aria-label]="actionName">{{ actionName }} with Aria</button>
+<button [attr.aria-label]='actionName'>{{ actionName }} with Aria</button>
 <br /><br />
 
 <!-- The following effects are not discussed in the chapter -->
 <div>
   <!-- any use of [attr.disabled] creates the disabled attribute -->
-  <button [attr.disabled]="isUnchanged">Disabled</button>
+  <button [attr.disabled]='isUnchanged'>Disabled</button>
 
-  <button [attr.disabled]="!isUnchanged">Disabled as well</button>
+  <button [attr.disabled]='!isUnchanged'>Disabled as well</button>
 
   <!-- we'd have to remove it with property binding -->
-  <button disabled [disabled]="false">Enabled (but inert)</button>
+  <button disabled [disabled]='false'>Enabled (but inert)</button>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- class binding -->
 <hr />
 <h2 id="class-binding">Class Binding</h2>
 
 <!-- standard class attribute setting  -->
-<div class="bad curly special">Bad curly special</div>
+<div class='bad curly special'>Bad curly special</div>
 
 <!-- reset/override all class names with a binding  -->
-<div class="bad curly special" [class]="badCurly">Bad curly</div>
+<div class='bad curly special' [class]='badCurly'>Bad curly</div>
 
 <!-- toggle the "special" class on/off with a property -->
-<div [class.special]="isSpecial">The class binding is special</div>
+<div [class.special]='isSpecial'>The class binding is special</div>
 
 <!-- binding to \`class.special\` trumps the class attribute -->
-<div class="special" [class.special]="!isSpecial">
+<div class='special' [class.special]='!isSpecial'>
   This one is not so special
 </div>
 
-<div bind-class.special="isSpecial">This class binding is special too</div>
+<div bind-class.special='isSpecial'>This class binding is special too</div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!--style binding -->
 <hr />
 <h2 id="style-binding">Style Binding</h2>
 
-<button [style.color]="isSpecial ? 'red' : 'green'">Red</button>
-<button [style.background-color]="canSave ? 'cyan' : 'grey'">Save</button>
+<button [style.color]='isSpecial ? 'red' : 'green''>Red</button>
+<button [style.background-color]='canSave ? 'cyan' : 'grey''>Save</button>
 
-<button [style.font-size.em]="isSpecial ? 3 : 1">Big</button>
-<button [style.font-size.%]="!isSpecial ? 150 : 50">Small</button>
+<button [style.font-size.em]='isSpecial ? 3 : 1'>Big</button>
+<button [style.font-size.%]='!isSpecial ? 150 : 50'>Small</button>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- event binding -->
 <hr />
 <h2 id="event-binding">Event Binding</h2>
 
-<button (click)="onSave()">Save</button>
+<button (click)='onSave()'>Save</button>
 
-<button on-click="onSave()">On Save</button>
+<button on-click='onSave()'>On Save</button>
 
 <div>
   <!-- \`myClick\` is an event on the custom \`ClickDirective\` -->
-  <div (myClick)="clickMessage = $event" clickable>click with myClick</div>
+  <div (myClick)='clickMessage = $event' clickable>click with myClick</div>
   {{ clickMessage }}
 </div>
 
 <!-- binding to a nested component -->
 <app-hero-detail
-  (deleteRequest)="deleteHero($event)"
-  [hero]="currentHero"
+  (deleteRequest)='deleteHero($event)'
+  [hero]='currentHero'
 ></app-hero-detail>
 <br />
 
-<app-big-hero-detail (deleteRequest)="deleteHero($event)" [hero]="currentHero">
+<app-big-hero-detail (deleteRequest)='deleteHero($event)' [hero]='currentHero'>
 </app-big-hero-detail>
 
-<div class="parent-div" (click)="onClickMe($event)" clickable>
+<div class='parent-div' (click)='onClickMe($event)' clickable>
   Click me
-  <div class="child-div">Click me too!</div>
+  <div class='child-div'>Click me too!</div>
 </div>
 
 <!-- Will save only once -->
-<div (click)="onSave()" clickable>
-  <button (click)="onSave($event)">Save, no propagation</button>
+<div (click)='onSave()' clickable>
+  <button (click)='onSave($event)'>Save, no propagation</button>
 </div>
 
 <!-- Will save twice -->
-<div (click)="onSave()" clickable>
-  <button (click)="onSave()">Save w/ propagation</button>
+<div (click)='onSave()' clickable>
+  <button (click)='onSave()'>Save w/ propagation</button>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <hr />
 <h2 id="two-way">Two-way Binding</h2>
 <div id="two-way-1">
-  <app-sizer [(size)]="fontSizePx"></app-sizer>
-  <div [style.font-size.px]="fontSizePx">Resizable Text</div>
-  <label>FontSize (px): <input [(ngModel)]="fontSizePx" /></label>
+  <app-sizer [(size)]='fontSizePx'></app-sizer>
+  <div [style.font-size.px]='fontSizePx'>Resizable Text</div>
+  <label>FontSize (px): <input [(ngModel)]='fontSizePx' /></label>
 </div>
 <br />
 <div id="two-way-2">
   <h3>De-sugared two-way binding</h3>
-  <app-sizer [size]="fontSizePx" (sizeChange)="fontSizePx = $event"></app-sizer>
+  <app-sizer [size]='fontSizePx' (sizeChange)='fontSizePx = $event'></app-sizer>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- Two way data binding unwound;
     passing the changed display value to the event handler via \`$event\` -->
@@ -13225,187 +13225,187 @@ can be found in the LICENSE file at http://angular.io/license
 <h3>Result: {{ currentHero.name }}</h3>
 
 <input
-  [value]="currentHero.name"
-  (input)="currentHero.name = $event.target.value"
+  [value]='currentHero.name'
+  (input)='currentHero.name = $event.target.value'
 />
 without NgModel
 <br />
-<input [(ngModel)]="currentHero.name" />
+<input [(ngModel)]='currentHero.name' />
 [(ngModel)]
 <br />
-<input bindon-ngModel="currentHero.name" />
+<input bindon-ngModel='currentHero.name' />
 bindon-ngModel
 <br />
 <input
-  [ngModel]="currentHero.name"
-  (ngModelChange)="currentHero.name = $event"
+  [ngModel]='currentHero.name'
+  (ngModelChange)='currentHero.name = $event'
 />
 (ngModelChange)="...name=$event"
 <br />
 <input
-  [ngModel]="currentHero.name"
-  (ngModelChange)="setUppercaseName($event)"
+  [ngModel]='currentHero.name'
+  (ngModelChange)='setUppercaseName($event)'
 />
 (ngModelChange)="setUppercaseName($event)"
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- NgClass binding -->
 <hr />
 <h2 id="ngClass">NgClass Binding</h2>
 
 <p>currentClasses is {{ currentClasses | json }}</p>
-<div [ngClass]="currentClasses">
+<div [ngClass]='currentClasses'>
   This div is initially saveable, unchanged, and special
 </div>
 
 <!-- not used in chapter -->
 <br />
-<label>saveable <input type="checkbox" [(ngModel)]="canSave" /></label> |
+<label>saveable <input type="checkbox" [(ngModel)]='canSave' /></label> |
 <label
   >modified:
   <input
     type="checkbox"
-    [value]="!isUnchanged"
-    (change)="isUnchanged = !isUnchanged"
+    [value]='!isUnchanged'
+    (change)='isUnchanged = !isUnchanged'
 /></label>
 |
-<label>special: <input type="checkbox" [(ngModel)]="isSpecial" /></label>
-<button (click)="setCurrentClasses()">Refresh currentClasses</button>
+<label>special: <input type="checkbox" [(ngModel)]='isSpecial' /></label>
+<button (click)='setCurrentClasses()'>Refresh currentClasses</button>
 <br /><br />
-<div [ngClass]="currentClasses">
+<div [ngClass]='currentClasses'>
   This div should be {{ canSave ? "" : "not" }} saveable,
   {{ isUnchanged ? "unchanged" : "modified" }} and,
   {{ isSpecial ? "" : "not" }} special after clicking "Refresh".
 </div>
 <br /><br />
 
-<div [ngClass]="isSpecial ? 'special' : ''">This div is special</div>
+<div [ngClass]='isSpecial ? 'special' : '''>This div is special</div>
 
-<div class="bad curly special">Bad curly special</div>
-<div [ngClass]="{ bad: false, curly: true, special: true }">Curly special</div>
+<div class='bad curly special'>Bad curly special</div>
+<div [ngClass]='{ bad: false, curly: true, special: true }'>Curly special</div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- NgStyle binding -->
 <hr />
 <h2 id="ngStyle">NgStyle Binding</h2>
 
-<div [style.font-size]="isSpecial ? 'x-large' : 'smaller'">
+<div [style.font-size]='isSpecial ? 'x-large' : 'smaller''>
   This div is x-large or smaller.
 </div>
 
 <h3>[ngStyle] binding to currentStyles - CSS property names</h3>
 <p>currentStyles is {{ currentStyles | json }}</p>
-<div [ngStyle]="currentStyles">
+<div [ngStyle]='currentStyles'>
   This div is initially italic, normal weight, and extra large (24px).
 </div>
 
 <!-- not used in chapter -->
 <br />
-<label>italic: <input type="checkbox" [(ngModel)]="canSave" /></label> |
-<label>normal: <input type="checkbox" [(ngModel)]="isUnchanged" /></label> |
-<label>xlarge: <input type="checkbox" [(ngModel)]="isSpecial" /></label>
-<button (click)="setCurrentStyles()">Refresh currentStyles</button>
+<label>italic: <input type="checkbox" [(ngModel)]='canSave' /></label> |
+<label>normal: <input type="checkbox" [(ngModel)]='isUnchanged' /></label> |
+<label>xlarge: <input type="checkbox" [(ngModel)]='isSpecial' /></label>
+<button (click)='setCurrentStyles()'>Refresh currentStyles</button>
 <br /><br />
-<div [ngStyle]="currentStyles">
+<div [ngStyle]='currentStyles'>
   This div should be {{ canSave ? "italic" : "plain" }},
   {{ isUnchanged ? "normal weight" : "bold" }} and,
   {{ isSpecial ? "extra large" : "normal size" }} after clicking "Refresh".
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- NgIf binding -->
 <hr />
 <h2 id="ngIf">NgIf Binding</h2>
 
-<app-hero-detail *ngIf="isActive"></app-hero-detail>
+<app-hero-detail *ngIf='isActive'></app-hero-detail>
 
-<div *ngIf="currentHero">Hello, {{ currentHero.name }}</div>
-<div *ngIf="nullHero">Hello, {{ nullHero.name }}</div>
+<div *ngIf='currentHero'>Hello, {{ currentHero.name }}</div>
+<div *ngIf='nullHero'>Hello, {{ nullHero.name }}</div>
 
 <!-- NgIf binding with template (no *) -->
 
-<ng-template [ngIf]="currentHero"
+<ng-template [ngIf]='currentHero'
   >Add {{ currentHero.name }} with template</ng-template
 >
 
 <!-- Does not show because isActive is false! -->
 <div>Hero Detail removed from DOM (via template) because isActive is false</div>
-<ng-template [ngIf]="isActive">
+<ng-template [ngIf]='isActive'>
   <app-hero-detail></app-hero-detail>
 </ng-template>
 
 <!-- isSpecial is true -->
-<div [class.hidden]="!isSpecial">Show with class</div>
-<div [class.hidden]="isSpecial">Hide with class</div>
+<div [class.hidden]='!isSpecial'>Show with class</div>
+<div [class.hidden]='isSpecial'>Hide with class</div>
 
 <!-- HeroDetail is in the DOM but hidden -->
-<app-hero-detail [class.hidden]="isSpecial"></app-hero-detail>
+<app-hero-detail [class.hidden]='isSpecial'></app-hero-detail>
 
-<div [style.display]="isSpecial ? 'block' : 'none'">Show with style</div>
-<div [style.display]="isSpecial ? 'none' : 'block'">Hide with style</div>
+<div [style.display]='isSpecial ? 'block' : 'none''>Show with style</div>
+<div [style.display]='isSpecial ? 'none' : 'block''>Hide with style</div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- NgFor binding -->
 <hr />
 <h2 id="ngFor">NgFor Binding</h2>
 
-<div class="box">
-  <div *ngFor="let hero of heroes">{{ hero.name }}</div>
+<div class='box'>
+  <div *ngFor='let hero of heroes'>{{ hero.name }}</div>
 </div>
 <br />
 
-<div class="box">
+<div class='box'>
   <!-- *ngFor w/ hero-detail Component -->
-  <app-hero-detail *ngFor="let hero of heroes" [hero]="hero"></app-hero-detail>
+  <app-hero-detail *ngFor='let hero of heroes' [hero]='hero'></app-hero-detail>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <h4 id="ngFor-index">*ngFor with index</h4>
 <p>with <i>semi-colon</i> separator</p>
-<div class="box">
-  <div *ngFor="let hero of heroes; let i = index">
+<div class='box'>
+  <div *ngFor='let hero of heroes; let i = index'>
     {{ i + 1 }} - {{ hero.name }}
   </div>
 </div>
 
 <p>with <i>comma</i> separator</p>
-<div class="box">
+<div class='box'>
   <!-- Ex: "1 - Hercules" -->
-  <div *ngFor="let hero of heroes; let i = index">
+  <div *ngFor='let hero of heroes; let i = index'>
     {{ i + 1 }} - {{ hero.name }}
   </div>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <h4 id="ngFor-trackBy">*ngFor trackBy</h4>
-<button (click)="resetHeroes()">Reset heroes</button>
-<button (click)="changeIds()">Change ids</button>
-<button (click)="clearTrackByCounts()">Clear counts</button>
+<button (click)='resetHeroes()'>Reset heroes</button>
+<button (click)='changeIds()'>Change ids</button>
+<button (click)='clearTrackByCounts()'>Clear counts</button>
 
 <p><i>without</i> trackBy</p>
-<div class="box">
-  <div #noTrackBy *ngFor="let hero of heroes">
+<div class='box'>
+  <div #noTrackBy *ngFor='let hero of heroes'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 
-  <div id="noTrackByCnt" *ngIf="heroesNoTrackByCount">
+  <div id="noTrackByCnt" *ngIf='heroesNoTrackByCount'>
     Hero DOM elements change #{{ heroesNoTrackByCount }} without trackBy
   </div>
 </div>
 
 <p>with trackBy</p>
-<div class="box">
-  <div #withTrackBy *ngFor="let hero of heroes; trackBy: trackByHeroes">
+<div class='box'>
+  <div #withTrackBy *ngFor='let hero of heroes; trackBy: trackByHeroes'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 
-  <div id="withTrackByCnt" *ngIf="heroesWithTrackByCount">
+  <div id="withTrackByCnt" *ngIf='heroesWithTrackByCount'>
     Hero DOM elements change #{{ heroesWithTrackByCount }} with trackBy
   </div>
 </div>
@@ -13413,34 +13413,34 @@ bindon-ngModel
 <br /><br /><br />
 
 <p>with trackBy and <i>semi-colon</i> separator</p>
-<div class="box">
-  <div *ngFor="let hero of heroes; trackBy: trackByHeroes">
+<div class='box'>
+  <div *ngFor='let hero of heroes; trackBy: trackByHeroes'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 </div>
 
 <p>with trackBy and <i>comma</i> separator</p>
-<div class="box">
-  <div *ngFor="let hero of heroes; trackBy: trackByHeroes">
+<div class='box'>
+  <div *ngFor='let hero of heroes; trackBy: trackByHeroes'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 </div>
 
 <p>with trackBy and <i>space</i> separator</p>
-<div class="box">
-  <div *ngFor="let hero of heroes; trackBy: trackByHeroes">
+<div class='box'>
+  <div *ngFor='let hero of heroes; trackBy: trackByHeroes'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 </div>
 
 <p>with <i>generic</i> trackById function</p>
-<div class="box">
-  <div *ngFor="let hero of heroes; trackBy: trackById">
+<div class='box'>
+  <div *ngFor='let hero of heroes; trackBy: trackById'>
     ({{ hero.id }}) {{ hero.name }}
   </div>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- NgSwitch binding -->
 <hr />
@@ -13448,27 +13448,27 @@ bindon-ngModel
 
 <p>Pick your favorite hero</p>
 <div>
-  <label *ngFor="let h of heroes">
-    <input type="radio" name="heroes" [(ngModel)]="currentHero" [value]="h" />{{
+  <label *ngFor='let h of heroes'>
+    <input type="radio" name="heroes" [(ngModel)]='currentHero' [value]='h' />{{
       h.name
     }}
   </label>
 </div>
 
-<div [ngSwitch]="currentHero.emotion">
-  <app-happy-hero *ngSwitchCase="'happy'" [hero]="currentHero"></app-happy-hero>
-  <app-sad-hero *ngSwitchCase="'sad'" [hero]="currentHero"></app-sad-hero>
+<div [ngSwitch]='currentHero.emotion'>
+  <app-happy-hero *ngSwitchCase=''happy'' [hero]='currentHero'></app-happy-hero>
+  <app-sad-hero *ngSwitchCase=''sad'' [hero]='currentHero'></app-sad-hero>
   <app-confused-hero
-    *ngSwitchCase="'confused'"
-    [hero]="currentHero"
+    *ngSwitchCase=''confused''
+    [hero]='currentHero'
   ></app-confused-hero>
-  <div *ngSwitchCase="'confused'">
+  <div *ngSwitchCase=''confused''>
     Are you as confused as {{ currentHero.name }}?
   </div>
-  <app-unknown-hero *ngSwitchDefault [hero]="currentHero"></app-unknown-hero>
+  <app-unknown-hero *ngSwitchDefault [hero]='currentHero'></app-unknown-hero>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- template reference variable -->
 <hr />
@@ -13479,37 +13479,37 @@ bindon-ngModel
 <!-- lots of other elements -->
 
 <!-- phone refers to the input element; pass its \`value\` to an event handler -->
-<button (click)="callPhone(phone.value)">Call</button>
+<button (click)='callPhone(phone.value)'>Call</button>
 
 <input ref-fax placeholder="fax number" />
-<button (click)="callFax(fax.value)">Fax</button>
+<button (click)='callFax(fax.value)'>Fax</button>
 
 <!-- btn refers to the button element; show its disabled state -->
 <button
   #btn
   disabled
-  [innerHTML]="'disabled by attribute: ' + btn.disabled"
+  [innerHTML]=''disabled by attribute: ' + btn.disabled'
 ></button>
 
 <h4>Example Form</h4>
-<app-hero-form [hero]="currentHero"></app-hero-form>
+<app-hero-form [hero]='currentHero'></app-hero-form>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- inputs and output -->
 <hr />
 <h2 id="inputs-and-outputs">Inputs and Outputs</h2>
 
-<img [src]="iconUrl" />
-<button (click)="onSave()">Save</button>
+<img [src]='iconUrl' />
+<button (click)='onSave()'>Save</button>
 
-<app-hero-detail [hero]="currentHero" (deleteRequest)="deleteHero($event)">
+<app-hero-detail [hero]='currentHero' (deleteRequest)='deleteHero($event)'>
 </app-hero-detail>
 
-<div (myClick)="clickMessage2 = $event" clickable>myClick2</div>
+<div (myClick)='clickMessage2 = $event' clickable>myClick2</div>
 {{ clickMessage2 }}
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- Pipes -->
 <hr />
@@ -13537,7 +13537,7 @@ bindon-ngModel
   <label>Price: </label>{{ product.price | currency: "USD" : true }}
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- Null values and the safe navigation operator -->
 <hr />
@@ -13557,7 +13557,7 @@ See console log:
 -->
 
 <!--No hero, div not displayed, no error -->
-<div *ngIf="nullHero">The null hero's name is {{ nullHero.name }}</div>
+<div *ngIf='nullHero'>The null hero's name is {{ nullHero.name }}</div>
 
 <div>The null hero's name is {{ nullHero && nullHero.name }}</div>
 
@@ -13566,7 +13566,7 @@ See console log:
   The null hero's name is {{ nullHero?.name }}
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- non-null assertion operator -->
 <hr />
@@ -13574,10 +13574,10 @@ See console log:
 
 <div>
   <!--No hero, no text -->
-  <div *ngIf="hero">The hero's name is {{ hero!.name }}</div>
+  <div *ngIf='hero'>The hero's name is {{ hero!.name }}</div>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- non-null assertion operator -->
 <hr />
@@ -13593,7 +13593,7 @@ See console log:
   <div>Undeclared members is {{ $any(this).member }}</div>
 </div>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- TODO: discuss this in the Style binding section -->
 <!-- enums in bindings -->
@@ -13603,12 +13603,12 @@ See console log:
 <p>
   The name of the Color.Red enum is {{ Color[Color.Red] }}.<br />
   The current color is {{ Color[color] }} and its number is {{ color }}.<br />
-  <button [style.color]="Color[color]" (click)="colorToggle()">
+  <button [style.color]='Color[color]' (click)='colorToggle()'>
     Enum Toggle
   </button>
 </p>
 
-<a class="to-toc" href="#toc">top</a>
+<a class='to-toc' href="#toc">top</a>
 
 <!-- 
 Copyright 2017-2018 Google Inc. All Rights Reserved.
@@ -13617,21 +13617,21 @@ can be found in the LICENSE file at http://angular.io/license
 -->
 
 <div id="heroForm">
-  <form (ngSubmit)="onSubmit(heroForm)" #heroForm="ngForm">
-    <div class="form-group">
+  <form (ngSubmit)='onSubmit(heroForm)' #heroForm="ngForm">
+    <div class='form-group'>
       <label for="name"
         >Name
         <input
-          class="form-control"
+          class='form-control'
           name="name"
           required
-          [(ngModel)]="hero.name"
+          [(ngModel)]='hero.name'
         />
       </label>
     </div>
-    <button type="submit" [disabled]="!heroForm.form.valid">Submit</button>
+    <button type="submit" [disabled]='!heroForm.form.valid'>Submit</button>
   </form>
-  <div [hidden]="!heroForm.form.valid">
+  <div [hidden]='!heroForm.form.valid'>
     {{ submitMessage }}
   </div>
 </div>

--- a/tests/format/angular/bracket-same-line/__snapshots__/format.test.js.snap
+++ b/tests/format/angular/bracket-same-line/__snapshots__/format.test.js.snap
@@ -27,37 +27,37 @@ printWidth: 80
 
 =====================================output=====================================
 <div
-  ng-if="$ctrl.shouldShowWarning && !$ctrl.loading"
-  bindon-target="a | b: c"
-  (event)="(foo == $event)"
-  *ngIf="something ? true : false"
-  [(ngModel)]="canSave"
+  ng-if='$ctrl.shouldShowWarning && !$ctrl.loading'
+  bindon-target='a | b: c'
+  (event)='(foo == $event)'
+  *ngIf='something ? true : false'
+  [(ngModel)]='canSave'
 >
   Warning!
 </div>
 <span
-  ng-if="$ctrl.shouldShowWarning && !$ctrl.loading"
-  bindon-target="a | b: c"
-  (event)="(foo == $event)"
-  *ngIf="something ? true : false"
-  [(ngModel)]="canSave"
+  ng-if='$ctrl.shouldShowWarning && !$ctrl.loading'
+  bindon-target='a | b: c'
+  (event)='(foo == $event)'
+  *ngIf='something ? true : false'
+  [(ngModel)]='canSave'
   >Warning!</span
 >
 <img
-  ng-if="$ctrl.shouldShowWarning && !$ctrl.loading"
-  bindon-target="a | b: c"
-  (event)="(foo == $event)"
-  *ngIf="something ? true : false"
-  [(ngModel)]="canSave"
+  ng-if='$ctrl.shouldShowWarning && !$ctrl.loading'
+  bindon-target='a | b: c'
+  (event)='(foo == $event)'
+  *ngIf='something ? true : false'
+  [(ngModel)]='canSave'
 />
 <script
   long-attribute="long_long_long_long_long_long_long_long_long_long_long_long_long_value"
 >
   alert(1);
 </script>
-<div (event)="(foo == $event)">Warning!</div>
-<span (event)="(foo == $event)">Warning!</span>
-<img (event)="(foo == $event)" />
+<div (event)='(foo == $event)'>Warning!</div>
+<span (event)='(foo == $event)'>Warning!</span>
+<img (event)='(foo == $event)' />
 <script>
   alert(1);
 </script>
@@ -92,34 +92,34 @@ printWidth: 80
 
 =====================================output=====================================
 <div
-  ng-if="$ctrl.shouldShowWarning && !$ctrl.loading"
-  bindon-target="a | b: c"
-  (event)="(foo == $event)"
-  *ngIf="something ? true : false"
-  [(ngModel)]="canSave">
+  ng-if='$ctrl.shouldShowWarning && !$ctrl.loading'
+  bindon-target='a | b: c'
+  (event)='(foo == $event)'
+  *ngIf='something ? true : false'
+  [(ngModel)]='canSave'>
   Warning!
 </div>
 <span
-  ng-if="$ctrl.shouldShowWarning && !$ctrl.loading"
-  bindon-target="a | b: c"
-  (event)="(foo == $event)"
-  *ngIf="something ? true : false"
-  [(ngModel)]="canSave"
+  ng-if='$ctrl.shouldShowWarning && !$ctrl.loading'
+  bindon-target='a | b: c'
+  (event)='(foo == $event)'
+  *ngIf='something ? true : false'
+  [(ngModel)]='canSave'
   >Warning!</span
 >
 <img
-  ng-if="$ctrl.shouldShowWarning && !$ctrl.loading"
-  bindon-target="a | b: c"
-  (event)="(foo == $event)"
-  *ngIf="something ? true : false"
-  [(ngModel)]="canSave" />
+  ng-if='$ctrl.shouldShowWarning && !$ctrl.loading'
+  bindon-target='a | b: c'
+  (event)='(foo == $event)'
+  *ngIf='something ? true : false'
+  [(ngModel)]='canSave' />
 <script
   long-attribute="long_long_long_long_long_long_long_long_long_long_long_long_long_value">
   alert(1);
 </script>
-<div (event)="(foo == $event)">Warning!</div>
-<span (event)="(foo == $event)">Warning!</span>
-<img (event)="(foo == $event)" />
+<div (event)='(foo == $event)'>Warning!</div>
+<span (event)='(foo == $event)'>Warning!</span>
+<img (event)='(foo == $event)' />
 <script>
   alert(1);
 </script>

--- a/tests/format/angular/control-flow/__snapshots__/format.test.js.snap
+++ b/tests/format/angular/control-flow/__snapshots__/format.test.js.snap
@@ -33,21 +33,21 @@ printWidth: 80
     }
 
 =====================================output=====================================
-<ion-list class="timeline" appScrollItem>
+<ion-list class='timeline' appScrollItem>
   @for (let item of items; index as i; trackBy: trackByFn) {
     <app-tweet-item></app-tweet-item>
     @if (areaId && canTweet) {
-      <ion-item class="recommend-trust-up" lines="full"></ion-item>
+      <ion-item class='recommend-trust-up' lines="full"></ion-item>
     }
   }
 </ion-list>
 
-<ng-container *ngIf="areaId && canTweet">
-  <ion-item class="recommend-trust-up" lines="full"></ion-item>
+<ng-container *ngIf='areaId && canTweet'>
+  <ion-item class='recommend-trust-up' lines="full"></ion-item>
 </ng-container>
 
 @if (areaId && canTweet) {
-  <ion-item class="recommend-trust-up" lines="full"></ion-item>
+  <ion-item class='recommend-trust-up' lines="full"></ion-item>
 }
 
 ================================================================================
@@ -302,7 +302,7 @@ item of
   }
 </ul>
 
-<li *ngFor="let item of items; index as i; trackBy: trackByFn"></li>
+<li *ngFor='let item of items; index as i; trackBy: trackByFn'></li>
 
 <ul>
   @for (
@@ -330,18 +330,18 @@ item of
     <span>The collection is empty</span>
   }
 </ul>
-<li *ngFor="item of emptyCollection; track item.id"></li>
+<li *ngFor='item of emptyCollection; track item.id'></li>
 
 <div>
   @for (item of items; track item) {}
 
-  <div *ngFor="item of items; track item"></div>
+  <div *ngFor='item of items; track item'></div>
 </div>
 
 <div>
   @for (item of items; let i = $index; track block) {}
 
-  <div *ngFor="item of items; let i = $index; track block"></div>
+  <div *ngFor='item of items; let i = $index; track block'></div>
 </div>
 
 ================================================================================
@@ -396,8 +396,8 @@ topStartToSideStartMaxSize) {
   <input
     #checkbox
     type="checkbox"
-    [checked]="isChecked()"
-    (change)="isChecked.set(checkbox.checked)"
+    [checked]='isChecked()'
+    (change)='isChecked.set(checkbox.checked)'
     id="checkbox"
   />
 </div>
@@ -415,7 +415,7 @@ topStartToSideStartMaxSize) {
   {{ users.length }}
 }
 
-<div *ngIf="users$ | async; as users">{{ users.length }}</div>
+<div *ngIf='users$ | async; as users'>{{ users.length }}</div>
 
 @else {}
 
@@ -433,7 +433,7 @@ topStartToSideStartMaxSize) {
 
 @if (widthCategory; as item) {}
 
-<div *ngIf="widthCategory; as item"></div>
+<div *ngIf='widthCategory; as item'></div>
 
 ================================================================================
 `;
@@ -499,11 +499,11 @@ printWidth: 80
 
 =====================================output=====================================
 @if (user.isHuman) {
-  <human-profile [data]="user" />
+  <human-profile [data]='user' />
 } @else if (user.isRobot) {
   <!-- robot users are rare, so load their profiles lazily -->
   @defer {
-    <robot-profile [data]="user" />
+    <robot-profile [data]='user' />
   }
 } @else {
   <p>The profile is unknown!</p>

--- a/tests/format/angular/icu-expression/__snapshots__/format.test.js.snap
+++ b/tests/format/angular/icu-expression/__snapshots__/format.test.js.snap
@@ -121,7 +121,7 @@ printWidth: 80
       Found <ph
         id="0"
         equiv="INTERPOLATION"
-        disp="{{ response.getItemsList().length }}"
+        disp='{{ response.getItemsList().length }}'
       /> results
     }
   }</bar>

--- a/tests/format/angular/let-declaration/__snapshots__/format.test.js.snap
+++ b/tests/format/angular/let-declaration/__snapshots__/format.test.js.snap
@@ -69,7 +69,7 @@ printWidth: 80
   @let nested = value;
 }
 
-<div *ngIf="condition">
+<div *ngIf='condition'>
   @let nestedNgIf = value;
 </div>
 

--- a/tests/format/angular/shorthand/__snapshots__/format.test.js.snap
+++ b/tests/format/angular/shorthand/__snapshots__/format.test.js.snap
@@ -10,8 +10,8 @@ printWidth: 80
 <div dir [input]="{   a,   b:   2   }"></div>
 
 =====================================output=====================================
-<ng-container *ngTemplateOutlet="someTmpl; context: { app }"></ng-container>
-<div dir [input]="{ a, b: 2 }"></div>
+<ng-container *ngTemplateOutlet='someTmpl; context: { app }'></ng-container>
+<div dir [input]='{ a, b: 2 }'></div>
 
 ================================================================================
 `;

--- a/tests/format/angular/trailing-comma/__snapshots__/format.test.js.snap
+++ b/tests/format/angular/trailing-comma/__snapshots__/format.test.js.snap
@@ -66,7 +66,7 @@ trailingComma: "all"
 
 =====================================output=====================================
 <div
-  (action)="
+  (action)='
     ({
       long,
       long,
@@ -81,8 +81,8 @@ trailingComma: "all"
       object,
       property,
     })
-  "
-  (action)="
+  '
+  (action)='
     ([
       long,
       long,
@@ -97,8 +97,8 @@ trailingComma: "all"
       array,
       element,
     ])
-  "
-  (action)="
+  '
+  (action)='
     call(
       long,
       long,
@@ -113,8 +113,8 @@ trailingComma: "all"
       call,
       argument
     )
-  "
-  [binding]="{
+  '
+  [binding]='{
     long,
     long,
     long,
@@ -127,8 +127,8 @@ trailingComma: "all"
     long,
     object,
     property,
-  }"
-  [binding]="[
+  }'
+  [binding]='[
     long,
     long,
     long,
@@ -141,8 +141,8 @@ trailingComma: "all"
     long,
     array,
     element,
-  ]"
-  [binding]="
+  ]'
+  [binding]='
     call(
       long,
       long,
@@ -157,8 +157,8 @@ trailingComma: "all"
       call,
       argument
     )
-  "
-  *directive="{
+  '
+  *directive='{
     long,
     long,
     long,
@@ -171,8 +171,8 @@ trailingComma: "all"
     long,
     object,
     property,
-  }"
-  *directive="[
+  }'
+  *directive='[
     long,
     long,
     long,
@@ -185,8 +185,8 @@ trailingComma: "all"
     long,
     array,
     element,
-  ]"
-  *directive="
+  ]'
+  *directive='
     call(
       long,
       long,
@@ -201,7 +201,7 @@ trailingComma: "all"
       call,
       argument
     )
-  "
+  '
 ></div>
 
 ================================================================================
@@ -273,7 +273,7 @@ trailingComma: "es5"
 
 =====================================output=====================================
 <div
-  (action)="
+  (action)='
     ({
       long,
       long,
@@ -288,8 +288,8 @@ trailingComma: "es5"
       object,
       property,
     })
-  "
-  (action)="
+  '
+  (action)='
     ([
       long,
       long,
@@ -304,8 +304,8 @@ trailingComma: "es5"
       array,
       element,
     ])
-  "
-  (action)="
+  '
+  (action)='
     call(
       long,
       long,
@@ -320,8 +320,8 @@ trailingComma: "es5"
       call,
       argument
     )
-  "
-  [binding]="{
+  '
+  [binding]='{
     long,
     long,
     long,
@@ -334,8 +334,8 @@ trailingComma: "es5"
     long,
     object,
     property,
-  }"
-  [binding]="[
+  }'
+  [binding]='[
     long,
     long,
     long,
@@ -348,8 +348,8 @@ trailingComma: "es5"
     long,
     array,
     element,
-  ]"
-  [binding]="
+  ]'
+  [binding]='
     call(
       long,
       long,
@@ -364,8 +364,8 @@ trailingComma: "es5"
       call,
       argument
     )
-  "
-  *directive="{
+  '
+  *directive='{
     long,
     long,
     long,
@@ -378,8 +378,8 @@ trailingComma: "es5"
     long,
     object,
     property,
-  }"
-  *directive="[
+  }'
+  *directive='[
     long,
     long,
     long,
@@ -392,8 +392,8 @@ trailingComma: "es5"
     long,
     array,
     element,
-  ]"
-  *directive="
+  ]'
+  *directive='
     call(
       long,
       long,
@@ -408,7 +408,7 @@ trailingComma: "es5"
       call,
       argument
     )
-  "
+  '
 ></div>
 
 ================================================================================
@@ -480,7 +480,7 @@ trailingComma: "none"
 
 =====================================output=====================================
 <div
-  (action)="
+  (action)='
     ({
       long,
       long,
@@ -495,8 +495,8 @@ trailingComma: "none"
       object,
       property
     })
-  "
-  (action)="
+  '
+  (action)='
     ([
       long,
       long,
@@ -511,8 +511,8 @@ trailingComma: "none"
       array,
       element
     ])
-  "
-  (action)="
+  '
+  (action)='
     call(
       long,
       long,
@@ -527,8 +527,8 @@ trailingComma: "none"
       call,
       argument
     )
-  "
-  [binding]="{
+  '
+  [binding]='{
     long,
     long,
     long,
@@ -541,8 +541,8 @@ trailingComma: "none"
     long,
     object,
     property
-  }"
-  [binding]="[
+  }'
+  [binding]='[
     long,
     long,
     long,
@@ -555,8 +555,8 @@ trailingComma: "none"
     long,
     array,
     element
-  ]"
-  [binding]="
+  ]'
+  [binding]='
     call(
       long,
       long,
@@ -571,8 +571,8 @@ trailingComma: "none"
       call,
       argument
     )
-  "
-  *directive="{
+  '
+  *directive='{
     long,
     long,
     long,
@@ -585,8 +585,8 @@ trailingComma: "none"
     long,
     object,
     property
-  }"
-  *directive="[
+  }'
+  *directive='[
     long,
     long,
     long,
@@ -599,8 +599,8 @@ trailingComma: "none"
     long,
     array,
     element
-  ]"
-  *directive="
+  ]'
+  *directive='
     call(
       long,
       long,
@@ -615,7 +615,7 @@ trailingComma: "none"
       call,
       argument
     )
-  "
+  '
 ></div>
 
 ================================================================================

--- a/tests/format/html/attributes/__snapshots__/format.test.js.snap
+++ b/tests/format/html/attributes/__snapshots__/format.test.js.snap
@@ -87,11 +87,11 @@ and HTML5 Apps. It also documents Mozilla products, like Firefox OS.">
 <input name="address" maxlength="200" />
 <input name="address" maxlength="200" />
 <input name="address" maxlength="200" />
-<div class="foo"></div>
-<div class="foo"></div>
-<div class="foo bar"></div>
-<div class="foo bar" id="header"></div>
-<div class="foo bar" id="header"></div>
+<div class='foo'></div>
+<div class='foo'></div>
+<div class='foo bar'></div>
+<div class='foo bar' id="header"></div>
+<div class='foo bar' id="header"></div>
 <div data-prettier></div>
 <div data-prettier="true"></div>
 <meta
@@ -151,7 +151,7 @@ and HTML5 Apps. It also documents Mozilla products, like Firefox OS."
 <X a="1"> </X>
 <X a="1" b="2"> </X>
 <X a="1" b="2" c="3"> </X>
-<p class="foo bar baz"></p>
+<p class='foo bar baz'></p>
 
 ================================================================================
 `;
@@ -253,17 +253,17 @@ printWidth: 80
 
 =====================================output=====================================
 <div
-  class="ProviderMeasuresContainer__heading-row d-flex flex-column flex-lg-row justify-content-start justify-content-lg-between align-items-start align-items-lg-center"
+  class='ProviderMeasuresContainer__heading-row d-flex flex-column flex-lg-row justify-content-start justify-content-lg-between align-items-start align-items-lg-center'
 >
   Foo
 </div>
 
-<div class="a-bem-block a-bem-block--with-modifer">
+<div class='a-bem-block a-bem-block--with-modifer'>
   <div
-    class="a-bem-block__element a-bem-block__element--with-modifer also-another-block"
+    class='a-bem-block__element a-bem-block__element--with-modifer also-another-block'
   >
     <div
-      class="a-bem-block__element a-bem-block__element--with-modifer also-another-block__element"
+      class='a-bem-block__element a-bem-block__element--with-modifer also-another-block__element'
     ></div>
   </div>
 </div>
@@ -300,11 +300,11 @@ printWidth: 80
 </div>
 
 =====================================output=====================================
-<div class="news__header widget__content">
-  <div class="news__tabs">
-    <h1 class="news__tab-wrapper news__head-item">
+<div class='news__header widget__content'>
+  <div class='news__tabs'>
+    <h1 class='news__tab-wrapper news__head-item'>
       <a
-        class="home-link home-link_blue_yes news__tab news__tab_selected_yes mix-tabber__tab mix-tabber__tab_selected_yes"
+        class='home-link home-link_blue_yes news__tab news__tab_selected_yes mix-tabber__tab mix-tabber__tab_selected_yes'
         tabindex="0"
         aria-selected="true"
         aria-controls="news_panel_news"
@@ -335,7 +335,7 @@ printWidth: 80
 
 =====================================output=====================================
 <my-tag
-  class="md:foo-bg md:foo-color md:foo--sub-bg md:foo--sub-color xl:foo xl:prefix2 --prefix2--something-else unrelated_class_to_fill_80_chars"
+  class='md:foo-bg md:foo-color md:foo--sub-bg md:foo--sub-color xl:foo xl:prefix2 --prefix2--something-else unrelated_class_to_fill_80_chars'
 ></my-tag>
 
 ================================================================================
@@ -353,11 +353,11 @@ printWidth: 80
 
 =====================================output=====================================
 <my-tag
-  class="__prefix1__foo __prefix1__bar __prefix2__foo prefix2 prefix2--something --prefix2--something-else"
+  class='__prefix1__foo __prefix1__bar __prefix2__foo prefix2 prefix2--something --prefix2--something-else'
 ></my-tag>
 
 <my-tag
-  class="--prefix1--foo --prefix1--bar --prefix2--foo prefix2 prefix2__something __prefix2__something_else"
+  class='--prefix1--foo --prefix1--bar --prefix2--foo prefix2 prefix2__something __prefix2__something_else'
 ></my-tag>
 
 ================================================================================
@@ -377,10 +377,10 @@ printWidth: 80
 =====================================output=====================================
 <div
   aria-hidden="true"
-  class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump"
+  class='border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump'
 >
   Jump to
-  <span class="d-inline-block ml-1 v-align-middle">x</span>
+  <span class='d-inline-block ml-1 v-align-middle'>x</span>
 </div>
 
 ================================================================================
@@ -446,13 +446,13 @@ src="https://s.yimg.com/rz/p/yahoo_frontpage_en-US_s_f_p_205x58_frontpage_2x.png
 width="205px" alt="Yahoo"/></a></h1></div></div>
 
 =====================================output=====================================
-<img class="foo bar" />
+<img class='foo bar' />
 
 <img class="  " />
 <img class />
 
 <img
-  class="looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong a-long-long-long-long-long-class-name another-long-long-long-class-name foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar"
+  class='looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong a-long-long-long-long-long-class-name another-long-long-long-class-name foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar'
 />
 
 <img class="{{ ...classes }}" />
@@ -460,25 +460,25 @@ width="205px" alt="Yahoo"/></a></h1></div></div>
 
 <!-- escaped -->
 <!-- from: https://developer.mozilla.org/en-US/docs/Web/API/CSS/escape#Basic_results -->
-<img class="\\.foo\\#bar \\(\\)\\[\\]\\{\\} --a \\30 \\ufffd" />
+<img class='\\.foo\\#bar \\(\\)\\[\\]\\{\\} --a \\30 \\ufffd' />
 
 <!-- from yahoo website -->
 <div
   id="header-wrapper"
-  class="Bgc(#fff) Bdbc(t) Bdbs(s) Bdbw(1px) D(tb) Pos(f) Tbl(f) W(100%) Z(4) has-scrolled_Bdc($c-fuji-grey-d) Scrolling_Bdc($c-fuji-grey-d) has-scrolled_Bxsh($headerShadow) Scrolling_Bxsh($headerShadow)"
+  class='Bgc(#fff) Bdbc(t) Bdbs(s) Bdbw(1px) D(tb) Pos(f) Tbl(f) W(100%) Z(4) has-scrolled_Bdc($c-fuji-grey-d) Scrolling_Bdc($c-fuji-grey-d) has-scrolled_Bxsh($headerShadow) Scrolling_Bxsh($headerShadow)'
 >
   <div
-    class="Bgc(#fff) M(a) Maw(1301px) Miw(1000px) Pb(12px) Pt(22px) Pos(r) TranslateZ(0) Z(6)"
+    class='Bgc(#fff) M(a) Maw(1301px) Miw(1000px) Pb(12px) Pt(22px) Pos(r) TranslateZ(0) Z(6)'
   >
-    <h1 class="Fz(0) Pstart(15px) Pos(a)">
+    <h1 class='Fz(0) Pstart(15px) Pos(a)'>
       <a
         id="header-logo"
         href="https://www.yahoo.com/"
-        class="D(b) Pos(r)"
+        class='D(b) Pos(r)'
         data-ylk="elm:img;elmt:logo;sec:hd;slk:logo"
       >
         <img
-          class="H(27px)!--sm1024 Mt(9px)!--sm1024 W(90px)!--sm1024"
+          class='H(27px)!--sm1024 Mt(9px)!--sm1024 W(90px)!--sm1024'
           src="https://s.yimg.com/rz/p/yahoo_frontpage_en-US_s_f_p_205x58_frontpage_2x.png"
           height="58px"
           width="205px"
@@ -503,7 +503,7 @@ printWidth: 80
 =====================================output=====================================
 <div
   aria-hidden="true"
-  class="border rounded-1 flex-shrink-0 bg-gray px-1 loooooooooooooooooooooooong"
+  class='border rounded-1 flex-shrink-0 bg-gray px-1 loooooooooooooooooooooooong'
 ></div>
 
 ================================================================================
@@ -618,37 +618,37 @@ alt="">
 =====================================output=====================================
 <img
   src="/assets/visual.png"
-  srcset="/assets/visual@0.5.png 400w, /assets/visual.png 805w"
+  srcset='/assets/visual@0.5.png 400w, /assets/visual.png 805w'
   sizes="(max-width: 66rem) 100vw, 66rem"
   alt=""
 />
 <img
   src="/assets/visual.png"
-  srcset="
+  srcset='
     /assets/visual@0.5.png  400w,
     /assets/visual.png      805w,
     /assets/visual@2x.png  1610w,
     /assets/visual@3x.png  2415w
-  "
+  '
   sizes="(max-width: 66rem) 100vw, 66rem"
   alt=""
 />
 <img
   src="/assets/visual.png"
-  srcset="
+  srcset='
     /assets/visual@0.5.png    0.5x,
     /assets/visual.png     1111x,
     /assets/visual@2x.png     2x,
     /assets/visual@3x.png     3.3333x
-  "
+  '
   sizes="(max-width: 66rem) 100vw, 66rem"
   alt=""
 />
-<img srcset="/media/examples/surfer-240-200.jpg" />
+<img srcset='/media/examples/surfer-240-200.jpg' />
 <!-- #8150 -->
 <img
   sizes="(max-width: 1400px) 100vw, 1400px"
-  srcset="
+  srcset='
     _20200401_145009_szrhju_c_scale,w_200.jpg   200w,
     _20200401_145009_szrhju_c_scale,w_379.jpg   379w,
     _20200401_145009_szrhju_c_scale,w_515.jpg   515w,
@@ -664,7 +664,7 @@ alt="">
     _20200401_145009_szrhju_c_scale,w_1350.jpg 1350w,
     _20200401_145009_szrhju_c_scale,w_1398.jpg 1398w,
     _20200401_145009_szrhju_c_scale,w_1400.jpg 1400w
-  "
+  '
   src="_20200401_145009_szrhju_c_scale,w_1400.jpg"
   alt=""
 />
@@ -713,33 +713,37 @@ background: linear-gradient(to left, hotpink, hsla(240, 100%, 50%, .05), transpa
   </div>
 
 
-<div style="  
+<div style="
 
 color: green;
 
-display: inline 
+display: inline
 
 ">
   </div>
 
-<div attribute-1 attribute-2 attribute-3 attribute-4 attribute-5 attribute-6 attribute-7 
+<div attribute-1 attribute-2 attribute-3 attribute-4 attribute-5 attribute-6 attribute-7
 style="css-prop-1: css-value;css-prop-2: css-value;css-prop-3: css-value;css-prop-4: css-value;"
  attribute-1 attribute-2 attribute-3 attribute-4 attribute-5 attribute-6 attribute-7 >
   </div>
 
-<div style="{{ ...styles }}" 
+<div style="{{ ...styles }}"
 ></div>
 
 <div style="color: red; {{ otherStyles }}"
 ></div>
-=====================================output=====================================
-<div style="color: #fff"></div>
+<div
+    style="font-family: 'Arial';"
+></div>
 
-<div style=""></div>
+=====================================output=====================================
+<div style='color: #fff'></div>
+
+<div style=''></div>
 <div style></div>
 
 <div
-  style="
+  style='
     all: initial;
     display: block;
     contain: content;
@@ -758,28 +762,28 @@ style="css-prop-1: css-value;css-prop-2: css-value;css-prop-3: css-value;css-pro
     margin: 0 auto;
     border-radius: 8px;
     transition: transform 0.2s ease-out;
-  "
+  '
 ></div>
 
 <div
-  style="
+  style='
     background: linear-gradient(
       to left,
       hotpink,
       hsla(240, 100%, 50%, 0.05),
       transparent
     );
-  "
+  '
 ></div>
 
-<div style="color: red; display: inline"></div>
+<div style='color: red; display: inline'></div>
 
 <div
-  style="
+  style='
     color: green;
 
     display: inline;
-  "
+  '
 ></div>
 
 <div
@@ -790,12 +794,12 @@ style="css-prop-1: css-value;css-prop-2: css-value;css-prop-3: css-value;css-pro
   attribute-5
   attribute-6
   attribute-7
-  style="
+  style='
     css-prop-1: css-value;
     css-prop-2: css-value;
     css-prop-3: css-value;
     css-prop-4: css-value;
-  "
+  '
   attribute-1
   attribute-2
   attribute-3
@@ -808,6 +812,7 @@ style="css-prop-1: css-value;css-prop-2: css-value;css-prop-3: css-value;css-pro
 <div style="{{ ...styles }}"></div>
 
 <div style="color: red; {{ otherStyles }}"></div>
+<div style='font-family: "Arial"'></div>
 
 ================================================================================
 `;

--- a/tests/format/html/attributes/style.html
+++ b/tests/format/html/attributes/style.html
@@ -33,22 +33,25 @@ background: linear-gradient(to left, hotpink, hsla(240, 100%, 50%, .05), transpa
   </div>
 
 
-<div style="  
+<div style="
 
 color: green;
 
-display: inline 
+display: inline
 
 ">
   </div>
 
-<div attribute-1 attribute-2 attribute-3 attribute-4 attribute-5 attribute-6 attribute-7 
+<div attribute-1 attribute-2 attribute-3 attribute-4 attribute-5 attribute-6 attribute-7
 style="css-prop-1: css-value;css-prop-2: css-value;css-prop-3: css-value;css-prop-4: css-value;"
  attribute-1 attribute-2 attribute-3 attribute-4 attribute-5 attribute-6 attribute-7 >
   </div>
 
-<div style="{{ ...styles }}" 
+<div style="{{ ...styles }}"
 ></div>
 
 <div style="color: red; {{ otherStyles }}"
+></div>
+<div
+    style="font-family: 'Arial';"
 ></div>

--- a/tests/format/html/basics/__snapshots__/format.test.js.snap
+++ b/tests/format/html/basics/__snapshots__/format.test.js.snap
@@ -159,31 +159,31 @@ printWidth: 80
 
 =====================================output=====================================
 <form>
-  <div class="form-group">
+  <div class='form-group'>
     <label for="exampleInputEmail1">Email address</label>
     <input
       type="email"
-      class="form-control"
+      class='form-control'
       id="exampleInputEmail1"
       aria-describedby="emailHelp"
       placeholder="Enter email"
     />
-    <small id="emailHelp" class="form-text text-muted"
+    <small id="emailHelp" class='form-text text-muted'
       >We'll never share your email with anyone else.</small
     >
   </div>
-  <div class="form-group">
+  <div class='form-group'>
     <label for="exampleInputPassword1">Password</label>
     <input
       type="password"
-      class="form-control"
+      class='form-control'
       id="exampleInputPassword1"
       placeholder="Password"
     />
   </div>
-  <div class="form-group">
+  <div class='form-group'>
     <label for="exampleSelect1">Example select</label>
-    <select class="form-control" id="exampleSelect1">
+    <select class='form-control' id="exampleSelect1">
       <option>1</option>
       <option>2</option>
       <option>3</option>
@@ -191,9 +191,9 @@ printWidth: 80
       <option>5</option>
     </select>
   </div>
-  <div class="form-group">
+  <div class='form-group'>
     <label for="exampleSelect2">Example multiple select</label>
-    <select multiple class="form-control" id="exampleSelect2">
+    <select multiple class='form-control' id="exampleSelect2">
       <option>1</option>
       <option>2</option>
       <option>3</option>
@@ -201,30 +201,30 @@ printWidth: 80
       <option>5</option>
     </select>
   </div>
-  <div class="form-group">
+  <div class='form-group'>
     <label for="exampleTextarea">Example textarea</label>
-    <textarea class="form-control" id="exampleTextarea" rows="3"></textarea>
+    <textarea class='form-control' id="exampleTextarea" rows="3"></textarea>
   </div>
-  <div class="form-group">
+  <div class='form-group'>
     <label for="exampleInputFile">File input</label>
     <input
       type="file"
-      class="form-control-file"
+      class='form-control-file'
       id="exampleInputFile"
       aria-describedby="fileHelp"
     />
-    <small id="fileHelp" class="form-text text-muted"
+    <small id="fileHelp" class='form-text text-muted'
       >This is some placeholder block-level help text for the above input. It's
       a bit lighter and easily wraps to a new line.</small
     >
   </div>
-  <fieldset class="form-group">
+  <fieldset class='form-group'>
     <legend>Radio buttons</legend>
-    <div class="form-check">
-      <label class="form-check-label">
+    <div class='form-check'>
+      <label class='form-check-label'>
         <input
           type="radio"
-          class="form-check-input"
+          class='form-check-input'
           name="optionsRadios"
           id="optionsRadios1"
           value="option1"
@@ -233,11 +233,11 @@ printWidth: 80
         Option one is this and that&mdash;be sure to include why it's great
       </label>
     </div>
-    <div class="form-check">
-      <label class="form-check-label">
+    <div class='form-check'>
+      <label class='form-check-label'>
         <input
           type="radio"
-          class="form-check-input"
+          class='form-check-input'
           name="optionsRadios"
           id="optionsRadios2"
           value="option2"
@@ -246,11 +246,11 @@ printWidth: 80
         one
       </label>
     </div>
-    <div class="form-check disabled">
-      <label class="form-check-label">
+    <div class='form-check disabled'>
+      <label class='form-check-label'>
         <input
           type="radio"
-          class="form-check-input"
+          class='form-check-input'
           name="optionsRadios"
           id="optionsRadios3"
           value="option3"
@@ -260,13 +260,13 @@ printWidth: 80
       </label>
     </div>
   </fieldset>
-  <div class="form-check">
-    <label class="form-check-label">
-      <input type="checkbox" class="form-check-input" />
+  <div class='form-check'>
+    <label class='form-check-label'>
+      <input type="checkbox" class='form-check-input' />
       Check me out
     </label>
   </div>
-  <button type="submit" class="btn btn-primary">Submit</button>
+  <button type="submit" class='btn btn-primary'>Submit</button>
 </form>
 
 ================================================================================
@@ -330,7 +330,7 @@ printWidth: 80
 <html>
   <body>
     <a href="#">Anchor</a>
-    <div hidden class="foo" id="bar"></div>
+    <div hidden class='foo' id="bar"></div>
   </body>
 </html>
 
@@ -386,7 +386,7 @@ printWidth: 80
 
 =====================================output=====================================
 <!doctype html>
-<html class="no-js" lang="">
+<html class='no-js' lang="">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
@@ -407,7 +407,7 @@ printWidth: 80
 
   <body>
     <!--[if lte IE 9]>
-      <p class="browserupgrade">
+      <p class='browserupgrade'>
         You are using an <strong>outdated</strong> browser. Please
         <a href="https://browsehappy.com/">upgrade your browser</a> to improve
         your experience and security.
@@ -513,7 +513,7 @@ printWidth: 80
   <head></head>
   <body>
     <a href="#">Anchor</a>
-    <div hidden class="foo" id="bar"></div>
+    <div hidden class='foo' id="bar"></div>
   </body>
 </html>
 

--- a/tests/format/html/bracket-same-line/__snapshots__/format.test.js.snap
+++ b/tests/format/html/bracket-same-line/__snapshots__/format.test.js.snap
@@ -25,8 +25,8 @@ text
 <div
   long_long_attribute="long_long_long_long_long_long_long_long_long_long_long_value"
 ></div>
-<div class="a">text</div>
-<div class="a">text</div>
+<div class='a'>text</div>
+<div class='a'>text</div>
 
 ================================================================================
 `;
@@ -54,8 +54,8 @@ text
 </div>
 <div
   long_long_attribute="long_long_long_long_long_long_long_long_long_long_long_value"></div>
-<div class="a">text</div>
-<div class="a">text</div>
+<div class='a'>text</div>
+<div class='a'>text</div>
 
 ================================================================================
 `;
@@ -170,20 +170,20 @@ text
 <span
   long_long_attribute="long_long_long_long_long_long_long_long_long_long_long_value"
 ></span>
-<span class="a">text</span>
+<span class='a'>text</span>
 <span
   long_long_attribute="long_long_long_long_long_long_long_long_long_long_long_value"
 >
   text
 </span>
-<span class="a">text</span
+<span class='a'>text</span
 ><span
   long_long_attribute="long_long_long_long_long_long_long_long_long_long_long_value"
 >
   text
 </span>
-<span class="a">text</span><span class="a">text</span><span class="a">text</span
-><span class="a">text</span><span class="a">text</span>
+<span class='a'>text</span><span class='a'>text</span><span class='a'>text</span
+><span class='a'>text</span><span class='a'>text</span>
 
 ================================================================================
 `;
@@ -216,18 +216,18 @@ text
 </span>
 <span
   long_long_attribute="long_long_long_long_long_long_long_long_long_long_long_value"></span>
-<span class="a">text</span>
+<span class='a'>text</span>
 <span
   long_long_attribute="long_long_long_long_long_long_long_long_long_long_long_value">
   text
 </span>
-<span class="a">text</span
+<span class='a'>text</span
 ><span
   long_long_attribute="long_long_long_long_long_long_long_long_long_long_long_value">
   text
 </span>
-<span class="a">text</span><span class="a">text</span><span class="a">text</span
-><span class="a">text</span><span class="a">text</span>
+<span class='a'>text</span><span class='a'>text</span><span class='a'>text</span
+><span class='a'>text</span><span class='a'>text</span>
 
 ================================================================================
 `;

--- a/tests/format/html/case/__snapshots__/format.test.js.snap
+++ b/tests/format/html/case/__snapshots__/format.test.js.snap
@@ -25,7 +25,7 @@ printWidth: 80
 
 =====================================output=====================================
 <!doctype html>
-<html class="no-js mY-ClAsS">
+<html class='no-js mY-ClAsS'>
   <head>
     <meta charset="utf-8" />
     <title>My tITlE</title>

--- a/tests/format/html/doctype_declarations/__snapshots__/format.test.js.snap
+++ b/tests/format/html/doctype_declarations/__snapshots__/format.test.js.snap
@@ -242,7 +242,7 @@ printWidth: 80
     <meta http-equiv="Content-Type" content="text/html; charset=windows-1251" />
     <title>XHTML markup</title>
   </head>
-  <body style="background-color: #ffffcc; color: #008800">
+  <body style='background-color: #ffffcc; color: #008800'>
     <br />
     <h2 align="center">Sample XHTML page</h2>
     <br />
@@ -255,7 +255,7 @@ printWidth: 80
         vspace="20"
       />
     </div>
-    <p align="center" style="font-size: 17px">
+    <p align="center" style='font-size: 17px'>
       Bar Foo,<br />
       Foo,<br />
       Bar<br />

--- a/tests/format/html/prettier_ignore/__snapshots__/format.test.js.snap
+++ b/tests/format/html/prettier_ignore/__snapshots__/format.test.js.snap
@@ -71,7 +71,7 @@ printWidth: 80
 
 =====================================output=====================================
 <!doctype html>
-<html class="no-js" lang="en">
+<html class='no-js' lang="en">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />

--- a/tests/format/html/tags/__snapshots__/format.test.js.snap
+++ b/tests/format/html/tags/__snapshots__/format.test.js.snap
@@ -394,7 +394,7 @@ printWidth: 80
   width="250"
   height="200"
   behavior="alternate"
-  style="border: solid"
+  style='border: solid'
 >
   <marquee behavior="alternate">This text will bounce</marquee>
 </marquee>
@@ -432,7 +432,7 @@ printWidth: 80
   width="250"
   height="200"
   behavior="alternate"
-  style="border: solid"
+  style='border: solid'
 >
   <marquee behavior="alternate"> This text will bounce </marquee>
 </marquee>
@@ -463,7 +463,7 @@ printWidth: Infinity
 
 <marquee direction="up">This text will scroll from bottom to top</marquee>
 
-<marquee direction="down" width="250" height="200" behavior="alternate" style="border: solid">
+<marquee direction="down" width="250" height="200" behavior="alternate" style='border: solid'>
   <marquee behavior="alternate">This text will bounce</marquee>
 </marquee>
 
@@ -519,9 +519,9 @@ printWidth: 1
   width="250"
   height="200"
   behavior="alternate"
-  style="
+  style='
     border: solid;
-  "
+  '
 >
   <marquee
     behavior="alternate"
@@ -565,7 +565,7 @@ printWidth: 80
   width="250"
   height="200"
   behavior="alternate"
-  style="border: solid"
+  style='border: solid'
 >
   <marquee behavior="alternate">This text will bounce</marquee>
 </marquee>
@@ -2934,9 +2934,9 @@ printWidth: 80
 </div>
 <ul>
   123
-  <li class="foo" id="bar">First</li>
+  <li class='foo' id="bar">First</li>
   456
-  <li class="baz">Second</li>
+  <li class='baz'>Second</li>
   789
 </ul>
 <span>
@@ -3027,9 +3027,9 @@ printWidth: 80
   .
 </div>
 <span>
-  <i class="fa fa-refresh fa-spin" />
-  <i class="fa fa-refresh fa-spin" />
-  <i class="fa fa-refresh fa-spin" />
+  <i class='fa fa-refresh fa-spin' />
+  <i class='fa fa-refresh fa-spin' />
+  <i class='fa fa-refresh fa-spin' />
 </span>
 
 <!-- #5810 -->
@@ -3283,8 +3283,8 @@ printWidth: 80
   <div>string</div>
 </div>
 <ul
-  >123<li class="foo" id="bar">First</li
-  >456<li class="baz">Second</li
+  >123<li class='foo' id="bar">First</li
+  >456<li class='baz'>Second</li
   >789</ul
 >
 <span>*<b>200</b></span>
@@ -3346,9 +3346,9 @@ printWidth: 80
   <strong>seddoeiusmod</strong>.
 </div>
 <span>
-  <i class="fa fa-refresh fa-spin" />
-  <i class="fa fa-refresh fa-spin" />
-  <i class="fa fa-refresh fa-spin" />
+  <i class='fa fa-refresh fa-spin' />
+  <i class='fa fa-refresh fa-spin' />
+  <i class='fa fa-refresh fa-spin' />
 </span>
 
 <!-- #5810 -->
@@ -3563,9 +3563,9 @@ printWidth: Infinity
 </div>
 <ul>
   123
-  <li class="foo" id="bar">First</li>
+  <li class='foo' id="bar">First</li>
   456
-  <li class="baz">Second</li>
+  <li class='baz'>Second</li>
   789
 </ul>
 <span>*<b>200</b></span>
@@ -3609,9 +3609,9 @@ printWidth: Infinity
   <strong>seddoeiusmod</strong>.
 </div>
 <span>
-  <i class="fa fa-refresh fa-spin" />
-  <i class="fa fa-refresh fa-spin" />
-  <i class="fa fa-refresh fa-spin" />
+  <i class='fa fa-refresh fa-spin' />
+  <i class='fa fa-refresh fa-spin' />
+  <i class='fa fa-refresh fa-spin' />
 </span>
 
 <!-- #5810 -->
@@ -3989,14 +3989,14 @@ printWidth: 1
 <ul>
   123
   <li
-    class="foo"
+    class='foo'
     id="bar"
   >
     First
   </li>
   456
   <li
-    class="baz"
+    class='baz'
   >
     Second
   </li>
@@ -4138,13 +4138,13 @@ printWidth: 1
 </div>
 <span>
   <i
-    class="fa fa-refresh fa-spin"
+    class='fa fa-refresh fa-spin'
   />
   <i
-    class="fa fa-refresh fa-spin"
+    class='fa fa-refresh fa-spin'
   />
   <i
-    class="fa fa-refresh fa-spin"
+    class='fa fa-refresh fa-spin'
   />
 </span>
 
@@ -4431,9 +4431,9 @@ printWidth: 80
 </div>
 <ul>
   123
-  <li class="foo" id="bar">First</li>
+  <li class='foo' id="bar">First</li>
   456
-  <li class="baz">Second</li>
+  <li class='baz'>Second</li>
   789
 </ul>
 <span>*<b>200</b></span>
@@ -4495,9 +4495,9 @@ printWidth: 80
   <strong>seddoeiusmod</strong>.
 </div>
 <span>
-  <i class="fa fa-refresh fa-spin" />
-  <i class="fa fa-refresh fa-spin" />
-  <i class="fa fa-refresh fa-spin" />
+  <i class='fa fa-refresh fa-spin' />
+  <i class='fa fa-refresh fa-spin' />
+  <i class='fa fa-refresh fa-spin' />
 </span>
 
 <!-- #5810 -->

--- a/tests/format/html/whitespace/__snapshots__/format.test.js.snap
+++ b/tests/format/html/whitespace/__snapshots__/format.test.js.snap
@@ -79,7 +79,7 @@ printWidth: 80
 
 =====================================output=====================================
 <!doctype html>
-<html class="no-js mY-ClAsS">
+<html class='no-js mY-ClAsS'>
   <head>
     <meta charset="utf-8" />
     <title>My tITlE</title>
@@ -113,7 +113,7 @@ printWidth: 80
   <img
     src="/images/pansies.jpg"
     alt="about fedco bottom image"
-    style="float: left"
+    style='float: left'
   /><strong>We are a cooperative</strong>, one of the few seed companies so
   organized in the United States. Because we do not have an individual owner or
   beneficiary, profit is not our primary goal. Consumers own 60% of the
@@ -212,7 +212,7 @@ printWidth: 80
 
 =====================================output=====================================
 <a href="/wiki/Help:IPA/English" title="Help:IPA/English"
-  >/<span style="border-bottom: 1px dotted"
+  >/<span style='border-bottom: 1px dotted'
     ><span title="/ˌ/: secondary stress follows">ˌ</span
     ><span title="/ɪ/: &#39;i&#39; in &#39;kit&#39;">ɪ</span
     ><span title="&#39;l&#39; in &#39;lie&#39;">l</span
@@ -223,14 +223,14 @@ printWidth: 80
   >/</a
 >
 
-<span class="word"
-  ><span class="syllable"
-    ><span class="letter vowel">i</span
-    ><span class="letter consonant">p</span></span
-  ><span class="syllable"
-    ><span class="letter consonant onset">s</span
-    ><span class="letter vowel">u</span
-    ><span class="letter consonant">m</span></span
+<span class='word'
+  ><span class='syllable'
+    ><span class='letter vowel'>i</span
+    ><span class='letter consonant'>p</span></span
+  ><span class='syllable'
+    ><span class='letter consonant onset'>s</span
+    ><span class='letter vowel'>u</span
+    ><span class='letter consonant'>m</span></span
   ></span
 >
 

--- a/tests/format/lwc/lwc/__snapshots__/format.test.js.snap
+++ b/tests/format/lwc/lwc/__snapshots__/format.test.js.snap
@@ -27,7 +27,7 @@ semi: false
     data-for={value[0]}
     data-for={value.toString()}
     data-for={value()}
-    class="test"
+    class='test'
   ></div>
 </template>
 <template if:true={value.error}>
@@ -65,7 +65,7 @@ trailingComma: "es5"
     data-for={value[0]}
     data-for={value.toString()}
     data-for={value()}
-    class="test"
+    class='test'
   ></div>
 </template>
 <template if:true={value.error}>
@@ -103,7 +103,7 @@ trailingComma: "none"
     data-for={value[0]}
     data-for={value.toString()}
     data-for={value()}
-    class="test"
+    class='test'
   ></div>
 </template>
 <template if:true={value.error}>

--- a/tests/format/vue/bracket-same-line/__snapshots__/format.test.js.snap
+++ b/tests/format/vue/bracket-same-line/__snapshots__/format.test.js.snap
@@ -55,37 +55,37 @@ text
     <template>
       <div id="js-app">
         <div
-          :click="
+          :click='
             long_long_long_long_long_long_long_long_long_long_long_long_long_long_value
-          "
+          '
         >
           text
         </div>
         <div
-          :click="
+          :click='
             long_long_long_long_long_long_long_long_long_long_long_long_long_long_value
-          "
+          '
         ></div>
         <span
-          :click="
+          :click='
             long_long_long_long_long_long_long_long_long_long_long_long_long_long_value
-          "
+          '
         >
           text
         </span>
         <span
-          :long_long_attribute="
+          :long_long_attribute='
             long_long_long_long_long_long_long_long_long_long_long_value
-          "
+          '
         ></span>
         <img
-          :long_long_attribute="
+          :long_long_attribute='
             long_long_long_long_long_long_long_long_long_long_long_value
-          "
+          '
         />
-        <div class="a">text</div>
-        <span class="a"> text </span>
-        <img class="a" />
+        <div class='a'>text</div>
+        <span class='a'> text </span>
+        <img class='a' />
       </div>
     </template>
 
@@ -162,32 +162,32 @@ text
     <template>
       <div id="js-app">
         <div
-          :click="
+          :click='
             long_long_long_long_long_long_long_long_long_long_long_long_long_long_value
-          ">
+          '>
           text
         </div>
         <div
-          :click="
+          :click='
             long_long_long_long_long_long_long_long_long_long_long_long_long_long_value
-          "></div>
+          '></div>
         <span
-          :click="
+          :click='
             long_long_long_long_long_long_long_long_long_long_long_long_long_long_value
-          ">
+          '>
           text
         </span>
         <span
-          :long_long_attribute="
+          :long_long_attribute='
             long_long_long_long_long_long_long_long_long_long_long_value
-          "></span>
+          '></span>
         <img
-          :long_long_attribute="
+          :long_long_attribute='
             long_long_long_long_long_long_long_long_long_long_long_value
-          " />
-        <div class="a">text</div>
-        <span class="a"> text </span>
-        <img class="a" />
+          ' />
+        <div class='a'>text</div>
+        <span class='a'> text </span>
+        <img class='a' />
       </div>
     </template>
 
@@ -242,16 +242,16 @@ text
 <template>
   <div>
     <div
-      :long_long_attribute="
+      :long_long_attribute='
         long_long_long_long_long_long_long_long_long_long_long_value
-      "
+      '
     >
       text
     </div>
     <div
-      v-on:long_long_attribute="
+      v-on:long_long_attribute='
         long_long_long_long_long_long_long_long_long_long_long_value
-      "
+      '
     ></div>
     <span
       long_long_attribute="long_long_long_long_long_long_long_long_long_long_long_value"
@@ -264,9 +264,9 @@ text
     <img
       long_long_attribute="long_long_long_long_long_long_long_long_long_long_long_value"
     />
-    <div class="a">text</div>
-    <span class="a"> text </span>
-    <img class="a" />
+    <div class='a'>text</div>
+    <span class='a'> text </span>
+    <img class='a' />
   </div>
 </template>
 
@@ -321,15 +321,15 @@ text
 <template>
   <div>
     <div
-      :long_long_attribute="
+      :long_long_attribute='
         long_long_long_long_long_long_long_long_long_long_long_value
-      ">
+      '>
       text
     </div>
     <div
-      v-on:long_long_attribute="
+      v-on:long_long_attribute='
         long_long_long_long_long_long_long_long_long_long_long_value
-      "></div>
+      '></div>
     <span
       long_long_attribute="long_long_long_long_long_long_long_long_long_long_long_value">
       text
@@ -338,9 +338,9 @@ text
       long_long_attribute="long_long_long_long_long_long_long_long_long_long_long_value"></span>
     <img
       long_long_attribute="long_long_long_long_long_long_long_long_long_long_long_value" />
-    <div class="a">text</div>
-    <span class="a"> text </span>
-    <img class="a" />
+    <div class='a'>text</div>
+    <span class='a'> text </span>
+    <img class='a' />
   </div>
 </template>
 

--- a/tests/format/vue/custom_block/html-whitespace-sensitivity/__snapshots__/format.test.js.snap
+++ b/tests/format/vue/custom_block/html-whitespace-sensitivity/__snapshots__/format.test.js.snap
@@ -14,7 +14,7 @@ printWidth: 80
 <docs lang="unknown"></docs>
 <!-- display: inline -->
 <docs lang="unknown"></docs>
-<docs lang="unknown" style="display: inline"></docs>
+<docs lang="unknown" style='display: inline'></docs>
 
 ================================================================================
 `;
@@ -33,7 +33,7 @@ printWidth: 80
 <docs lang="unknown"></docs>
 <!-- display: inline -->
 <docs lang="unknown"></docs>
-<docs lang="unknown" style="display: inline"></docs>
+<docs lang="unknown" style='display: inline'></docs>
 
 ================================================================================
 `;
@@ -52,7 +52,7 @@ printWidth: 80
 <docs lang="unknown"></docs>
 <!-- display: inline -->
 <docs lang="unknown"></docs>
-<docs lang="unknown" style="display: inline"></docs>
+<docs lang="unknown" style='display: inline'></docs>
 
 ================================================================================
 `;
@@ -70,7 +70,7 @@ printWidth: 80
 <docs lang="unknown"></docs>
 <!-- display: inline -->
 <docs lang="unknown"></docs>
-<docs lang="unknown" style="display: inline"></docs>
+<docs lang="unknown" style='display: inline'></docs>
 
 ================================================================================
 `;

--- a/tests/format/vue/event-binding/__snapshots__/format.test.js.snap
+++ b/tests/format/vue/event-binding/__snapshots__/format.test.js.snap
@@ -27,13 +27,13 @@ function log(...args) {
 
 <template>
   <div
-    @click="
+    @click='
       if (x === (1 as number)) {
         log('hello');
       } else {
         log('nonhello');
       }
-    "
+    '
   >
     {{ x }}
   </div>
@@ -62,14 +62,14 @@ printWidth: 80
 <script setup lang="ts"></script>
 
 <template>
-  <div @click="(x: never) => null">arrow</div>
+  <div @click='(x: never) => null'>arrow</div>
   <div
-    @click="
+    @click='
       function (a: unknown[]) {
         console.log('abcdefg');
         return;
       }
-    "
+    '
   >
     anonymous function
   </div>

--- a/tests/format/vue/event-binding/no-semi/__snapshots__/format.test.js.snap
+++ b/tests/format/vue/event-binding/no-semi/__snapshots__/format.test.js.snap
@@ -17,8 +17,8 @@ semi: false
 =====================================output=====================================
 <template>
   <foo-bar
-    @click="[foo, bar].forEach((fn) => void fn())"
-    @loaded="(map = $event) && initMap()"
+    @click='[foo, bar].forEach((fn) => void fn())'
+    @loaded='(map = $event) && initMap()'
   ></foo-bar>
 </template>
 

--- a/tests/format/vue/html-vue/__snapshots__/format.test.js.snap
+++ b/tests/format/vue/html-vue/__snapshots__/format.test.js.snap
@@ -321,7 +321,7 @@ printWidth: 80
 <!doctype html>
 <html>
   <body>
-    <div v-if="foo === 'foo'"></div>
+    <div v-if='foo === 'foo''></div>
     <script>
       new Vue({ el: "#app" });
     </script>
@@ -367,7 +367,7 @@ new Vue({el: '#app'})
 <!doctype html>
 <html>
   <body>
-    <div v-if="foo === 'foo'"></div>
+    <div v-if='foo === 'foo''></div>
     <script>
       new Vue({ el: "#app" });
     </script>
@@ -414,7 +414,7 @@ printWidth: 80
 =====================================output=====================================
 <html>
   <body>
-    <div v-if="foo === 'foo'"></div>
+    <div v-if='foo === 'foo''></div>
     <script>
       new Vue({ el: "#app" });
     </script>

--- a/tests/format/vue/interpolation/__snapshots__/format.test.js.snap
+++ b/tests/format/vue/interpolation/__snapshots__/format.test.js.snap
@@ -79,8 +79,8 @@ printWidth: 80
 =====================================output=====================================
 <template>
   <root>
-    <div class="red">We are going to add this simple card here</div>
-    <div class="red">What is going on {{ prop1 }} and {{ prop2 }}</div>
+    <div class='red'>We are going to add this simple card here</div>
+    <div class='red'>What is going on {{ prop1 }} and {{ prop2 }}</div>
   </root>
 </template>
 

--- a/tests/format/vue/invalid/__snapshots__/format.test.js.snap
+++ b/tests/format/vue/invalid/__snapshots__/format.test.js.snap
@@ -35,12 +35,12 @@ printWidth: 80
       v-for="    _       in          "
       v-for="            in _        "
       v-for="            in          "
-      v-for="_ in a"
+      v-for='_ in a'
       v-for="    ,_      in a        "
-      v-for="(a, b) in a"
+      v-for='(a, b) in a'
       v-for="    a,  , c     in a        "
       v-for="     , b, c     in a        "
-      v-for="(a, b) in a"
+      v-for='(a, b) in a'
       v-for="     , b, c     in a        "
       v-for="    a,  , c     in a        "
       v-for="    (,a,b) of 'abcd'        "

--- a/tests/format/vue/multiparser/__snapshots__/format.test.js.snap
+++ b/tests/format/vue/multiparser/__snapshots__/format.test.js.snap
@@ -173,9 +173,9 @@ let x: string | number = 1;
 <script></script>
 <template>
   <span
-    v-if="(x as string).length > 0"
-    v-for="a in [1, 2, 3, 4, 5].map((x: number) => x * x)"
-    :foo="(x as number).toFixed(2)"
+    v-if='(x as string).length > 0'
+    v-for='a in [1, 2, 3, 4, 5].map((x: number) => x * x)'
+    :foo='(x as number).toFixed(2)'
   >
     {{ (x as number).toFixed(2) }}
   </span>
@@ -291,13 +291,13 @@ printWidth: 80
 
 =====================================output=====================================
 <template>
-  <div v-bind:id="'list-' + id"></div>
-  <div v-bind:id="'list-' + id"></div>
-  <div v-bind:id="'list-' + id"></div>
-  <div v-bind:id="'&quot;' + id"></div>
-  <div v-bind:id="rawId | formatId"></div>
-  <div v-bind:id="ok ? 'YES' : 'NO'"></div>
-  <button @click="foo(arg, 'string')"></button>
+  <div v-bind:id=''list-' + id'></div>
+  <div v-bind:id=''list-' + id'></div>
+  <div v-bind:id=''list-' + id'></div>
+  <div v-bind:id=''"' + id'></div>
+  <div v-bind:id='rawId | formatId'></div>
+  <div v-bind:id='ok ? 'YES' : 'NO''></div>
+  <button @click='foo(arg, 'string')'></button>
 </template>
 
 ================================================================================
@@ -322,12 +322,12 @@ printWidth: 80
 =====================================output=====================================
 <template>
   <h2
-    class="title"
-    :class="{
+    class='title'
+    :class='{
       'issue-realtime-pre-pulse': preAnimation,
       'issue-realtime-trigger-pulse': pulseAnimation,
-    }"
-    v-html="titleHtml"
+    }'
+    v-html='titleHtml'
   ></h2>
 </template>
 

--- a/tests/format/vue/ts-expression/__snapshots__/format.test.js.snap
+++ b/tests/format/vue/ts-expression/__snapshots__/format.test.js.snap
@@ -18,18 +18,18 @@ printWidth: 80
 <script lang="ts"></script>
 
 <template>
-  <comp :foo="(a: string) => 1" />
+  <comp :foo='(a: string) => 1' />
   <comp
-    :foo="
+    :foo='
       <X extends Something & AnothoerOne, Y extends unknown[]>(x: X, y: Y) =>
         y.length + x.foobar.abcdefg
-    "
+    '
   />
   <comp
-    :foo="
+    :foo='
       (myFunction<T | U>(qwerty, qwerty.qwerty?.qwerty) as any) +
       x.filter(abcdefg as never).join(xxx)
-    "
+    '
   />
 </template>
 
@@ -51,8 +51,8 @@ printWidth: 80
 
 =====================================output=====================================
 <template>
-  <p v-if="isFolder(file)">{{ (file as mymodule.Folder).deadline }}</p>
-  <prettier :format="myFunc(o as unknown)" />
+  <p v-if='isFolder(file)'>{{ (file as mymodule.Folder).deadline }}</p>
+  <prettier :format='myFunc(o as unknown)' />
 </template>
 
 <script lang="ts"></script>
@@ -81,16 +81,16 @@ printWidth: 80
 =====================================output=====================================
 <template>
   <div
-    v-if="
+    v-if='
       // leading comment
       isFolder(/* NOTE: I like pizza */ file)
       // trailing comment
-    "
-    :format="
+    '
+    :format='
       /* leading comment */ myFunc(
         /* NOTE: I like banana */ o as unknown,
       ) /* trailing comment */
-    "
+    '
   >
     {{
       /* leading comment */ (file as /* NOTE: I like sushi */ mymodule.Folder)
@@ -136,7 +136,7 @@ printWidth: 80
 <!-- vue filters are only allowed in v-bind and interpolation -->
 <template>
   <div>
-    <div class="allowed">
+    <div class='allowed'>
       {{
         value
           | thisIsARealSuperLongFilterPipe("arg1", arg2 as unknown)
@@ -145,31 +145,31 @@ printWidth: 80
       }}
     </div>
     <div
-      class="allowed"
-      v-bind:something="
+      class='allowed'
+      v-bind:something='
         value
           | thisIsARealSuperLongFilterPipe('arg1', arg2 as unknown)
           | anotherPipeLongJustForFun
           | pipeTheThird
-      "
+      '
     ></div>
     <div
-      class="allowed"
-      :class="
+      class='allowed'
+      :class='
         value
           | thisIsARealSuperLongFilterPipe('arg1', arg2 as unknown)
           | anotherPipeLongJustForFun
           | pipeTheThird
-      "
+      '
     ></div>
     <div
-      class="not-allowed"
-      v-if="
+      class='not-allowed'
+      v-if='
         value |
           thisIsARealSuperLongBitwiseOr('arg1', arg2 as unknown) |
           anotherBitwiseOrLongJustForFun |
           bitwiseOrTheThird
-      "
+      '
     ></div>
   </div>
 </template>
@@ -192,7 +192,7 @@ printWidth: 80
 
 =====================================output=====================================
 <template>
-  <p v-if="isFolder(file)">{{ (   file as   mymodule.Folder    ).deadline }}</p>
+  <p v-if='isFolder(file)'>{{ (   file as   mymodule.Folder    ).deadline }}</p>
   <prettier :format=" myFunc(  o as unknown )" />
 </template>
 

--- a/tests/format/vue/v-for/__snapshots__/format.test.js.snap
+++ b/tests/format/vue/v-for/__snapshots__/format.test.js.snap
@@ -41,10 +41,10 @@ v-for="([longLongProp, longLongProp, [longLongProp, longLongProp='Hello, Prettie
 <script lang="ts"></script>
 <template>
   <div
-    v-for="a: number of x as number[]"
-    v-for="[a, b]: [string, string] of x as Array<[string, string]>"
-    v-for="a of list.map((x: any): unknown => x.foo.bar)"
-    v-for="(
+    v-for='a: number of x as number[]'
+    v-for='[a, b]: [string, string] of x as Array<[string, string]>'
+    v-for='a of list.map((x: any): unknown => x.foo.bar)'
+    v-for='(
       [
         longLongProp,
         longLongProp,
@@ -67,7 +67,7 @@ v-for="([longLongProp, longLongProp, [longLongProp, longLongProp='Hello, Prettie
         yetAnotherLongLongProp,
       ],
       index
-    ) of longLongLongLongLongLongLongLongList"
+    ) of longLongLongLongLongLongLongLongList'
   ></div>
 </template>
 

--- a/tests/format/vue/vue-3/__snapshots__/format.test.js.snap
+++ b/tests/format/vue/vue-3/__snapshots__/format.test.js.snap
@@ -39,27 +39,27 @@ extends string &
 
 
 =====================================output=====================================
-<script setup lang="ts" generic="T"></script>
+<script setup lang="ts" generic='T'></script>
 
 <script
   setup
   lang="ts"
-  generic="T extends Type1 & Type2 & (Type3 | Type4), U"
+  generic='T extends Type1 & Type2 & (Type3 | Type4), U'
 ></script>
 
 <script
   setup
   lang="ts"
-  generic="
+  generic='
     T extends Type1 & Type2 & (Type3 | Type4),
     U extends string | number | boolean
-  "
+  '
 ></script>
 
 <script
   setup
   lang="ts"
-  generic="
+  generic='
     T extends
       | 'loooooooooooooooooooooooooooooooooong'
       | 'looooooooooooooooooooooooooooooooooong',
@@ -80,13 +80,13 @@ extends string &
       >
     >,
     C
-  "
+  '
 ></script>
 
 <script
   setup
   lang="ts"
-  generic="
+  generic='
     // comment 1:
     T extends string &
       'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooong',
@@ -95,7 +95,7 @@ extends string &
      */
     U extends number, // comment 3
     /** comment 4 */ C extends MyType
-  "
+  '
 ></script>
 
 <template>
@@ -137,14 +137,14 @@ printWidth: 80
 
 =====================================output=====================================
 <script setup></script>
-<script setup="foo"></script>
-<script setup="{ row }"></script>
+<script setup='foo'></script>
+<script setup='{ row }'></script>
 <script
-  setup="{
+  setup='{
     destructuring: {
       a: { b },
     },
-  }"
+  }'
 ></script>
 
 <!-- Not script -->
@@ -191,14 +191,14 @@ printWidth: 80
 
 =====================================output=====================================
 <style vars></style>
-<style vars="foo"></style>
-<style vars="{ row }"></style>
+<style vars='foo'></style>
+<style vars='{ row }'></style>
 <style
-  vars="{
+  vars='{
     destructuring: {
       a: { b },
     },
-  }"
+  }'
 ></style>
 
 <!-- Not style -->

--- a/tests/format/vue/vue/__snapshots__/format.test.js.snap
+++ b/tests/format/vue/vue/__snapshots__/format.test.js.snap
@@ -79,17 +79,17 @@ semi: false
 =====================================output=====================================
 <template>
   <div
-    v-for="(
+    v-for='(
       { longLongProp, longLongProp }, index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="(
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='(
       { longLongProp = 42, longLongProp = 'Hello, World!' }, index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="{
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='{
       longLongProp,
       longLongProp,
-    } of longLongLongLongLongLongLongLongList"
-    v-for="(
+    } of longLongLongLongLongLongLongLongList'
+    v-for='(
       {
         longLongProp,
         longLongProp,
@@ -97,18 +97,18 @@ semi: false
         yetAnotherLongLongProp,
       },
       index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="{
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='{
       longLongProp,
       longLongProp,
       anotherLongLongProp,
       yetAnotherLongLongProp,
-    } of longLongLongLongLongLongLongLongList"
-    v-for="(
+    } of longLongLongLongLongLongLongLongList'
+    v-for='(
       [longLongProp, longLongProp, anotherLongLongProp, yetAnotherLongLongProp],
       index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="(
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='(
       [
         longLongProp,
         longLongProp = 42,
@@ -116,8 +116,8 @@ semi: false
         yetAnotherLongLongProp = 'Hello, World!',
       ],
       index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="(
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='(
       [
         longLongProp,
         longLongProp,
@@ -135,8 +135,8 @@ semi: false
         yetAnotherLongLongProp,
       ],
       index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="(
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='(
       [
         longLongProp,
         longLongProp,
@@ -159,8 +159,8 @@ semi: false
         yetAnotherLongLongProp,
       ],
       index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="(
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='(
       [
         { longLongProp, longLongProp },
         { longLongProp, longLongProp },
@@ -176,8 +176,8 @@ semi: false
         yetAnotherLongLongProp,
       ],
       index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="(
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='(
       {
         firstValue,
         secondValue: {
@@ -189,19 +189,19 @@ semi: false
       },
       objectKey,
       index
-    ) in objectWithAVeryVeryVeryVeryLongName"
-    v-for="(
+    ) in objectWithAVeryVeryVeryVeryLongName'
+    v-for='(
       { firstValue = { longLongProp, longLongProp }, secondValue },
       objectKey,
       index
-    ) in objectWithAVeryVeryVeryVeryLongName"
-    v-for="(
+    ) in objectWithAVeryVeryVeryVeryLongName'
+    v-for='(
       { firstValue, secondValue, thirdValue, fourthValue }, objectKey, index
-    ) in objectWithAVeryVeryVeryVeryLongName"
-    v-for="(
+    ) in objectWithAVeryVeryVeryVeryLongName'
+    v-for='(
       { firstValue, secondValue, thirdValue, fourthValue }, objectKey, index
-    ) in objectWithAVeryVeryVeryVeryLongName"
-    v-for="(
+    ) in objectWithAVeryVeryVeryVeryLongName'
+    v-for='(
       {
         firstValue,
         secondValue,
@@ -218,8 +218,8 @@ semi: false
       },
       objectKey,
       index
-    ) in objectWithAVeryVeryVeryVeryLongName"
-    v-for="(
+    ) in objectWithAVeryVeryVeryVeryLongName'
+    v-for='(
       {
         firstValue,
         secondValue,
@@ -249,8 +249,8 @@ semi: false
       },
       objectKey,
       index
-    ) in objectWithAVeryVeryVeryVeryLongName"
-    v-for="(
+    ) in objectWithAVeryVeryVeryVeryLongName'
+    v-for='(
       {
         firstValue,
         secondValue,
@@ -272,94 +272,94 @@ semi: false
       },
       objectKey,
       index
-    ) in objectWithAVeryVeryVeryVeryLongName"
-    v-for="item in items"
-    v-for="item of items"
-    v-for="(item, index) in items"
-    v-for="value in object"
-    v-for="(value, key) in object"
-    v-for="(value, key) of object"
-    v-for="(value, key, index) in object"
-    v-for="n in evenNumbers"
-    v-for="n in even(numbers)"
-    v-for="n in 10"
-    v-for="{ a } in [0].map(() => ({ a: 1 }))"
-    v-for="({ a }, [c]) in [0].map(() => 1)"
-    v-for="n in items.map((x) => {
+    ) in objectWithAVeryVeryVeryVeryLongName'
+    v-for='item in items'
+    v-for='item of items'
+    v-for='(item, index) in items'
+    v-for='value in object'
+    v-for='(value, key) in object'
+    v-for='(value, key) of object'
+    v-for='(value, key, index) in object'
+    v-for='n in evenNumbers'
+    v-for='n in even(numbers)'
+    v-for='n in 10'
+    v-for='{ a } in [0].map(() => ({ a: 1 }))'
+    v-for='({ a }, [c]) in [0].map(() => 1)'
+    v-for='n in items.map((x) => {
       return x
-    })"
-    @click="/* hello */"
-    @click="/* 1 */ $emit(/* 2 */ 'click' /* 3 */) /* 4 */ /* 5 */"
-    @click="$emit('click')"
-    @click="$emit('click')"
-    @click="
+    })'
+    @click='/* hello */'
+    @click='/* 1 */ $emit(/* 2 */ 'click' /* 3 */) /* 4 */ /* 5 */'
+    @click='$emit('click')'
+    @click='$emit('click')'
+    @click='
       $emit('click')
       if (something) {
         for (let i = j; i < 100; i++) {}
       } else {
       }
-    "
-    slot-scope="foo"
-    slot-scope="{ row }"
-    slot-scope="{
+    '
+    slot-scope='foo'
+    slot-scope='{ row }'
+    slot-scope='{
       destructuring: {
         a: { b },
       },
-    }"
-    #default="foo"
-    #default="{ row }"
-    #default="{
+    }'
+    #default='foo'
+    #default='{ row }'
+    #default='{
       destructuring: {
         a: { b },
       },
-    }"
-    v-slot="foo"
-    v-slot="{ row }"
-    v-slot="{
+    }'
+    v-slot='foo'
+    v-slot='{ row }'
+    v-slot='{
       destructuring: {
         a: { b },
       },
-    }"
-    v-slot:name="foo"
-    v-slot:name="{ row }"
-    v-slot:name="{
+    }'
+    v-slot:name='foo'
+    v-slot:name='{ row }'
+    v-slot:name='{
       destructuring: {
         a: { b },
       },
-    }"
-    :class="{
+    }'
+    :class='{
       longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: true,
-    }"
-    :class="
+    }'
+    :class='
       (() => {
         return 'hello'
       })()
-    "
-    :key="index /* hello */"
-    :key="
+    '
+    :key='index /* hello */'
+    :key='
       index // hello
-    "
-    @click="
+    '
+    @click='
       () => {
         console.log(test)
       }
-    "
-    @click="
+    '
+    @click='
       () => {
         console.log(test)
       }
-    "
-    @click="doSomething()"
-    @click="doSomething;"
-    @click="a.b;"
-    @click="a[1];"
-    @click="a['b'];"
-    @click="a[null]"
-    #default="{
+    '
+    @click='doSomething()'
+    @click='doSomething;'
+    @click='a.b;'
+    @click='a[1];'
+    @click='a['b'];'
+    @click='a[null]'
+    #default='{
       foo: {
         bar: { baz },
       },
-    }"
+    }'
   ></div>
 </template>
 
@@ -445,17 +445,17 @@ trailingComma: "es5"
 =====================================output=====================================
 <template>
   <div
-    v-for="(
+    v-for='(
       { longLongProp, longLongProp }, index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="(
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='(
       { longLongProp = 42, longLongProp = 'Hello, World!' }, index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="{
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='{
       longLongProp,
       longLongProp,
-    } of longLongLongLongLongLongLongLongList"
-    v-for="(
+    } of longLongLongLongLongLongLongLongList'
+    v-for='(
       {
         longLongProp,
         longLongProp,
@@ -463,18 +463,18 @@ trailingComma: "es5"
         yetAnotherLongLongProp,
       },
       index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="{
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='{
       longLongProp,
       longLongProp,
       anotherLongLongProp,
       yetAnotherLongLongProp,
-    } of longLongLongLongLongLongLongLongList"
-    v-for="(
+    } of longLongLongLongLongLongLongLongList'
+    v-for='(
       [longLongProp, longLongProp, anotherLongLongProp, yetAnotherLongLongProp],
       index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="(
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='(
       [
         longLongProp,
         longLongProp = 42,
@@ -482,8 +482,8 @@ trailingComma: "es5"
         yetAnotherLongLongProp = 'Hello, World!',
       ],
       index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="(
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='(
       [
         longLongProp,
         longLongProp,
@@ -501,8 +501,8 @@ trailingComma: "es5"
         yetAnotherLongLongProp,
       ],
       index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="(
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='(
       [
         longLongProp,
         longLongProp,
@@ -525,8 +525,8 @@ trailingComma: "es5"
         yetAnotherLongLongProp,
       ],
       index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="(
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='(
       [
         { longLongProp, longLongProp },
         { longLongProp, longLongProp },
@@ -542,8 +542,8 @@ trailingComma: "es5"
         yetAnotherLongLongProp,
       ],
       index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="(
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='(
       {
         firstValue,
         secondValue: {
@@ -555,19 +555,19 @@ trailingComma: "es5"
       },
       objectKey,
       index
-    ) in objectWithAVeryVeryVeryVeryLongName"
-    v-for="(
+    ) in objectWithAVeryVeryVeryVeryLongName'
+    v-for='(
       { firstValue = { longLongProp, longLongProp }, secondValue },
       objectKey,
       index
-    ) in objectWithAVeryVeryVeryVeryLongName"
-    v-for="(
+    ) in objectWithAVeryVeryVeryVeryLongName'
+    v-for='(
       { firstValue, secondValue, thirdValue, fourthValue }, objectKey, index
-    ) in objectWithAVeryVeryVeryVeryLongName"
-    v-for="(
+    ) in objectWithAVeryVeryVeryVeryLongName'
+    v-for='(
       { firstValue, secondValue, thirdValue, fourthValue }, objectKey, index
-    ) in objectWithAVeryVeryVeryVeryLongName"
-    v-for="(
+    ) in objectWithAVeryVeryVeryVeryLongName'
+    v-for='(
       {
         firstValue,
         secondValue,
@@ -584,8 +584,8 @@ trailingComma: "es5"
       },
       objectKey,
       index
-    ) in objectWithAVeryVeryVeryVeryLongName"
-    v-for="(
+    ) in objectWithAVeryVeryVeryVeryLongName'
+    v-for='(
       {
         firstValue,
         secondValue,
@@ -615,8 +615,8 @@ trailingComma: "es5"
       },
       objectKey,
       index
-    ) in objectWithAVeryVeryVeryVeryLongName"
-    v-for="(
+    ) in objectWithAVeryVeryVeryVeryLongName'
+    v-for='(
       {
         firstValue,
         secondValue,
@@ -638,94 +638,94 @@ trailingComma: "es5"
       },
       objectKey,
       index
-    ) in objectWithAVeryVeryVeryVeryLongName"
-    v-for="item in items"
-    v-for="item of items"
-    v-for="(item, index) in items"
-    v-for="value in object"
-    v-for="(value, key) in object"
-    v-for="(value, key) of object"
-    v-for="(value, key, index) in object"
-    v-for="n in evenNumbers"
-    v-for="n in even(numbers)"
-    v-for="n in 10"
-    v-for="{ a } in [0].map(() => ({ a: 1 }))"
-    v-for="({ a }, [c]) in [0].map(() => 1)"
-    v-for="n in items.map((x) => {
+    ) in objectWithAVeryVeryVeryVeryLongName'
+    v-for='item in items'
+    v-for='item of items'
+    v-for='(item, index) in items'
+    v-for='value in object'
+    v-for='(value, key) in object'
+    v-for='(value, key) of object'
+    v-for='(value, key, index) in object'
+    v-for='n in evenNumbers'
+    v-for='n in even(numbers)'
+    v-for='n in 10'
+    v-for='{ a } in [0].map(() => ({ a: 1 }))'
+    v-for='({ a }, [c]) in [0].map(() => 1)'
+    v-for='n in items.map((x) => {
       return x;
-    })"
-    @click="/* hello */"
-    @click="/* 1 */ $emit(/* 2 */ 'click' /* 3 */) /* 4 */ /* 5 */"
-    @click="$emit('click')"
-    @click="$emit('click')"
-    @click="
+    })'
+    @click='/* hello */'
+    @click='/* 1 */ $emit(/* 2 */ 'click' /* 3 */) /* 4 */ /* 5 */'
+    @click='$emit('click')'
+    @click='$emit('click')'
+    @click='
       $emit('click');
       if (something) {
         for (let i = j; i < 100; i++) {}
       } else {
       }
-    "
-    slot-scope="foo"
-    slot-scope="{ row }"
-    slot-scope="{
+    '
+    slot-scope='foo'
+    slot-scope='{ row }'
+    slot-scope='{
       destructuring: {
         a: { b },
       },
-    }"
-    #default="foo"
-    #default="{ row }"
-    #default="{
+    }'
+    #default='foo'
+    #default='{ row }'
+    #default='{
       destructuring: {
         a: { b },
       },
-    }"
-    v-slot="foo"
-    v-slot="{ row }"
-    v-slot="{
+    }'
+    v-slot='foo'
+    v-slot='{ row }'
+    v-slot='{
       destructuring: {
         a: { b },
       },
-    }"
-    v-slot:name="foo"
-    v-slot:name="{ row }"
-    v-slot:name="{
+    }'
+    v-slot:name='foo'
+    v-slot:name='{ row }'
+    v-slot:name='{
       destructuring: {
         a: { b },
       },
-    }"
-    :class="{
+    }'
+    :class='{
       longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: true,
-    }"
-    :class="
+    }'
+    :class='
       (() => {
         return 'hello';
       })()
-    "
-    :key="index /* hello */"
-    :key="
+    '
+    :key='index /* hello */'
+    :key='
       index // hello
-    "
-    @click="
+    '
+    @click='
       () => {
         console.log(test);
       }
-    "
-    @click="
+    '
+    @click='
       () => {
         console.log(test);
       }
-    "
-    @click="doSomething()"
-    @click="doSomething;"
-    @click="a.b;"
-    @click="a[1];"
-    @click="a['b'];"
-    @click="a[null]"
-    #default="{
+    '
+    @click='doSomething()'
+    @click='doSomething;'
+    @click='a.b;'
+    @click='a[1];'
+    @click='a['b'];'
+    @click='a[null]'
+    #default='{
       foo: {
         bar: { baz },
       },
-    }"
+    }'
   ></div>
 </template>
 
@@ -811,17 +811,17 @@ trailingComma: "none"
 =====================================output=====================================
 <template>
   <div
-    v-for="(
+    v-for='(
       { longLongProp, longLongProp }, index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="(
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='(
       { longLongProp = 42, longLongProp = 'Hello, World!' }, index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="{
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='{
       longLongProp,
       longLongProp
-    } of longLongLongLongLongLongLongLongList"
-    v-for="(
+    } of longLongLongLongLongLongLongLongList'
+    v-for='(
       {
         longLongProp,
         longLongProp,
@@ -829,18 +829,18 @@ trailingComma: "none"
         yetAnotherLongLongProp
       },
       index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="{
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='{
       longLongProp,
       longLongProp,
       anotherLongLongProp,
       yetAnotherLongLongProp
-    } of longLongLongLongLongLongLongLongList"
-    v-for="(
+    } of longLongLongLongLongLongLongLongList'
+    v-for='(
       [longLongProp, longLongProp, anotherLongLongProp, yetAnotherLongLongProp],
       index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="(
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='(
       [
         longLongProp,
         longLongProp = 42,
@@ -848,8 +848,8 @@ trailingComma: "none"
         yetAnotherLongLongProp = 'Hello, World!'
       ],
       index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="(
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='(
       [
         longLongProp,
         longLongProp,
@@ -867,8 +867,8 @@ trailingComma: "none"
         yetAnotherLongLongProp
       ],
       index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="(
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='(
       [
         longLongProp,
         longLongProp,
@@ -891,8 +891,8 @@ trailingComma: "none"
         yetAnotherLongLongProp
       ],
       index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="(
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='(
       [
         { longLongProp, longLongProp },
         { longLongProp, longLongProp },
@@ -908,8 +908,8 @@ trailingComma: "none"
         yetAnotherLongLongProp
       ],
       index
-    ) of longLongLongLongLongLongLongLongList"
-    v-for="(
+    ) of longLongLongLongLongLongLongLongList'
+    v-for='(
       {
         firstValue,
         secondValue: {
@@ -921,19 +921,19 @@ trailingComma: "none"
       },
       objectKey,
       index
-    ) in objectWithAVeryVeryVeryVeryLongName"
-    v-for="(
+    ) in objectWithAVeryVeryVeryVeryLongName'
+    v-for='(
       { firstValue = { longLongProp, longLongProp }, secondValue },
       objectKey,
       index
-    ) in objectWithAVeryVeryVeryVeryLongName"
-    v-for="(
+    ) in objectWithAVeryVeryVeryVeryLongName'
+    v-for='(
       { firstValue, secondValue, thirdValue, fourthValue }, objectKey, index
-    ) in objectWithAVeryVeryVeryVeryLongName"
-    v-for="(
+    ) in objectWithAVeryVeryVeryVeryLongName'
+    v-for='(
       { firstValue, secondValue, thirdValue, fourthValue }, objectKey, index
-    ) in objectWithAVeryVeryVeryVeryLongName"
-    v-for="(
+    ) in objectWithAVeryVeryVeryVeryLongName'
+    v-for='(
       {
         firstValue,
         secondValue,
@@ -950,8 +950,8 @@ trailingComma: "none"
       },
       objectKey,
       index
-    ) in objectWithAVeryVeryVeryVeryLongName"
-    v-for="(
+    ) in objectWithAVeryVeryVeryVeryLongName'
+    v-for='(
       {
         firstValue,
         secondValue,
@@ -981,8 +981,8 @@ trailingComma: "none"
       },
       objectKey,
       index
-    ) in objectWithAVeryVeryVeryVeryLongName"
-    v-for="(
+    ) in objectWithAVeryVeryVeryVeryLongName'
+    v-for='(
       {
         firstValue,
         secondValue,
@@ -1004,94 +1004,94 @@ trailingComma: "none"
       },
       objectKey,
       index
-    ) in objectWithAVeryVeryVeryVeryLongName"
-    v-for="item in items"
-    v-for="item of items"
-    v-for="(item, index) in items"
-    v-for="value in object"
-    v-for="(value, key) in object"
-    v-for="(value, key) of object"
-    v-for="(value, key, index) in object"
-    v-for="n in evenNumbers"
-    v-for="n in even(numbers)"
-    v-for="n in 10"
-    v-for="{ a } in [0].map(() => ({ a: 1 }))"
-    v-for="({ a }, [c]) in [0].map(() => 1)"
-    v-for="n in items.map((x) => {
+    ) in objectWithAVeryVeryVeryVeryLongName'
+    v-for='item in items'
+    v-for='item of items'
+    v-for='(item, index) in items'
+    v-for='value in object'
+    v-for='(value, key) in object'
+    v-for='(value, key) of object'
+    v-for='(value, key, index) in object'
+    v-for='n in evenNumbers'
+    v-for='n in even(numbers)'
+    v-for='n in 10'
+    v-for='{ a } in [0].map(() => ({ a: 1 }))'
+    v-for='({ a }, [c]) in [0].map(() => 1)'
+    v-for='n in items.map((x) => {
       return x;
-    })"
-    @click="/* hello */"
-    @click="/* 1 */ $emit(/* 2 */ 'click' /* 3 */) /* 4 */ /* 5 */"
-    @click="$emit('click')"
-    @click="$emit('click')"
-    @click="
+    })'
+    @click='/* hello */'
+    @click='/* 1 */ $emit(/* 2 */ 'click' /* 3 */) /* 4 */ /* 5 */'
+    @click='$emit('click')'
+    @click='$emit('click')'
+    @click='
       $emit('click');
       if (something) {
         for (let i = j; i < 100; i++) {}
       } else {
       }
-    "
-    slot-scope="foo"
-    slot-scope="{ row }"
-    slot-scope="{
+    '
+    slot-scope='foo'
+    slot-scope='{ row }'
+    slot-scope='{
       destructuring: {
         a: { b }
       }
-    }"
-    #default="foo"
-    #default="{ row }"
-    #default="{
+    }'
+    #default='foo'
+    #default='{ row }'
+    #default='{
       destructuring: {
         a: { b }
       }
-    }"
-    v-slot="foo"
-    v-slot="{ row }"
-    v-slot="{
+    }'
+    v-slot='foo'
+    v-slot='{ row }'
+    v-slot='{
       destructuring: {
         a: { b }
       }
-    }"
-    v-slot:name="foo"
-    v-slot:name="{ row }"
-    v-slot:name="{
+    }'
+    v-slot:name='foo'
+    v-slot:name='{ row }'
+    v-slot:name='{
       destructuring: {
         a: { b }
       }
-    }"
-    :class="{
+    }'
+    :class='{
       longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: true
-    }"
-    :class="
+    }'
+    :class='
       (() => {
         return 'hello';
       })()
-    "
-    :key="index /* hello */"
-    :key="
+    '
+    :key='index /* hello */'
+    :key='
       index // hello
-    "
-    @click="
+    '
+    @click='
       () => {
         console.log(test);
       }
-    "
-    @click="
+    '
+    @click='
       () => {
         console.log(test);
       }
-    "
-    @click="doSomething()"
-    @click="doSomething;"
-    @click="a.b;"
-    @click="a[1];"
-    @click="a['b'];"
-    @click="a[null]"
-    #default="{
+    '
+    @click='doSomething()'
+    @click='doSomething;'
+    @click='a.b;'
+    @click='a[1];'
+    @click='a['b'];'
+    @click='a[null]'
+    #default='{
       foo: {
         bar: { baz }
       }
-    }"
+    }'
   ></div>
 </template>
 
@@ -1239,24 +1239,24 @@ export default {
 
 <template>
   <li
-    class="card"
-    :class="{
+    class='card'
+    :class='{
       'user-can-drag': !disabled && issue.id,
       'is-disabled': disabled || !issue.id,
       'is-active': issueDetailVisible,
-    }"
-    :index="index"
-    :data-issue-id="issue.id"
-    @mousedown="mouseDown"
-    @mousemove="mouseMove"
-    @mouseup="showIssue($event)"
+    }'
+    :index='index'
+    :data-issue-id='issue.id'
+    @mousedown='mouseDown'
+    @mousemove='mouseMove'
+    @mouseup='showIssue($event)'
   >
     <issue-card-inner
-      :list="list"
-      :issue="issue"
-      :issue-link-base="issueLinkBase"
-      :root-path="rootPath"
-      :update-filters="true"
+      :list='list'
+      :issue='issue'
+      :issue-link-base='issueLinkBase'
+      :root-path='rootPath'
+      :update-filters='true'
     />
   </li>
 </template>
@@ -1405,24 +1405,24 @@ export default {
 
 <template>
   <li
-    class="card"
-    :class="{
+    class='card'
+    :class='{
       'user-can-drag': !disabled && issue.id,
       'is-disabled': disabled || !issue.id,
       'is-active': issueDetailVisible,
-    }"
-    :index="index"
-    :data-issue-id="issue.id"
-    @mousedown="mouseDown"
-    @mousemove="mouseMove"
-    @mouseup="showIssue($event)"
+    }'
+    :index='index'
+    :data-issue-id='issue.id'
+    @mousedown='mouseDown'
+    @mousemove='mouseMove'
+    @mouseup='showIssue($event)'
   >
     <issue-card-inner
-      :list="list"
-      :issue="issue"
-      :issue-link-base="issueLinkBase"
-      :root-path="rootPath"
-      :update-filters="true"
+      :list='list'
+      :issue='issue'
+      :issue-link-base='issueLinkBase'
+      :root-path='rootPath'
+      :update-filters='true'
     />
   </li>
 </template>
@@ -1571,24 +1571,24 @@ export default {
 
 <template>
   <li
-    class="card"
-    :class="{
+    class='card'
+    :class='{
       'user-can-drag': !disabled && issue.id,
       'is-disabled': disabled || !issue.id,
       'is-active': issueDetailVisible
-    }"
-    :index="index"
-    :data-issue-id="issue.id"
-    @mousedown="mouseDown"
-    @mousemove="mouseMove"
-    @mouseup="showIssue($event)"
+    }'
+    :index='index'
+    :data-issue-id='issue.id'
+    @mousedown='mouseDown'
+    @mousemove='mouseMove'
+    @mouseup='showIssue($event)'
   >
     <issue-card-inner
-      :list="list"
-      :issue="issue"
-      :issue-link-base="issueLinkBase"
-      :root-path="rootPath"
-      :update-filters="true"
+      :list='list'
+      :issue='issue'
+      :issue-link-base='issueLinkBase'
+      :root-path='rootPath'
+      :update-filters='true'
     />
   </li>
 </template>
@@ -1767,20 +1767,20 @@ semi: false
 <!-- #7396 -->
 <template>
   <MyComponent
-    :foo="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo} template literal value\`"
-    :bar="
+    :foo='\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo} template literal value\`'
+    :bar='
       \`\${first} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\` +
       \`\${second} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\`
-    "
-    :baz="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo + bar} template literal value\`"
-    :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog literal string value'"
-    :add="
+    '
+    :baz='\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo + bar} template literal value\`'
+    :src=''loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog literal string value''
+    :add='
       'first loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog' +
       'second loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog'
-    "
-    :num="
+    '
+    :num='
       100000000000000000000000000000000000000000000000000000000000000000000000000
-    "
+    '
   />
 </template>
 
@@ -1811,20 +1811,20 @@ trailingComma: "es5"
 <!-- #7396 -->
 <template>
   <MyComponent
-    :foo="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo} template literal value\`"
-    :bar="
+    :foo='\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo} template literal value\`'
+    :bar='
       \`\${first} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\` +
       \`\${second} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\`
-    "
-    :baz="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo + bar} template literal value\`"
-    :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog literal string value'"
-    :add="
+    '
+    :baz='\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo + bar} template literal value\`'
+    :src=''loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog literal string value''
+    :add='
       'first loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog' +
       'second loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog'
-    "
-    :num="
+    '
+    :num='
       100000000000000000000000000000000000000000000000000000000000000000000000000
-    "
+    '
   />
 </template>
 
@@ -1855,20 +1855,20 @@ trailingComma: "none"
 <!-- #7396 -->
 <template>
   <MyComponent
-    :foo="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo} template literal value\`"
-    :bar="
+    :foo='\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo} template literal value\`'
+    :bar='
       \`\${first} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\` +
       \`\${second} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\`
-    "
-    :baz="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo + bar} template literal value\`"
-    :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog literal string value'"
-    :add="
+    '
+    :baz='\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo + bar} template literal value\`'
+    :src=''loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog literal string value''
+    :add='
       'first loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog' +
       'second loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog'
-    "
-    :num="
+    '
+    :num='
       100000000000000000000000000000000000000000000000000000000000000000000000000
-    "
+    '
   />
 </template>
 
@@ -1900,20 +1900,20 @@ semi: false
 <!-- #7396 -->
 <template>
   <MyComponent
-    :foo="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo} template literal value\`"
-    :bar="
+    :foo='\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo} template literal value\`'
+    :bar='
       \`\${first} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\` +
       \`\${second} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\`
-    "
-    :baz="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo + bar} template literal value\`"
-    :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog literal string value'"
-    :add="
+    '
+    :baz='\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo + bar} template literal value\`'
+    :src=''loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog literal string value''
+    :add='
       'first loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog' +
       'second loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog'
-    "
-    :num="
+    '
+    :num='
       100000000000000000000000000000000000000000000000000000000000000000000000000
-    "
+    '
   />
 </template>
 <script lang="ts"></script>
@@ -1946,20 +1946,20 @@ trailingComma: "es5"
 <!-- #7396 -->
 <template>
   <MyComponent
-    :foo="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo} template literal value\`"
-    :bar="
+    :foo='\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo} template literal value\`'
+    :bar='
       \`\${first} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\` +
       \`\${second} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\`
-    "
-    :baz="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo + bar} template literal value\`"
-    :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog literal string value'"
-    :add="
+    '
+    :baz='\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo + bar} template literal value\`'
+    :src=''loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog literal string value''
+    :add='
       'first loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog' +
       'second loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog'
-    "
-    :num="
+    '
+    :num='
       100000000000000000000000000000000000000000000000000000000000000000000000000
-    "
+    '
   />
 </template>
 <script lang="ts"></script>
@@ -1992,20 +1992,20 @@ trailingComma: "none"
 <!-- #7396 -->
 <template>
   <MyComponent
-    :foo="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo} template literal value\`"
-    :bar="
+    :foo='\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo} template literal value\`'
+    :bar='
       \`\${first} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\` +
       \`\${second} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\`
-    "
-    :baz="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo + bar} template literal value\`"
-    :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog literal string value'"
-    :add="
+    '
+    :baz='\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo + bar} template literal value\`'
+    :src=''loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog literal string value''
+    :add='
       'first loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog' +
       'second loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog'
-    "
-    :num="
+    '
+    :num='
       100000000000000000000000000000000000000000000000000000000000000000000000000
-    "
+    '
   />
 </template>
 <script lang="ts"></script>
@@ -2031,7 +2031,7 @@ semi: false
 =====================================output=====================================
 <!-- vue filters are only allowed in v-bind and interpolation -->
 <template>
-  <div class="allowed">
+  <div class='allowed'>
     {{
       value
         | thisIsARealSuperLongFilterPipe("arg1", arg2)
@@ -2040,31 +2040,31 @@ semi: false
     }}
   </div>
   <div
-    class="allowed"
-    v-bind:something="
+    class='allowed'
+    v-bind:something='
       value
         | thisIsARealSuperLongFilterPipe('arg1', arg2)
         | anotherPipeLongJustForFun
         | pipeTheThird
-    "
+    '
   ></div>
   <div
-    class="allowed"
-    :class="
+    class='allowed'
+    :class='
       value
         | thisIsARealSuperLongFilterPipe('arg1', arg2)
         | anotherPipeLongJustForFun
         | pipeTheThird
-    "
+    '
   ></div>
   <div
-    class="not-allowed"
-    v-if="
+    class='not-allowed'
+    v-if='
       value |
         thisIsARealSuperLongBitwiseOr('arg1', arg2) |
         anotherBitwiseOrLongJustForFun |
         bitwiseOrTheThird
-    "
+    '
   ></div>
 </template>
 
@@ -2089,7 +2089,7 @@ trailingComma: "es5"
 =====================================output=====================================
 <!-- vue filters are only allowed in v-bind and interpolation -->
 <template>
-  <div class="allowed">
+  <div class='allowed'>
     {{
       value
         | thisIsARealSuperLongFilterPipe("arg1", arg2)
@@ -2098,31 +2098,31 @@ trailingComma: "es5"
     }}
   </div>
   <div
-    class="allowed"
-    v-bind:something="
+    class='allowed'
+    v-bind:something='
       value
         | thisIsARealSuperLongFilterPipe('arg1', arg2)
         | anotherPipeLongJustForFun
         | pipeTheThird
-    "
+    '
   ></div>
   <div
-    class="allowed"
-    :class="
+    class='allowed'
+    :class='
       value
         | thisIsARealSuperLongFilterPipe('arg1', arg2)
         | anotherPipeLongJustForFun
         | pipeTheThird
-    "
+    '
   ></div>
   <div
-    class="not-allowed"
-    v-if="
+    class='not-allowed'
+    v-if='
       value |
         thisIsARealSuperLongBitwiseOr('arg1', arg2) |
         anotherBitwiseOrLongJustForFun |
         bitwiseOrTheThird
-    "
+    '
   ></div>
 </template>
 
@@ -2147,7 +2147,7 @@ trailingComma: "none"
 =====================================output=====================================
 <!-- vue filters are only allowed in v-bind and interpolation -->
 <template>
-  <div class="allowed">
+  <div class='allowed'>
     {{
       value
         | thisIsARealSuperLongFilterPipe("arg1", arg2)
@@ -2156,31 +2156,31 @@ trailingComma: "none"
     }}
   </div>
   <div
-    class="allowed"
-    v-bind:something="
+    class='allowed'
+    v-bind:something='
       value
         | thisIsARealSuperLongFilterPipe('arg1', arg2)
         | anotherPipeLongJustForFun
         | pipeTheThird
-    "
+    '
   ></div>
   <div
-    class="allowed"
-    :class="
+    class='allowed'
+    :class='
       value
         | thisIsARealSuperLongFilterPipe('arg1', arg2)
         | anotherPipeLongJustForFun
         | pipeTheThird
-    "
+    '
   ></div>
   <div
-    class="not-allowed"
-    v-if="
+    class='not-allowed'
+    v-if='
       value |
         thisIsARealSuperLongBitwiseOr('arg1', arg2) |
         anotherBitwiseOrLongJustForFun |
         bitwiseOrTheThird
-    "
+    '
   ></div>
 </template>
 
@@ -2979,7 +2979,7 @@ semi: false
 =====================================output=====================================
 <template>
   <!-- copied from https://github.com/gitlabhq/gitlabhq/blob/master/app/assets/javascripts/ide/components/jobs/detail.vue -->
-  <pre ref="buildTrace" class="build-trace mb-0 h-100" @scroll="scrollBuildLog">
+  <pre ref="buildTrace" class='build-trace mb-0 h-100' @scroll='scrollBuildLog'>
   <code
     v-show="!detailJob.isLoading"
     class="bash"
@@ -2999,19 +2999,19 @@ semi: false
 
 <!-- copied from https://github.com/gitlabhq/gitlabhq/blob/master/app/assets/javascripts/vue_shared/components/code_block.vue -->
 <template>
-  <pre class="code-block rounded">
+  <pre class='code-block rounded'>
     <code class="d-block">{{ code }}</code>
   </pre>
 </template>
 
 <template>
-  <pre class="woot">
+  <pre class='woot'>
   {{ stuff }}
   </pre>
 </template>
 
 <template>
-  <pre class="woot">
+  <pre class='woot'>
   123{{
       wqeqwwqwqweqweqwewwq ||
       wqeqwwqwqweqweqwewwq ||
@@ -3085,7 +3085,7 @@ trailingComma: "es5"
 =====================================output=====================================
 <template>
   <!-- copied from https://github.com/gitlabhq/gitlabhq/blob/master/app/assets/javascripts/ide/components/jobs/detail.vue -->
-  <pre ref="buildTrace" class="build-trace mb-0 h-100" @scroll="scrollBuildLog">
+  <pre ref="buildTrace" class='build-trace mb-0 h-100' @scroll='scrollBuildLog'>
   <code
     v-show="!detailJob.isLoading"
     class="bash"
@@ -3105,19 +3105,19 @@ trailingComma: "es5"
 
 <!-- copied from https://github.com/gitlabhq/gitlabhq/blob/master/app/assets/javascripts/vue_shared/components/code_block.vue -->
 <template>
-  <pre class="code-block rounded">
+  <pre class='code-block rounded'>
     <code class="d-block">{{ code }}</code>
   </pre>
 </template>
 
 <template>
-  <pre class="woot">
+  <pre class='woot'>
   {{ stuff }}
   </pre>
 </template>
 
 <template>
-  <pre class="woot">
+  <pre class='woot'>
   123{{
       wqeqwwqwqweqweqwewwq ||
       wqeqwwqwqweqweqwewwq ||
@@ -3191,7 +3191,7 @@ trailingComma: "none"
 =====================================output=====================================
 <template>
   <!-- copied from https://github.com/gitlabhq/gitlabhq/blob/master/app/assets/javascripts/ide/components/jobs/detail.vue -->
-  <pre ref="buildTrace" class="build-trace mb-0 h-100" @scroll="scrollBuildLog">
+  <pre ref="buildTrace" class='build-trace mb-0 h-100' @scroll='scrollBuildLog'>
   <code
     v-show="!detailJob.isLoading"
     class="bash"
@@ -3211,19 +3211,19 @@ trailingComma: "none"
 
 <!-- copied from https://github.com/gitlabhq/gitlabhq/blob/master/app/assets/javascripts/vue_shared/components/code_block.vue -->
 <template>
-  <pre class="code-block rounded">
+  <pre class='code-block rounded'>
     <code class="d-block">{{ code }}</code>
   </pre>
 </template>
 
 <template>
-  <pre class="woot">
+  <pre class='woot'>
   {{ stuff }}
   </pre>
 </template>
 
 <template>
-  <pre class="woot">
+  <pre class='woot'>
   123{{
       wqeqwwqwqweqweqwewwq ||
       wqeqwwqwqweqweqwewwq ||
@@ -3334,7 +3334,7 @@ foo()
 </script>
 
 <template>
-  <div class="container">
+  <div class='container'>
     <HomeH />
     <HomeA />
     <HomeX />
@@ -3389,7 +3389,7 @@ foo();
 </script>
 
 <template>
-  <div class="container">
+  <div class='container'>
     <HomeH />
     <HomeA />
     <HomeX />
@@ -3444,7 +3444,7 @@ foo();
 </script>
 
 <template>
-  <div class="container">
+  <div class='container'>
     <HomeH />
     <HomeA />
     <HomeX />
@@ -3474,7 +3474,7 @@ semi: false
 
 =====================================output=====================================
 <template>
-  <span :class="$style.root"><slot /></span>
+  <span :class='$style.root'><slot /></span>
 </template>
 
 <style src="./style.css" module />
@@ -3497,7 +3497,7 @@ trailingComma: "es5"
 
 =====================================output=====================================
 <template>
-  <span :class="$style.root"><slot /></span>
+  <span :class='$style.root'><slot /></span>
 </template>
 
 <style src="./style.css" module />
@@ -3520,7 +3520,7 @@ trailingComma: "none"
 
 =====================================output=====================================
 <template>
-  <span :class="$style.root"><slot /></span>
+  <span :class='$style.root'><slot /></span>
 </template>
 
 <style src="./style.css" module />
@@ -3554,10 +3554,10 @@ semi: false
 <template>
   <comp>
     <template
-      v-slot="x: unknown[]"
-      v-slot:named="y: never"
-      slot-scope="{ des: { truc: tured } }: any"
-      #shorthand="abc: string"
+      v-slot='x: unknown[]'
+      v-slot:named='y: never'
+      slot-scope='{ des: { truc: tured } }: any'
+      #shorthand='abc: string'
     >
       {{ x[1] }}
     </template>
@@ -3593,10 +3593,10 @@ trailingComma: "es5"
 <template>
   <comp>
     <template
-      v-slot="x: unknown[]"
-      v-slot:named="y: never"
-      slot-scope="{ des: { truc: tured } }: any"
-      #shorthand="abc: string"
+      v-slot='x: unknown[]'
+      v-slot:named='y: never'
+      slot-scope='{ des: { truc: tured } }: any'
+      #shorthand='abc: string'
     >
       {{ x[1] }}
     </template>
@@ -3632,10 +3632,10 @@ trailingComma: "none"
 <template>
   <comp>
     <template
-      v-slot="x: unknown[]"
-      v-slot:named="y: never"
-      slot-scope="{ des: { truc: tured } }: any"
-      #shorthand="abc: string"
+      v-slot='x: unknown[]'
+      v-slot:named='y: never'
+      slot-scope='{ des: { truc: tured } }: any'
+      #shorthand='abc: string'
     >
       {{ x[1] }}
     </template>
@@ -4061,22 +4061,22 @@ semi: false
 =====================================output=====================================
 <!--copied from https://github.com/gitlabhq/gitlabhq/blob/master/app/assets/javascripts/vue_shared/components/content_viewer/viewers/image_viewer.vue-->
 <template>
-  <div class="file-container">
-    <div class="file-content image_file">
+  <div class='file-container'>
+    <div class='file-content image_file'>
       <img
         ref="contentImg"
-        :class="{ 'is-zoomable': isZoomable, 'is-zoomed': isZoomed }"
-        :src="path"
-        :alt="path"
-        @load="onImgLoad"
-        @click="onImgClick"
+        :class='{ 'is-zoomable': isZoomable, 'is-zoomed': isZoomed }'
+        :src='path'
+        :alt='path'
+        @load='onImgLoad'
+        @click='onImgClick'
       />
-      <p v-if="renderInfo" class="file-info prepend-top-10">
-        <template v-if="fileSize > 0">
+      <p v-if='renderInfo' class='file-info prepend-top-10'>
+        <template v-if='fileSize > 0'>
           {{ fileSizeReadable }}
         </template>
-        <template v-if="fileSize > 0 && width && height"> | </template>
-        <template v-if="width && height">
+        <template v-if='fileSize > 0 && width && height'> | </template>
+        <template v-if='width && height'>
           W: {{ width }} | H: {{ height }}
         </template>
       </p>
@@ -4125,22 +4125,22 @@ trailingComma: "es5"
 =====================================output=====================================
 <!--copied from https://github.com/gitlabhq/gitlabhq/blob/master/app/assets/javascripts/vue_shared/components/content_viewer/viewers/image_viewer.vue-->
 <template>
-  <div class="file-container">
-    <div class="file-content image_file">
+  <div class='file-container'>
+    <div class='file-content image_file'>
       <img
         ref="contentImg"
-        :class="{ 'is-zoomable': isZoomable, 'is-zoomed': isZoomed }"
-        :src="path"
-        :alt="path"
-        @load="onImgLoad"
-        @click="onImgClick"
+        :class='{ 'is-zoomable': isZoomable, 'is-zoomed': isZoomed }'
+        :src='path'
+        :alt='path'
+        @load='onImgLoad'
+        @click='onImgClick'
       />
-      <p v-if="renderInfo" class="file-info prepend-top-10">
-        <template v-if="fileSize > 0">
+      <p v-if='renderInfo' class='file-info prepend-top-10'>
+        <template v-if='fileSize > 0'>
           {{ fileSizeReadable }}
         </template>
-        <template v-if="fileSize > 0 && width && height"> | </template>
-        <template v-if="width && height">
+        <template v-if='fileSize > 0 && width && height'> | </template>
+        <template v-if='width && height'>
           W: {{ width }} | H: {{ height }}
         </template>
       </p>
@@ -4189,22 +4189,22 @@ trailingComma: "none"
 =====================================output=====================================
 <!--copied from https://github.com/gitlabhq/gitlabhq/blob/master/app/assets/javascripts/vue_shared/components/content_viewer/viewers/image_viewer.vue-->
 <template>
-  <div class="file-container">
-    <div class="file-content image_file">
+  <div class='file-container'>
+    <div class='file-content image_file'>
       <img
         ref="contentImg"
-        :class="{ 'is-zoomable': isZoomable, 'is-zoomed': isZoomed }"
-        :src="path"
-        :alt="path"
-        @load="onImgLoad"
-        @click="onImgClick"
+        :class='{ 'is-zoomable': isZoomable, 'is-zoomed': isZoomed }'
+        :src='path'
+        :alt='path'
+        @load='onImgLoad'
+        @click='onImgClick'
       />
-      <p v-if="renderInfo" class="file-info prepend-top-10">
-        <template v-if="fileSize > 0">
+      <p v-if='renderInfo' class='file-info prepend-top-10'>
+        <template v-if='fileSize > 0'>
           {{ fileSizeReadable }}
         </template>
-        <template v-if="fileSize > 0 && width && height"> | </template>
-        <template v-if="width && height">
+        <template v-if='fileSize > 0 && width && height'> | </template>
+        <template v-if='width && height'>
           W: {{ width }} | H: {{ height }}
         </template>
       </p>
@@ -4237,7 +4237,7 @@ new Vue({el: '#app'})
 <!doctype html>
 <html>
   <body>
-    <div v-if="foo === 'foo'"></div>
+    <div v-if='foo === 'foo''></div>
     <script>
       new Vue({ el: "#app" })
     </script>
@@ -4269,7 +4269,7 @@ new Vue({el: '#app'})
 <!doctype html>
 <html>
   <body>
-    <div v-if="foo === 'foo'"></div>
+    <div v-if='foo === 'foo''></div>
     <script>
       new Vue({ el: "#app" });
     </script>
@@ -4301,7 +4301,7 @@ new Vue({el: '#app'})
 <!doctype html>
 <html>
   <body>
-    <div v-if="foo === 'foo'"></div>
+    <div v-if='foo === 'foo''></div>
     <script>
       new Vue({ el: "#app" });
     </script>
@@ -4696,64 +4696,64 @@ long_long_long_long_long_long_long_condition_4
 <template>
   <root>
     <and
-      v-if="
+      v-if='
         long_long_long_long_long_long_long_condition_1 &&
         long_long_long_long_long_long_long_condition_2 &&
         short_1 &&
         short_2 &&
         long_long_long_long_long_long_long_condition_3 &&
         long_long_long_long_long_long_long_condition_4
-      "
+      '
     ></and>
     <and
-      v-if="
+      v-if='
         long_long_long_long_long_long_long_condition_1 &&
         long_long_long_long_long_long_long_condition_2 &&
         short_1 &&
         short_2 &&
         long_long_long_long_long_long_long_condition_3 &&
         long_long_long_long_long_long_long_condition_4
-      "
+      '
     ></and>
     <or
-      v-if="
+      v-if='
         long_long_long_long_long_long_long_condition_1 ||
         long_long_long_long_long_long_long_condition_2 ||
         short_1 ||
         short_2 ||
         long_long_long_long_long_long_long_condition_3 ||
         long_long_long_long_long_long_long_condition_4
-      "
+      '
     ></or>
     <or
-      v-if="
+      v-if='
         long_long_long_long_long_long_long_condition_1 ||
         long_long_long_long_long_long_long_condition_2 ||
         short_1 ||
         short_2 ||
         long_long_long_long_long_long_long_condition_3 ||
         long_long_long_long_long_long_long_condition_4
-      "
+      '
     ></or>
     <mixed
-      v-if="
+      v-if='
         (long_long_long_long_long_long_long_condition_1 &&
           long_long_long_long_long_long_long_condition_2) ||
         (short_1 &&
           short_2 &&
           long_long_long_long_long_long_long_condition_3 &&
           long_long_long_long_long_long_long_condition_4)
-      "
+      '
     ></mixed>
     <mixed
-      v-if="
+      v-if='
         (long_long_long_long_long_long_long_condition_1 &&
           long_long_long_long_long_long_long_condition_2) ||
         (short_1 &&
           short_2 &&
           long_long_long_long_long_long_long_condition_3) ||
         long_long_long_long_long_long_long_condition_4
-      "
+      '
     ></mixed>
   </root>
 </template>
@@ -4807,64 +4807,64 @@ long_long_long_long_long_long_long_condition_4
 <template>
   <root>
     <and
-      v-if="
+      v-if='
         long_long_long_long_long_long_long_condition_1 &&
         long_long_long_long_long_long_long_condition_2 &&
         short_1 &&
         short_2 &&
         long_long_long_long_long_long_long_condition_3 &&
         long_long_long_long_long_long_long_condition_4
-      "
+      '
     ></and>
     <and
-      v-if="
+      v-if='
         long_long_long_long_long_long_long_condition_1 &&
         long_long_long_long_long_long_long_condition_2 &&
         short_1 &&
         short_2 &&
         long_long_long_long_long_long_long_condition_3 &&
         long_long_long_long_long_long_long_condition_4
-      "
+      '
     ></and>
     <or
-      v-if="
+      v-if='
         long_long_long_long_long_long_long_condition_1 ||
         long_long_long_long_long_long_long_condition_2 ||
         short_1 ||
         short_2 ||
         long_long_long_long_long_long_long_condition_3 ||
         long_long_long_long_long_long_long_condition_4
-      "
+      '
     ></or>
     <or
-      v-if="
+      v-if='
         long_long_long_long_long_long_long_condition_1 ||
         long_long_long_long_long_long_long_condition_2 ||
         short_1 ||
         short_2 ||
         long_long_long_long_long_long_long_condition_3 ||
         long_long_long_long_long_long_long_condition_4
-      "
+      '
     ></or>
     <mixed
-      v-if="
+      v-if='
         (long_long_long_long_long_long_long_condition_1 &&
           long_long_long_long_long_long_long_condition_2) ||
         (short_1 &&
           short_2 &&
           long_long_long_long_long_long_long_condition_3 &&
           long_long_long_long_long_long_long_condition_4)
-      "
+      '
     ></mixed>
     <mixed
-      v-if="
+      v-if='
         (long_long_long_long_long_long_long_condition_1 &&
           long_long_long_long_long_long_long_condition_2) ||
         (short_1 &&
           short_2 &&
           long_long_long_long_long_long_long_condition_3) ||
         long_long_long_long_long_long_long_condition_4
-      "
+      '
     ></mixed>
   </root>
 </template>
@@ -4918,64 +4918,64 @@ long_long_long_long_long_long_long_condition_4
 <template>
   <root>
     <and
-      v-if="
+      v-if='
         long_long_long_long_long_long_long_condition_1 &&
         long_long_long_long_long_long_long_condition_2 &&
         short_1 &&
         short_2 &&
         long_long_long_long_long_long_long_condition_3 &&
         long_long_long_long_long_long_long_condition_4
-      "
+      '
     ></and>
     <and
-      v-if="
+      v-if='
         long_long_long_long_long_long_long_condition_1 &&
         long_long_long_long_long_long_long_condition_2 &&
         short_1 &&
         short_2 &&
         long_long_long_long_long_long_long_condition_3 &&
         long_long_long_long_long_long_long_condition_4
-      "
+      '
     ></and>
     <or
-      v-if="
+      v-if='
         long_long_long_long_long_long_long_condition_1 ||
         long_long_long_long_long_long_long_condition_2 ||
         short_1 ||
         short_2 ||
         long_long_long_long_long_long_long_condition_3 ||
         long_long_long_long_long_long_long_condition_4
-      "
+      '
     ></or>
     <or
-      v-if="
+      v-if='
         long_long_long_long_long_long_long_condition_1 ||
         long_long_long_long_long_long_long_condition_2 ||
         short_1 ||
         short_2 ||
         long_long_long_long_long_long_long_condition_3 ||
         long_long_long_long_long_long_long_condition_4
-      "
+      '
     ></or>
     <mixed
-      v-if="
+      v-if='
         (long_long_long_long_long_long_long_condition_1 &&
           long_long_long_long_long_long_long_condition_2) ||
         (short_1 &&
           short_2 &&
           long_long_long_long_long_long_long_condition_3 &&
           long_long_long_long_long_long_long_condition_4)
-      "
+      '
     ></mixed>
     <mixed
-      v-if="
+      v-if='
         (long_long_long_long_long_long_long_condition_1 &&
           long_long_long_long_long_long_long_condition_2) ||
         (short_1 &&
           short_2 &&
           long_long_long_long_long_long_long_condition_3) ||
         long_long_long_long_long_long_long_condition_4
-      "
+      '
     ></mixed>
   </root>
 </template>


### PR DESCRIPTION
## Description
fix  the <div style="font-family: 'Arial';"></div> converted to <div style="font-family: &quot;Arial&quot;"></div> and the expected result is this <div style='font-family: "Arial"'></div>

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
