### PR TITLE
Fix Yarn installation instructions to use yarn

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -142,7 +142,7 @@ For example, you can do the following to have Prettier run before each commit:
    ```bash
    yarn add --dev husky lint-staged
    npx husky init
-   node --eval "fs.writeFileSync('.husky/pre-commit','npx lint-staged\n')"
+   node --eval "fs.writeFileSync('.husky/pre-commit','yarn lint-staged\n')"
    ```
 
    > If you use Yarn 2, see https://typicode.github.io/husky/#/?id=yarn-2


### PR DESCRIPTION
The pre-commit hook currently specifies `npx` instead of `yarn` for the Yarn project.

## Description

Use the correct package manager for the Yarn installation instructions.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
