### PR TITLE
docs: fix angular link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Prettier is an opinionated code formatter with support for:
 
 - JavaScript (including experimental features)
 - [JSX](https://facebook.github.io/jsx/)
-- [Angular](https://angular.io/)
+- [Angular](https://angular.dev/)
 - [Vue](https://vuejs.org/)
 - [Flow](https://flow.org/)
 - [TypeScript](https://www.typescriptlang.org/)

--- a/website/versioned_docs/version-stable/index.md
+++ b/website/versioned_docs/version-stable/index.md
@@ -8,7 +8,7 @@ Prettier is an opinionated code formatter with support for:
 
 - JavaScript (including experimental features)
 - [JSX](https://facebook.github.io/jsx/)
-- [Angular](https://angular.io/)
+- [Angular](https://angular.dev/)
 - [Vue](https://vuejs.org/)
 - [Flow](https://flow.org/)
 - [TypeScript](https://www.typescriptlang.org/)


### PR DESCRIPTION
## Description

Update the old link of angular.io to angular.dev

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).


**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
