### PR TITLE
use package.json to determine build version

### DIFF
--- a/scripts/build/build-javascript-module.js
+++ b/scripts/build/build-javascript-module.js
@@ -241,7 +241,12 @@ function getEsbuildOptions({ file, files, cliOptions }) {
     external: ["pnpapi", ...(buildOptions.external ?? [])],
     // Disable esbuild auto discover `tsconfig.json` file
     tsconfigRaw: JSON.stringify({}),
-    target: [...(buildOptions.target ?? ["node14"])],
+    target: [
+      ...(buildOptions.target ??
+        Object.entries(packageJson.engines).map(
+          ([engine, version]) => engine + version.replace(/^>=/u, ""),
+        )),
+    ],
     logLevel: "error",
     format: file.output.format,
     outfile: path.join(DIST_DIR, cliOptions.saveAs ?? file.output.file),

--- a/scripts/build/build-javascript-module.js
+++ b/scripts/build/build-javascript-module.js
@@ -241,12 +241,11 @@ function getEsbuildOptions({ file, files, cliOptions }) {
     external: ["pnpapi", ...(buildOptions.external ?? [])],
     // Disable esbuild auto discover `tsconfig.json` file
     tsconfigRaw: JSON.stringify({}),
-    target: [
-      ...(buildOptions.target ??
-        Object.entries(packageJson.engines).map(
-          ([engine, version]) => engine + version.replace(/^>=/u, ""),
-        )),
-    ],
+    target:
+      buildOptions.target ??
+      Object.entries(packageJson.engines).map(
+        ([engine, version]) => engine + version.replace(/^>=/u, ""),
+      ),
     logLevel: "error",
     format: file.output.format,
     outfile: path.join(DIST_DIR, cliOptions.saveAs ?? file.output.file),


### PR DESCRIPTION
## Description

We already use `please-upgrade-node` and `package.json` => `engines` to determine Node.js support.
However the build script was hardcoded to build for Node 14.
Since `package.json` => `engines` mentions Node >= 18, we should do the same for our build targets in order to reduce the bundle size.

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
