### PR TITLE
Remove unnecessary parentheses around assignment in `v-on`

### DIFF
--- a/changelog_unreleased/vue/16887.md
+++ b/changelog_unreleased/vue/16887.md
@@ -1,0 +1,19 @@
+#### Remove unnecessary parentheses around assignment in `v-on` (#16887 by @fisker)
+
+<!-- prettier-ignore -->
+```vue
+<!-- Input -->
+<template>
+  <button @click="foo += 2">Click</button>
+</template>
+
+<!-- Prettier stable -->
+<template>
+  <button @click="(foo += 2)">Click</button>
+</template>
+
+<!-- Prettier main -->
+<template>
+  <button @click="foo += 2">Click</button>
+</template>
+```

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -808,6 +808,10 @@ function needsParens(path, options) {
         return false;
       }
 
+      if (key === "node" && parent.type === "JsExpressionRoot") {
+        return false;
+      }
+
       return true;
     }
     case "ConditionalExpression":

--- a/tests/format/vue/event-binding/__snapshots__/format.test.js.snap
+++ b/tests/format/vue/event-binding/__snapshots__/format.test.js.snap
@@ -1,5 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`assignment.vue format 1`] = `
+====================================options=====================================
+parsers: ["vue"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<template>
+  <div>
+    <button @click="  foo   =   1  "></button>
+    <button @click="  foo   =   1;  "></button>
+    <button @click="  foo   +=   1  "></button>
+    <button @click="  foo   +=   1;  "></button>
+    <button @click="  foo   -=   1  "></button>
+    <button @click="  foo   -=   1;  "></button>
+    <button @click="  foo   *=   1  "></button>
+    <button @click="  foo   *=   1;  "></button>
+    <button @click="  foo   /=   1  "></button>
+    <button @click="  foo   /=   1;  "></button>
+    <button @click="  foo   %=   1  "></button>
+    <button @click="  foo   %=   1;  "></button>
+    <button @click="  foo   <<=   1  "></button>
+    <button @click="  foo   <<=   1;  "></button>
+    <button @click="  foo   >>=   1  "></button>
+    <button @click="  foo   >>=   1;  "></button>
+    <button @click="  foo   >>>=   1  "></button>
+    <button @click="  foo   >>>=   1;  "></button>
+    <button @click="  foo   |=   1  "></button>
+    <button @click="  foo   |=   1;  "></button>
+    <button @click="  foo   ^=   1  "></button>
+    <button @click="  foo   ^=   1;  "></button>
+    <button @click="  foo   &=   1  "></button>
+    <button @click="  foo   &=   1;  "></button>
+    <button @click="  foo   ||=   1  "></button>
+    <button @click="  foo   ||=   1;  "></button>
+    <button @click="  foo   &&=   1  "></button>
+    <button @click="  foo   &&=   1;  "></button>
+    <button @click="  foo   ??=   1  "></button>
+    <button @click="  foo   ??=   1;  "></button>
+  </div>
+</template>
+
+=====================================output=====================================
+<template>
+  <div>
+    <button @click="foo = 1"></button>
+    <button @click="foo = 1"></button>
+    <button @click="foo += 1"></button>
+    <button @click="foo += 1"></button>
+    <button @click="foo -= 1"></button>
+    <button @click="foo -= 1"></button>
+    <button @click="foo *= 1"></button>
+    <button @click="foo *= 1"></button>
+    <button @click="foo /= 1"></button>
+    <button @click="foo /= 1"></button>
+    <button @click="foo %= 1"></button>
+    <button @click="foo %= 1"></button>
+    <button @click="foo <<= 1"></button>
+    <button @click="foo <<= 1"></button>
+    <button @click="foo >>= 1"></button>
+    <button @click="foo >>= 1"></button>
+    <button @click="foo >>>= 1"></button>
+    <button @click="foo >>>= 1"></button>
+    <button @click="foo |= 1"></button>
+    <button @click="foo |= 1"></button>
+    <button @click="foo ^= 1"></button>
+    <button @click="foo ^= 1"></button>
+    <button @click="foo &= 1"></button>
+    <button @click="foo &= 1"></button>
+    <button @click="foo ||= 1"></button>
+    <button @click="foo ||= 1"></button>
+    <button @click="foo &&= 1"></button>
+    <button @click="foo &&= 1"></button>
+    <button @click="foo ??= 1"></button>
+    <button @click="foo ??= 1"></button>
+  </div>
+</template>
+
+================================================================================
+`;
+
 exports[`basic-ts.vue format 1`] = `
 ====================================options=====================================
 parsers: ["vue"]

--- a/tests/format/vue/event-binding/assignment.vue
+++ b/tests/format/vue/event-binding/assignment.vue
@@ -1,0 +1,34 @@
+<template>
+  <div>
+    <button @click="  foo   =   1  "></button>
+    <button @click="  foo   =   1;  "></button>
+    <button @click="  foo   +=   1  "></button>
+    <button @click="  foo   +=   1;  "></button>
+    <button @click="  foo   -=   1  "></button>
+    <button @click="  foo   -=   1;  "></button>
+    <button @click="  foo   *=   1  "></button>
+    <button @click="  foo   *=   1;  "></button>
+    <button @click="  foo   /=   1  "></button>
+    <button @click="  foo   /=   1;  "></button>
+    <button @click="  foo   %=   1  "></button>
+    <button @click="  foo   %=   1;  "></button>
+    <button @click="  foo   <<=   1  "></button>
+    <button @click="  foo   <<=   1;  "></button>
+    <button @click="  foo   >>=   1  "></button>
+    <button @click="  foo   >>=   1;  "></button>
+    <button @click="  foo   >>>=   1  "></button>
+    <button @click="  foo   >>>=   1;  "></button>
+    <button @click="  foo   |=   1  "></button>
+    <button @click="  foo   |=   1;  "></button>
+    <button @click="  foo   ^=   1  "></button>
+    <button @click="  foo   ^=   1;  "></button>
+    <button @click="  foo   &=   1  "></button>
+    <button @click="  foo   &=   1;  "></button>
+    <button @click="  foo   ||=   1  "></button>
+    <button @click="  foo   ||=   1;  "></button>
+    <button @click="  foo   &&=   1  "></button>
+    <button @click="  foo   &&=   1;  "></button>
+    <button @click="  foo   ??=   1  "></button>
+    <button @click="  foo   ??=   1;  "></button>
+  </div>
+</template>


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fix #16885

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
