### PR TITLE
Remove outdated options for babel "flow" plugin

### DIFF
--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -221,11 +221,7 @@ const babelTSExpression = createBabelParser({
 });
 const babelFlow = createBabelParser({
   optionsCombinations: [
-    appendPlugins([
-      "jsx",
-      ["flow", { all: true, enums: true }],
-      "flowComments",
-    ]),
+    appendPlugins(["jsx", ["flow", { all: true }], "flowComments"]),
   ],
 });
 const babelEstree = createBabelParser({


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Part of #16801

[#​babel-16841](https://redirect.github.com/babel/babel/pull/16841) Always enable parsing of Flow enums

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
