### PR TITLE
Tell regexp-util to generate regex compatible with u flag

### DIFF
--- a/changelog_unreleased/markdown/16816.md
+++ b/changelog_unreleased/markdown/16816.md
@@ -2,7 +2,7 @@
 
 CJK characters outside of BMP and Ideographic Variation Sequences (IVS; variation selectors dedicated for han/kanji), which consume 2 characters in JavaScript string, have not been treated as CJK. This is due to the fact that Prettier has not passed the appropriate flag `"u"` to the `regexp-util` package.
 
-In the following example, “𠮷” (U+20BB7) is out of BMP, and “葛󠄀” is a combination of a han ”葛” (U+845B) in BMP and an IVS U+E0100. The latter requires a font with the support of Adobe Japan-1 (e.g. Yu Gothic UI and Source Han Sans) to be rendered as a form different from that of the character without IVS (葛).
+In the following example, “𠮷” (U+20BB7) is out of BMP, and “葛󠄀” is a combination of a han “葛” (U+845B) in BMP and an IVS U+E0100. The latter requires a font with the support of Adobe Japan-1 (e.g. Yu Gothic UI and Source Han Sans) to be rendered as a form different from that of the character without IVS (葛).
 
 <!-- prettier-ignore -->
 ```md

--- a/changelog_unreleased/markdown/16816.md
+++ b/changelog_unreleased/markdown/16816.md
@@ -1,0 +1,23 @@
+#### Tell regexp-util to generate regex compatible with u flag (#16816 by @tats-u)
+
+CJK characters outside of BMP and Ideographic Variation Sequences (IVS; variation selectors dedicated for han/kanji), which consume 2 characters in JavaScript string, have not been treated as CJK. This is due to the fact that Prettier has not passed the appropriate flag `"u"` to the `regexp-util` package.
+
+In the following example, “𠮷” (U+20BB7) is out of BMP, and “葛󠄀” is a combination of a han ”葛” (U+845B) in BMP and an IVS U+E0100. The latter requires a font with the support of Adobe Japan-1 (e.g. Yu Gothic UI and Source Han Sans) to be rendered as a form different from that of the character without IVS (葛).
+
+<!-- prettier-ignore -->
+```md
+<!-- Input (--prose-wrap=never) -->
+a 字 a 字 a 字
+𠮷
+𠮷
+葛󠄀
+葛󠄀
+終
+
+<!-- Prettier stable -->
+a 字 a 字 a 字 𠮷 𠮷 葛󠄀 葛󠄀 終
+
+<!-- Prettier main -->
+a 字 a 字 a 字𠮷𠮷葛󠄀葛󠄀終
+
+```

--- a/src/language-markdown/constants.evaluate.js
+++ b/src/language-markdown/constants.evaluate.js
@@ -21,7 +21,7 @@ const variationSelectorsCharset = unicodeRegex({
 });
 
 const CJK_REGEXP = new RegExp(
-  `(?:${cjkCharset.toString()})(?:${variationSelectorsCharset.toString()})?`,
+  `(?:${cjkCharset.toString("u")})(?:${variationSelectorsCharset.toString("u")})?`,
   "u",
 );
 
@@ -74,7 +74,7 @@ const unicodePunctuationClasses = [
 
 const PUNCTUATION_REGEXP = new RegExp(
   `(?:${[
-    new Charset(...asciiPunctuationCharacters).toRegExp().source,
+    new Charset(...asciiPunctuationCharacters).toRegExp("u").source,
     ...unicodePunctuationClasses.map(
       (charset) => `\\p{General_Category=${charset}}`,
     ),

--- a/tests/format/markdown/splitCjkText/non-bmp/format.test.js
+++ b/tests/format/markdown/splitCjkText/non-bmp/format.test.js
@@ -1,0 +1,19 @@
+// This preamble is unnecessary after #16805
+const preamble = "a 字 a 字 a 字";
+const code = `${preamble}\n${"葛\u{e0100}\n".repeat(3)}${"𠮷\n".repeat(2)}終\n`;
+const output = `${preamble}${"葛\u{e0100}".repeat(3)}${"𠮷".repeat(2)}終\n`;
+
+runFormatTest(
+  {
+    importMeta: import.meta,
+    snippets: [
+      {
+        code,
+        name: "Make sure non-BMP CJK characters are treated as CJK",
+        output,
+      },
+    ],
+  },
+  ["markdown"],
+  { proseWrap: "never" },
+);


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

non-BMP CJK characters and IVS are not recognized to CJK now.
`.toString` and `.toRegExp` in `regexp-util`.`CharSet`  generate regexps incompatible with the `u` flag by default.
We have to pass the `"u"` argument to make them compatible with `u`.

https://prettier.io/playground/#N4Igxg9gdgLgprEAuEBDABIdW10e79AOlIOYbgvHtGBa2UWZSADQgQAOMAltAM7KioBOvEAO4AFPgi4pUAG0GoAnlwYAjXqjABrODADKqALZwAMqyhxkAM2kc4y1Rq3amakwHNkMXgFcbIa3tbuXj5wAB5McLysBrDSACoRUHyscBKWUtYMHK5ScACKnhDwFlY+AFYcIdrZeQVFSGkZIACOtXDCAkwSaBwAtKZwACaD9CAeqKxSrgDCEHp6qMhoUlIjWVAuOQCCMB6sSp7wwhHGpsXpPgAWMHpSAOoXrPAcTmBw2uKPrABuj3KLYBxFCAvt4AJJQIawbRgSIsTYQ7QwOQ5M6NJgCay3VRMRamL4REYmay8GDtVAueaonxOXjExbzXjqAZCKAjdEmGC3VgDGAXZAADgADAxeHAWqxRWSKQt6iUGDBUEouTy+UgAEwMTzWWKK1JykBwPRKQZDAaGVDrTzkuAAMQgvHmO1ci1QBwgIAAvh6gA

https://prettier.io/playground/#N4Igxg9gdgLgprEAuEBDABIdW10e79AOlINohgAtuAAu0cVRVUSADQgQAOMAltAM7KioBO-CAHcACgIQ8UqADbDUATx5MARv1RgA1nBgBlVAFs4AGXZQ4yAGayucVeq07dLDWYDmyGPwCudkLYN2Tx8-OAAPFjh+diNYWQAVKKgBdjgpaxlbJi53GTgARW8IeCsbPwArLjDdXIKikqQMrJAAR3q4USEWKTQuAFpzOAATYcYQL1R2GXcAYQgDA1RkNBkZMZyoNzyAQRgvdhVveFEo03NSzL8ACxgDGQB1K-Z4LhcwOF1JZ-YAN2eFZZgLjKEA-XwASSgI1gujA0TY2yhuhgCjyF2aLCEtnu6hYy3MPyiYzMtn4ME6qDci3Rfhc-FJy0W-E0QxEUDGmLMMHu7CGMCuyAAHAAGJj8OBtdjiilUpaNMpMGCoFQ8vkCpAAJiY3ls8WV6QVIDgBhUwxGQ2MqE23kpcAAYhB+Is9u5lqgjhAQABfL1AA

https://prettier.io/playground/#N4Igxg9gdgLgprEAuEBDABIdW10e7gOlIEIbg7fuGmGDaIYALbgALtV2GBCviADQgQAOMAltAM7JQqAE4iIAdwAKohIJSoANhNQBPQewBGI1GADWcGAGVUAWzgAZHlDjIAZkv5wtO-YaOdd1gObIYIgFdnECdTHj9A4LgAD044ER5zWCUAFXioUR44eQdFJ3Z+H0U4AEUAiHh7R2CAK35ooyLS8sqkXPyQAEcWuClxTnk0fgBaGzgAEwm2EH9UHkUfAGEIU1NUZDRFRWnCqG9igEEYfx5NAPgpeKsbKrzggAsYU0UAdXueeH5PMDgjOQ+eAA3D6qDZgfgaECAoIASSgk1gRjACW4B3hRhgqmKtw6nHETheOk4GxsgPi02sThEMD6qG8axxwU8IipGzWIj040kUGmeOsMBePHGMHuyAAHAAGdgiODdHgy2n09ZtarsGCoTSC4WipAAJnYAScKQ1OVVIDgpk0E0m4wsqD2ATpcAAYhARGtjj4NqhzhAQABff1AA

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
