### PR TITLE
Use compile cache

### DIFF
--- a/bin/prettier.cjs
+++ b/bin/prettier.cjs
@@ -4,7 +4,10 @@
 
 var nodeModule = require("module");
 
-if (typeof nodeModule.enableCompileCache === "function") {
+if (
+  process.env.NODE_ENV === "production" &&
+  typeof nodeModule.enableCompileCache === "function"
+) {
   nodeModule.enableCompileCache();
 }
 

--- a/bin/prettier.cjs
+++ b/bin/prettier.cjs
@@ -4,10 +4,7 @@
 
 var nodeModule = require("module");
 
-if (
-  process.env.NODE_ENV === "production" &&
-  typeof nodeModule.enableCompileCache === "function"
-) {
+if (typeof nodeModule.enableCompileCache === "function") {
   nodeModule.enableCompileCache();
 }
 

--- a/bin/prettier.cjs
+++ b/bin/prettier.cjs
@@ -2,6 +2,12 @@
 
 "use strict";
 
+var nodeModule = require("module");
+
+if (typeof nodeModule.enableCompileCache === "function") {
+  nodeModule.enableCompileCache();
+}
+
 var pleaseUpgradeNode = require("please-upgrade-node");
 var packageJson = require("../package.json");
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

https://nodejs.org/en/blog/release/v22.8.0#new-js-api-for-compile-cache

```console
$ hyperfine --warmup 3 --min-runs 100 "node dist-without-cache/bin/prettier.cjs -v"
Benchmark 1: node dist-without-cache/bin/prettier.cjs -v
  Time (mean ± σ):      87.6 ms ±   3.1 ms    [User: 67.8 ms, System: 22.9 ms]
  Range (min … max):    83.8 ms … 104.2 ms    100 run

$ hyperfine --warmup 3 --min-runs 100 "node dist-with-cache/bin/prettier.cjs -v"
Benchmark 1: node dist-with-cache/bin/prettier.cjs -v
  Time (mean ± σ):      75.9 ms ±   3.6 ms    [User: 56.5 ms, System: 22.5 ms]
  Range (min … max):    71.5 ms …  98.9 ms    100 runs
```

```console
$ hyperfine --warmup 3 --min-runs 100 "node dist-without-cache/bin/prettier.cjs index.js"
Benchmark 1: node dist-without-cache/bin/prettier.cjs index.js
  Time (mean ± σ):     133.1 ms ±   5.4 ms    [User: 109.1 ms, System: 29.2 ms]
  Range (min … max):   125.8 ms … 150.8 ms    100 runs

$ hyperfine --warmup 3 --min-runs 100 "node dist-with-cache/bin/prettier.cjs index.js"
Benchmark 1: node dist-with-cache/bin/prettier.cjs index.js
  Time (mean ± σ):     113.3 ms ±   6.8 ms    [User: 90.2 ms, System: 28.0 ms]
  Range (min … max):   106.5 ms … 159.6 ms    100 runs
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
