### PR TITLE
[V4] Replace `strip-ansi` with `stripVTControlCharacters` from `node:util`

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "remark-parse": "8.0.3",
     "sdbm": "2.0.0",
     "smol-toml": "1.3.3",
-    "strip-ansi": "7.1.0",
     "to-fast-properties": "4.0.0",
     "trim-newlines": "5.0.0",
     "typescript": "5.8.3",

--- a/src/cli/utilities/clear-stream-text.js
+++ b/src/cli/utilities/clear-stream-text.js
@@ -1,11 +1,11 @@
 import readline from "node:readline";
-import stripAnsi from "strip-ansi";
+import { stripVTControlCharacters } from "node:util";
 import wcwidth from "wcwidth.js";
 
 const countLines = (stream, text) => {
   const columns = stream.columns || 80;
   let lineCount = 0;
-  for (const line of stripAnsi(text).split("\n")) {
+  for (const line of stripVTControlCharacters(text).split("\n")) {
     lineCount += Math.max(1, Math.ceil(wcwidth(line) / columns));
   }
   return lineCount;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7185,7 +7185,6 @@ __metadata:
     serialize-javascript: "npm:6.0.2"
     smol-toml: "npm:1.3.3"
     snapshot-diff: "npm:0.10.0"
-    strip-ansi: "npm:7.1.0"
     tempy: "npm:3.1.0"
     tinybench: "npm:4.0.1"
     to-fast-properties: "npm:4.0.0"
@@ -7991,7 +7990,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:7.1.0, strip-ansi@npm:^7.0.1, strip-ansi@npm:^7.1.0":
+"strip-ansi@npm:^7.0.1, strip-ansi@npm:^7.1.0":
   version: 7.1.0
   resolution: "strip-ansi@npm:7.1.0"
   dependencies:


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
