### PR TITLE
Fix ignoring entire mapping and sequence.

### DIFF
--- a/src/language-yaml/printer-yaml.js
+++ b/src/language-yaml/printer-yaml.js
@@ -95,7 +95,14 @@ function genericPrint(path, options, print) {
     ]);
   }
 
-  if (hasPrettierIgnore(path)) {
+  if (
+    (!isNode(node, ["mapping", "sequence"]) && hasPrettierIgnore(path)) ||
+    (path.isFirst &&
+      isNode(node, ["mappingItem", "sequenceItem"]) &&
+      path.callParent((path) => {
+        return hasPrettierIgnore(path);
+      }))
+  ) {
     parts.push(
       replaceEndOfLine(
         options.originalText

--- a/tests/format/yaml/prettier-ignore/__snapshots__/format.test.js.snap
+++ b/tests/format/yaml/prettier-ignore/__snapshots__/format.test.js.snap
@@ -31,14 +31,30 @@ parsers: ["yaml"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
-abc:     123
 # prettier-ignore
+abc:     123
 def:     456
+# prettier-ignore
+ghi:     789
+---
+# prettier-ignore
+-        abc
+-        def
+# prettier-ignore
+-        ghi
 
 =====================================output=====================================
-abc: 123
 # prettier-ignore
-def:     456
+abc:     123
+def: 456
+# prettier-ignore
+ghi:     789
+---
+# prettier-ignore
+-        abc
+- def
+# prettier-ignore
+-        ghi
 
 ================================================================================
 `;

--- a/tests/format/yaml/prettier-ignore/leading-comment.yml
+++ b/tests/format/yaml/prettier-ignore/leading-comment.yml
@@ -1,3 +1,11 @@
-abc:     123
 # prettier-ignore
+abc:     123
 def:     456
+# prettier-ignore
+ghi:     789
+---
+# prettier-ignore
+-        abc
+-        def
+# prettier-ignore
+-        ghi


### PR DESCRIPTION
## Description

Fix bug in #13008. Added a check to determine whether the YAML ignore comment is at the beginning of the file.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
