### PR TITLE
Improve string print perfomance

### DIFF
--- a/changelog_unreleased/javascript/16563.md
+++ b/changelog_unreleased/javascript/16563.md
@@ -1,4 +1,4 @@
-#### Don't remove useless `\` in string literals (#16563 by @sosukesuzuki)
+#### Don't remove useless `\` in string literals (#16563 by @sosukesuzuki, #16763 by @fisker)
 
 Previously, Prettier would remove useless escape characters (`\`) from string literals. However, this behavior was inconsistent as it did not apply to template literals, which was reported in [issue #16542](https://github.com/prettier/prettier/issues/16542).
 
@@ -8,7 +8,7 @@ After discussing this internally, the Prettier team concluded that removing usel
 
 This change disables the removal of useless escape characters in string literals across all languages supported by Prettier. To keep the previous behavior, we recommend using ESLint rules like [`no-useless-escape`](https://eslint.org/docs/latest/rules/no-useless-escape).
 
-Escaping quotes within string literals (e.g. `"\"\'"`) works the same as before. This is explained on the [Rationale](https://prettier.io/docs/en/rationale.html#strings) page of the official documentation.
+Escaped quotes (e.g. `"\"\'"`) may still get unescaped when changing between different quotes. This is explained on the [Rationale](https://prettier.io/docs/en/rationale.html#strings) page of the official documentation.
 
 <!-- prettier-ignore -->
 ```jsx

--- a/changelog_unreleased/javascript/16563.md
+++ b/changelog_unreleased/javascript/16563.md
@@ -8,7 +8,7 @@ After discussing this internally, the Prettier team concluded that removing usel
 
 This change disables the removal of useless escape characters in string literals across all languages supported by Prettier. To keep the previous behavior, we recommend using ESLint rules like [`no-useless-escape`](https://eslint.org/docs/latest/rules/no-useless-escape).
 
-Escaped quotes (e.g. `"\"\'"`) may still get unescaped when changing between different quotes. This is explained on the [Rationale](https://prettier.io/docs/en/rationale.html#strings) page of the official documentation.
+Escaped quotes (e.g. `"\"\'"`) may get unescaped when changing between different quotes. This is explained on the [Rationale](https://prettier.io/docs/en/rationale.html#strings) page of the official documentation.
 
 <!-- prettier-ignore -->
 ```jsx

--- a/src/utils/print-string.js
+++ b/src/utils/print-string.js
@@ -1,9 +1,12 @@
+import assert from "node:assert";
 import getPreferredQuote from "./get-preferred-quote.js";
 import makeString from "./make-string.js";
 
 /** @import {Quote} from "./get-preferred-quote.js" */
 
 function printString(raw, options) {
+  assert(/^(?<quote>["']).*\k<quote>$/su.test(raw));
+
   // `rawContent` is the string exactly like it appeared in the input source
   // code, without its enclosing quotes.
   const rawContent = raw.slice(1, -1);
@@ -25,6 +28,12 @@ function printString(raw, options) {
       : options.__isInHtmlAttribute
         ? "'"
         : getPreferredQuote(rawContent, options.singleQuote);
+
+  const originalQuote = raw.charAt(0);
+
+  if (originalQuote === enclosingQuote) {
+    return raw;
+  }
 
   // It might sound unnecessary to use `makeString` even if the string already
   // is enclosed with `enclosingQuote`, but it isn't. The string could contain

--- a/tests/format/css/quotes/__snapshots__/format.test.js.snap
+++ b/tests/format/css/quotes/__snapshots__/format.test.js.snap
@@ -137,7 +137,7 @@ one 'two' three {}
 
     /* One of each with unnecessary escapes. */
     content: '"\\'';
-    content: '"\\'';
+    content: '\\"\\'';
 
     /* More double quotes than single quotes. */
     content: '"\\'"';
@@ -156,8 +156,8 @@ one 'two' three {}
     content: '\\\\';
 
     /* Backslases. */
-    content: "\\"\\\\\\"\\\\\\\\\\" ''\\\\'\\\\'\\\\\\\\'";
-    content: '\\'\\\\\\'\\\\\\\\\\' ""\\\\"\\\\"\\\\\\\\"';
+    content: "\\"\\\\\\"\\\\\\\\\\" '\\'\\\\'\\\\\\'\\\\\\\\'";
+    content: '\\'\\\\\\'\\\\\\\\\\' "\\"\\\\"\\\\\\"\\\\\\\\"';
 
     /* Somewhat more real-word example. */
     content: "He's sayin': \\"How's it goin'?\\" Don't ask me why.";
@@ -332,7 +332,7 @@ one 'two' three {}
     content: "\\"'";
 
     /* One of each with unnecessary escapes. */
-    content: "\\"'";
+    content: "\\"\\'";
     content: "\\"'";
 
     /* More double quotes than single quotes. */
@@ -352,8 +352,8 @@ one 'two' three {}
     content: "\\\\";
 
     /* Backslases. */
-    content: "\\"\\\\\\"\\\\\\\\\\" ''\\\\'\\\\'\\\\\\\\'";
-    content: '\\'\\\\\\'\\\\\\\\\\' ""\\\\"\\\\"\\\\\\\\"';
+    content: "\\"\\\\\\"\\\\\\\\\\" '\\'\\\\'\\\\\\'\\\\\\\\'";
+    content: '\\'\\\\\\'\\\\\\\\\\' "\\"\\\\"\\\\\\"\\\\\\\\"';
 
     /* Somewhat more real-word example. */
     content: "He's sayin': \\"How's it goin'?\\" Don't ask me why.";

--- a/tests/format/js/quotes/__snapshots__/format.test.js.snap
+++ b/tests/format/js/quotes/__snapshots__/format.test.js.snap
@@ -234,8 +234,8 @@ singleQuote: true
 ("'");
 
 // Unnecessary escapes.
-("'");
-('"');
+("\\'");
+('\\"');
 ('\\a');
 ('\\a');
 ('hol\\a');
@@ -270,7 +270,7 @@ singleQuote: true
 
 // One of each with unnecessary escapes.
 ('"\\'');
-('"\\'');
+('\\"\\'');
 
 // More double quotes than single quotes.
 ('"\\'"');
@@ -289,8 +289,8 @@ singleQuote: true
 ('\\\\');
 
 // Backslases.
-("\\"\\\\\\"\\\\\\\\\\" ''\\\\'\\\\'\\\\\\\\'");
-('\\'\\\\\\'\\\\\\\\\\' ""\\\\"\\\\"\\\\\\\\"');
+("\\"\\\\\\"\\\\\\\\\\" '\\'\\\\'\\\\\\'\\\\\\\\'");
+('\\'\\\\\\'\\\\\\\\\\' "\\"\\\\"\\\\\\"\\\\\\\\"');
 
 // Somewhat more real-word example.
 ("He's sayin': \\"How's it goin'?\\" Don't ask me why.");
@@ -446,8 +446,8 @@ printWidth: 80
 ("'");
 
 // Unnecessary escapes.
-("'");
-('"');
+("\\'");
+('\\"');
 ("\\a");
 ("\\a");
 ("hol\\a");
@@ -481,7 +481,7 @@ printWidth: 80
 ("\\"'");
 
 // One of each with unnecessary escapes.
-("\\"'");
+("\\"\\'");
 ("\\"'");
 
 // More double quotes than single quotes.
@@ -501,8 +501,8 @@ printWidth: 80
 ("\\\\");
 
 // Backslases.
-("\\"\\\\\\"\\\\\\\\\\" ''\\\\'\\\\'\\\\\\\\'");
-('\\'\\\\\\'\\\\\\\\\\' ""\\\\"\\\\"\\\\\\\\"');
+("\\"\\\\\\"\\\\\\\\\\" '\\'\\\\'\\\\\\'\\\\\\\\'");
+('\\'\\\\\\'\\\\\\\\\\' "\\"\\\\"\\\\\\"\\\\\\\\"');
 
 // Somewhat more real-word example.
 ("He's sayin': \\"How's it goin'?\\" Don't ask me why.");

--- a/tests/format/js/strings/__snapshots__/format.test.js.snap
+++ b/tests/format/js/strings/__snapshots__/format.test.js.snap
@@ -11,13 +11,19 @@ export const MSG_GENERIC_OPERATION_FAILURE_BODY_1 =
   goog.getMsg("That's all we know");
 
 export const MSG_GENERIC_OPERATION_FAILURE_BODY_2 =
+  goog.getMsg('That\\'s all we know');
+
+export const MSG_GENERIC_OPERATION_FAILURE_BODY_3 =
   goog.getMsg("That\\'s all we know");
 
 =====================================output=====================================
 export const MSG_GENERIC_OPERATION_FAILURE_BODY_1 =
   goog.getMsg("That's all we know");
 
-export const MSG_GENERIC_OPERATION_FAILURE_BODY_2 = goog.getMsg(
+export const MSG_GENERIC_OPERATION_FAILURE_BODY_2 =
+  goog.getMsg("That's all we know");
+
+export const MSG_GENERIC_OPERATION_FAILURE_BODY_3 = goog.getMsg(
   "That\\'s all we know",
 );
 
@@ -35,13 +41,19 @@ export const MSG_GENERIC_OPERATION_FAILURE_BODY_1 =
   goog.getMsg("That's all we know");
 
 export const MSG_GENERIC_OPERATION_FAILURE_BODY_2 =
+  goog.getMsg('That\\'s all we know');
+
+export const MSG_GENERIC_OPERATION_FAILURE_BODY_3 =
   goog.getMsg("That\\'s all we know");
 
 =====================================output=====================================
 export const MSG_GENERIC_OPERATION_FAILURE_BODY_1 =
   goog.getMsg("That's all we know");
 
-export const MSG_GENERIC_OPERATION_FAILURE_BODY_2 = goog.getMsg(
+export const MSG_GENERIC_OPERATION_FAILURE_BODY_2 =
+  goog.getMsg("That's all we know");
+
+export const MSG_GENERIC_OPERATION_FAILURE_BODY_3 = goog.getMsg(
   "That\\'s all we know"
 );
 

--- a/tests/format/js/strings/__snapshots__/format.test.js.snap
+++ b/tests/format/js/strings/__snapshots__/format.test.js.snap
@@ -17,8 +17,9 @@ export const MSG_GENERIC_OPERATION_FAILURE_BODY_2 =
 export const MSG_GENERIC_OPERATION_FAILURE_BODY_1 =
   goog.getMsg("That's all we know");
 
-export const MSG_GENERIC_OPERATION_FAILURE_BODY_2 =
-  goog.getMsg("That's all we know");
+export const MSG_GENERIC_OPERATION_FAILURE_BODY_2 = goog.getMsg(
+  "That\\'s all we know",
+);
 
 ================================================================================
 `;
@@ -40,8 +41,9 @@ export const MSG_GENERIC_OPERATION_FAILURE_BODY_2 =
 export const MSG_GENERIC_OPERATION_FAILURE_BODY_1 =
   goog.getMsg("That's all we know");
 
-export const MSG_GENERIC_OPERATION_FAILURE_BODY_2 =
-  goog.getMsg("That's all we know");
+export const MSG_GENERIC_OPERATION_FAILURE_BODY_2 = goog.getMsg(
+  "That\\'s all we know"
+);
 
 ================================================================================
 `;
@@ -279,11 +281,11 @@ trailingComma: "all"
   "'",
 
   '"',
-  '"',
+  '\\"',
   '\\\\"',
 
   "'",
-  "'",
+  "\\'",
   "\\\\'",
 
   "'\\"",
@@ -342,11 +344,11 @@ trailingComma: "es5"
   "'",
 
   '"',
-  '"',
+  '\\"',
   '\\\\"',
 
   "'",
-  "'",
+  "\\'",
   "\\\\'",
 
   "'\\"",

--- a/tests/format/js/strings/escaped.js
+++ b/tests/format/js/strings/escaped.js
@@ -2,4 +2,7 @@ export const MSG_GENERIC_OPERATION_FAILURE_BODY_1 =
   goog.getMsg("That's all we know");
 
 export const MSG_GENERIC_OPERATION_FAILURE_BODY_2 =
+  goog.getMsg('That\'s all we know');
+
+export const MSG_GENERIC_OPERATION_FAILURE_BODY_3 =
   goog.getMsg("That\'s all we know");


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

We already  stop unescaping characters in #16563.

It makes sense to skip `makeString()` when the original quote matches the desired quote.

However, this will make the following code

```js
const foo = "\"\'"
```

untouched when using `--no-single-quote`,  but [unescape `"` when using `--single-quote`](https://deploy-preview-16763--prettier.netlify.app/playground/#N4Igxg9gdgLgprEAuc0DOMAEAzCFMC8mAOiMeWcQOSkgA0IEADjAJbrKgCGATjxAHcACrwRpkILgBsBXAJ7iGAIx5cwAazgwAylwC2cADKsocZNmlo4y1Rq3amakwHNkMHgFdrIK3tZvPbzgADyY4HlYDWGkAFXCoXlY4cSQLKSsGNBcpOABFDwh4AK8GACs0YO1svIKi1MtvAEdauCF+JhTJNABaUzgAEwH6EHcuVikXAGEIPT0uCWkpYayoZxyAQRh3ViUPeCFw41NzBoYACxg9KQB1M9Z4NEcwOG0xe9YAN3u5CTA0RRAHy8AEkoINYNowBEWOswdoYHIcid0t4mPwrNdVEwJGjkuEPmYGCYrDwYG0uM45siMiBHDwSRIlFwlHAlgw0SYYNdWP0YGdkAAOAAMDB4cGarDF5Mp83qKIYMGZ3N5-KQACYGB4rDFmSk0jS4HoWf1Bv1DFxVh4KXAAGIQHhzLYuBZ7CAgAC+7qAA).

I think it's acceptable. What do you think? @sosukesuzuki @kachkaev 

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
