### PR TITLE
loosen computational complexty check for printing fill

### DIFF
--- a/tests/unit/doc-printer.js
+++ b/tests/unit/doc-printer.js
@@ -46,9 +46,9 @@ test("`printDocToString` should not manipulate docs", () => {
 
 describe("`printDocToString` has linear time complexity at most to print fill()", () => {
   const baseSize = 3_000;
-  const relativeMargin = 0.4;
+  const relativeMargin = 0.6;
   const baseTime = time(makeFill(baseSize));
-  test.each([10_000, 20_000, 40_000])("numWords=%d", (numWords) => {
+  test.each([20_000, 40_000, 60_000])("numWords=%d", (numWords) => {
     const doc = makeFill(numWords);
     const ellapsed = time(doc);
     const ratio = numWords / baseSize;


### PR DESCRIPTION
## Description
Test for computational complexity sometimes fails. I loosen the check.

- https://github.com/prettier/prettier/actions/runs/10918652303/job/30304586314
- https://github.com/prettier/prettier/actions/runs/10926551730/job/30330691083
- https://github.com/prettier/prettier/actions/runs/11074432534/job/30773198271
- https://github.com/prettier/prettier/actions/runs/10926464116/job/30330396707
- https://github.com/prettier/prettier/actions/runs/10821470528/job/30023526559
- https://github.com/prettier/prettier/actions/runs/11099612409/job/30834112908?pr=16700


<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] ~I’ve added tests to confirm my change works.~
- [x] ~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).~
- [x] ~(If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
