### PR TITLE
Updated font family in html body in overrides.css

### DIFF
--- a/website/static/overrides.css
+++ b/website/static/overrides.css
@@ -2,14 +2,14 @@ html body {
   font-family:
     -apple-system,
     BlinkMacSystemFont,
-    Segoe UI,
+    "Segoe UI",
     Roboto,
     Oxygen,
     Ubuntu,
     Cantarell,
-    Fira Sans,
-    Droid Sans,
-    Helvetica Neue,
+    "Fira Sans",
+    "Droid Sans",
+    "Helvetica Neue",
     sans-serif;
 
   overflow-x: hidden;


### PR DESCRIPTION
html body tag: Added double quotations to multi-word font family names

## Description

According to the guidelines outlined in the CodeGuide for CSS, for font-family declarations, it states that font names containing spaces should be wrapped in quotation marks. This ensures that the font names are interpreted correctly by the browser.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
