### PR TITLE
Ignore files in the Jujutsu directory

### DIFF
--- a/changelog_unreleased/cli/16684.md
+++ b/changelog_unreleased/cli/16684.md
@@ -1,5 +1,5 @@
 #### Ignore files in the Jujutsu directory (#16684 by @marcusirgens)
 
-The Jujutsu VCS uses the `.jj` directory, similarily to how Git uses `.git`.
+The Jujutsu VCS uses the `.jj` directory, similarly to how Git uses `.git`.
 
 This change adds `.jj` to the list of directories which are silently ignored by prettier.

--- a/changelog_unreleased/cli/16684.md
+++ b/changelog_unreleased/cli/16684.md
@@ -1,27 +1,3 @@
-<!--
-
-1. Choose a folder based on which language your PR is for.
-
-   - For JavaScript, choose `javascript/` etc.
-   - For TypeScript specific syntax, choose `typescript/`.
-   - If your PR applies to multiple languages, such as TypeScript/Flow, choose one folder and mention which languages it applies to.
-
-2. In your chosen folder, create a file with your PR number: `XXXX.md`. For example: `typescript/6728.md`.
-
-3. Copy the content below and paste it in your new file.
-
-4. Fill in a title, the PR number and your user name.
-
-5. Optionally write a description. Many times it’s enough with just sample code.
-
-6. Change ```jsx to your language. For example, ```yaml.
-
-7. Change the `// Input` and `// Prettier` comments to the comment syntax of your language. For example, `# Input`.
-
-8. Choose some nice input example code. Paste it along with the output before and after your PR.
-
--->
-
 #### Ignore files in the Jujutsu directory (#16684 by @marcusirgens)
 
 The Jujutsu VCS uses the `.jj` directory, similarily to how Git uses `.git`.

--- a/changelog_unreleased/cli/16684.md
+++ b/changelog_unreleased/cli/16684.md
@@ -1,0 +1,29 @@
+<!--
+
+1. Choose a folder based on which language your PR is for.
+
+   - For JavaScript, choose `javascript/` etc.
+   - For TypeScript specific syntax, choose `typescript/`.
+   - If your PR applies to multiple languages, such as TypeScript/Flow, choose one folder and mention which languages it applies to.
+
+2. In your chosen folder, create a file with your PR number: `XXXX.md`. For example: `typescript/6728.md`.
+
+3. Copy the content below and paste it in your new file.
+
+4. Fill in a title, the PR number and your user name.
+
+5. Optionally write a description. Many times it’s enough with just sample code.
+
+6. Change ```jsx to your language. For example, ```yaml.
+
+7. Change the `// Input` and `// Prettier` comments to the comment syntax of your language. For example, `# Input`.
+
+8. Choose some nice input example code. Paste it along with the output before and after your PR.
+
+-->
+
+#### Ignore files in the Jujutsu directory (#16684 by @marcusirgens)
+
+The Jujutsu VCS uses the `.jj` directory, similarily to how Git uses `.git`.
+
+This change adds `.jj` to the list of directories which are silently ignored by prettier.

--- a/docs/ignore.md
+++ b/docs/ignore.md
@@ -24,7 +24,7 @@ coverage
 
 It’s recommended to have a `.prettierignore` in your project! This way you can run `prettier --write .` to make sure that everything is formatted (without mangling files you don’t want, or choking on generated files). And – your editor will know which files _not_ to format!
 
-By default prettier ignores files in version control systems directories (".git", ".sl", ".svn" and ".hg") and `node_modules` (unless the [`--with-node-modules` CLI option](cli.md#--with-node-modules) is specified). Prettier will also follow rules specified in the ".gitignore" file if it exists in the same directory from which it is run.
+By default prettier ignores files in version control systems directories (".git", ".jj", ".sl", ".svn" and ".hg") and `node_modules` (unless the [`--with-node-modules` CLI option](cli.md#--with-node-modules) is specified). Prettier will also follow rules specified in the ".gitignore" file if it exists in the same directory from which it is run.
 
 So by default it will be
 

--- a/src/cli/expand-patterns.js
+++ b/src/cli/expand-patterns.js
@@ -45,7 +45,7 @@ async function* expandPatterns(context) {
  */
 async function* expandPatternsInternal(context) {
   // Ignores files in version control systems directories and `node_modules`
-  const silentlyIgnoredDirs = [".git", ".sl", ".svn", ".hg"];
+  const silentlyIgnoredDirs = [".git", ".sl", ".svn", ".hg", ".jj"];
   if (context.argv.withNodeModules !== true) {
     silentlyIgnoredDirs.push("node_modules");
   }

--- a/tests/integration/__tests__/ignore-vcs-files.js
+++ b/tests/integration/__tests__/ignore-vcs-files.js
@@ -2,6 +2,7 @@ describe("ignores files in version control systems", () => {
   runCli("cli/ignore-vcs-files", [
     ".svn/file.js",
     ".hg/file.js",
+    ".jj/file.js",
     "file.js",
     "-l",
   ]).test({

--- a/tests/integration/cli/ignore-vcs-files/.jj/file.js
+++ b/tests/integration/cli/ignore-vcs-files/.jj/file.js
@@ -1,0 +1,1 @@
+'use strict';


### PR DESCRIPTION
## Description

[Jujutsu](https://martinvonz.github.io/jj/latest/) is a version control system that's Git-compatible.
Jujutsu, like the other VCSs, stores state to disk. Jujutsu uses the `.jj` directory for this.

This change updates the `silentlyIgnoredDirs` list to include this directory, which makes prettier treat it like other VCSs.

https://github.com/prettier/prettier/blob/724bb0cdf5fd1a86a4940cbb31f6623ad81afaa6/src/cli/expand-patterns.js#L48

In this change:

https://github.com/prettier/prettier/blob/a3c763c75abc608ce8041b115b3f1723af036851/src/cli/expand-patterns.js#L48

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
