### PR TITLE
Remove check on `TSImportType.isTypeOf`

### DIFF
--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -210,7 +210,6 @@ function printTypescript(path, options, print) {
       return [print("expression"), "!"];
     case "TSImportType":
       return [
-        !node.isTypeOf ? "" : "typeof ",
         "import(",
         print("argument"),
         ")",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

This property has been removed long time ago, https://github.com/typescript-eslint/typescript-eslint/pull/3076
Tests exits https://github.com/prettier/prettier/blob/d52e905869dffd6e870fed453f25aaf2f78b736c/tests/format/typescript/import-type/import-type.ts#L7

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
