### PR TITLE
Fix loading ESM-style shared config file in Node.js 23

### DIFF
--- a/changelog_unreleased/api/16857.md
+++ b/changelog_unreleased/api/16857.md
@@ -1,0 +1,12 @@
+#### Fix loading ESM-style shared config file in Node.js 23 (#16857 by @sosukesuzuki)
+
+In Prettier 3.3, attempting to load an ESM-style [shared config file](https://prettier.io/docs/en/sharing-configurations) in Node.js 23 resulted in the following warnings, preventing the options from being loaded:
+
+```
+[warn] Ignored unknown option { __esModule: true }.
+[warn] Ignored unknown option { default: { trailingComma: "es5", tabWidth: 4, singleQuote: true } }.
+```
+
+This issue was caused by a new module feature in Node.js 23, known as [`require(ESM)`](https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require). Prettier 3.4 resolves this problem, allowing the options to load correctly.
+
+For more details, please see https://github.com/prettier/prettier/issues/16812.

--- a/src/config/prettier-config/load-external-config.js
+++ b/src/config/prettier-config/load-external-config.js
@@ -15,7 +15,16 @@ async function loadExternalConfig(externalConfig, configFile) {
   3. is a dirname with index.js inside
   */
   try {
-    return requireFromFile(externalConfig, configFile);
+    const required = requireFromFile(externalConfig, configFile);
+    // Since Node.js v23 onwards, it is possible to load ESM using require.
+    // If that feature is enabled, it is necessary to return the default.
+    // https://github.com/prettier/prettier/issues/16812
+    // FIXME: We want to add tests but https://github.com/jestjs/jest/issues/15363 blocks
+    // @ts-expect-error
+    if (process.features.require_module && required.__esModule) {
+      return required.default;
+    }
+    return required;
   } catch (/** @type {any} */ error) {
     if (!requireErrorCodesShouldBeIgnored.has(error?.code)) {
       throw error;

--- a/src/config/prettier-config/load-external-config.js
+++ b/src/config/prettier-config/load-external-config.js
@@ -5,6 +5,7 @@ const requireErrorCodesShouldBeIgnored = new Set([
   "MODULE_NOT_FOUND",
   "ERR_REQUIRE_ESM",
   "ERR_PACKAGE_PATH_NOT_EXPORTED",
+  "ERR_REQUIRE_ASYNC_MODULE",
 ]);
 async function loadExternalConfig(externalConfig, configFile) {
   /*


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #16812

I don't add tests for this change due to https://github.com/jestjs/jest/issues/15363, but I was able to test it locally.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
