### PR TITLE
Fix Angular HTML formatting to keep closing `</a>` tag on the same line

### DIFF
--- a/src/language-html/print/children.js
+++ b/src/language-html/print/children.js
@@ -68,6 +68,10 @@ function printChild(childPath, options, print) {
     ];
   }
 
+  if (child.type === "element" && child.name === "a") {
+    return group(print());
+  }
+
   return print();
 }
 

--- a/src/language-html/print/element.js
+++ b/src/language-html/print/element.js
@@ -154,6 +154,17 @@ function printElement(path, options, print) {
     );
   }
 
+  if (node.name === "a") {
+    return printTag([
+      forceBreakContent(node) ? breakParent : "",
+      printChildrenDoc([
+        printLineBeforeChildren(),
+        printChildren(path, options, print),
+      ]),
+      printLineAfterChildren(),
+    ]);
+  }
+
   return printTag([
     forceBreakContent(node) ? breakParent : "",
     printChildrenDoc([

--- a/tests/integration/__tests__/format.js
+++ b/tests/integration/__tests__/format.js
@@ -68,3 +68,36 @@ test("'Adjacent JSX' error should not be swallowed by Babel's error recovery", a
     prettier.format(input, { parser: "babel" }),
   ).rejects.toThrowErrorMatchingSnapshot();
 });
+
+test("angular parser should format inline elements without breaking closing tag onto a new line", async () => {
+  const input = `
+  <a
+    class="link-menu-item"
+    type="button"
+    cdkMenuItem
+    routerLinkActive="active"
+    [routerLinkActiveOptions]="{ exact: true }"
+    [routerLink]="['/link']">
+    {{ t('body.menu.open-funds') }}</a>
+  `;
+  expect(
+    await prettier.format(input, {
+      parser: "angular",
+      singleQuote: true,
+      arrowParens: "always",
+      semi: true,
+      trailingComma: "es5",
+      bracketSameLine: true,
+      printWidth: 140,
+    }),
+  ).toMatchInlineSnapshot(`
+    "<a
+      class='link-menu-item'
+      type='button'
+      cdkMenuItem
+      routerLinkActive='active'
+      [routerLinkActiveOptions]='{ exact: true }'
+      [routerLink]='['/link']'>
+      {{ t('body.menu.open-funds') }}</a>"
+  `);
+});


### PR DESCRIPTION
Related to #16788

Modify Prettier to format Angular HTML without breaking the closing `</a>` tag onto a new line.

* Update `src/language-html/print/children.js` to handle inline elements like `a` tags and keep them on the same line.
* Adjust `src/language-html/print/element.js` to ensure inline elements are not broken onto new lines.
* Update `tests/integration/__tests__/format.js` to add tests verifying the new behavior for inline elements like `a` tags.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/prettier/prettier/issues/16788?shareId=b015dcbd-2dcb-4a1a-a6d1-035ff510cbce).