### PR TITLE
feat(parser): add handleParseError property

### DIFF
--- a/changelog_unreleased/api/16787.md
+++ b/changelog_unreleased/api/16787.md
@@ -1,0 +1,24 @@
+#### Add handleParseError property (#16787 by @MariaSolOs)
+
+This change adds a new `plugins.parsers.handleParseError` property, allowing plugins to handle errors when generating the AST.
+
+Here's an example of how a plugin can use this property to prevent Prettier from crashing when parsing fails in GraphQL files:
+
+<!-- prettier-ignore -->
+```ts
+import { parsers } from "prettier/plugins/graphql";
+
+const graphqlParser = {
+  ...parsers.graphql,
+  // Do nothing when parsing fails.
+  handleParseError(error, text) {}
+}
+
+const plugin = {
+  parsers = {
+    graphql = graphqlParser
+  }
+}
+```
+
+Note that regardless of how the error is handled, Prettier will just output the original text.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -112,6 +112,7 @@ export const parsers = {
     locStart,
     locEnd,
     preprocess,
+    handleParseError,
   },
 };
 ```
@@ -139,6 +140,12 @@ _(Optional)_ The preprocess function can process the input text before passing i
 ```ts
 function preprocess(text: string, options: object): string;
 ```
+
+```ts
+function handleParseError(error: Error, text: string): void;
+```
+
+_(Optional)_ The handleParseError function can have custom error handling when a problem occurs when generating the AST. By default the error returned by `parse` will be thrown.
 
 ### `printers`
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -465,6 +465,7 @@ export interface Parser<T = any> {
   preprocess?:
     | ((text: string, options: ParserOptions<T>) => string)
     | undefined;
+  handleParseError?: ((error: Error, text: string) => void) | undefined;
 }
 
 export interface Printer<T = any> {

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -28,6 +28,10 @@ async function coreFormat(originalText, opts, addAlignmentSize = 0) {
 
   const { ast, text } = await parseText(originalText, opts);
 
+  if (!ast) {
+    return { formatted: text, cursorOffset: -1, comments: [] };
+  }
+
   if (opts.cursorOffset >= 0) {
     opts = {
       ...opts,

--- a/src/main/parse.js
+++ b/src/main/parse.js
@@ -18,7 +18,11 @@ async function parse(originalText, options) {
       options,
     );
   } catch (error) {
-    handleParseError(error, originalText);
+    if (typeof parser.handleParseError === "function") {
+      parser.handleParseError(error, originalText);
+    } else {
+      handleParseError(error, originalText);
+    }
   }
 
   return { text, ast };

--- a/website/versioned_docs/version-stable/plugins.md
+++ b/website/versioned_docs/version-stable/plugins.md
@@ -113,6 +113,7 @@ export const parsers = {
     locStart,
     locEnd,
     preprocess,
+    handleParseError,
   },
 };
 ```
@@ -140,6 +141,12 @@ _(Optional)_ The preprocess function can process the input text before passing i
 ```ts
 function preprocess(text: string, options: object): string;
 ```
+
+```ts
+function handleParseError(error: Error, text: string): void;
+```
+
+_(Optional)_ The handleParseError function can have custom error handling when a problem occurs when generating the AST. By default the error returned by `parse` will be thrown.
 
 ### `printers`
 


### PR DESCRIPTION
## Description

This PR adds a new `plugins.parsers.handleParseError` property, allowing plugins to handle errors when generating the AST.

## Motivation

Some languages like GraphQL have adopted practices in their ecosystem for various language features. An example is the use of `#import` comments in GraphQL files to import definitions from other files. Despite this being supported by various tooling, the official GraphQL parser will crash with such files that only contain "import comments" since the grammar requires a document to have at least one definition, and since Prettier uses its parser [here](https://github.com/prettier/prettier/blob/2f409df61dbfb725d8b874a6da9280045eae2891/src/language-graphql/parser-graphql.js#L38), this makes Prettier loudly crash with an error.

## Proposed solution

Despite the motivation above being exclusive to GraphQL, for Prettier's scope I believe it more suitable to offer a more flexible entry point for plugins to control what should happen when parsing fails. For example: If we want Prettier to silently do nothing, a plugin can simply have an empty `handleParseError` function.

Closes https://github.com/prettier/prettier/issues/6145 (and possibly more but I haven't looked carefully yet).

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
