### PR TITLE
Correct fit() for fill()

### DIFF
--- a/changelog_unreleased/javascript/16899.md
+++ b/changelog_unreleased/javascript/16899.md
@@ -1,0 +1,35 @@
+#### Fix non-idempotent formatting (#16899 by @seiyab)
+
+This bug fix is not language-specific. You may see similar change in any languages. This fixes regression in 3.4.0 so change caused by it should yield same formatting as 3.3.3.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+<div>
+  foo
+  <span>longlonglonglonglonglonglonglonglonglonglonglonglonglonglongl foo</span>
+  , abc
+</div>;
+
+// Prettier stable (first)
+<div>
+  foo
+  <span>
+    longlonglonglonglonglonglonglonglonglonglonglonglonglonglongl foo
+  </span>, abc
+</div>;
+
+// Prettier stable (second)
+<div>
+  foo
+  <span>longlonglonglonglonglonglonglonglonglonglonglonglonglonglongl foo</span>
+  , abc
+</div>;
+
+// Prettier main
+<div>
+  foo
+  <span>longlonglonglonglonglonglonglonglonglonglonglonglonglonglongl foo</span>
+  , abc
+</div>;
+```

--- a/src/document/printer.js
+++ b/src/document/printer.js
@@ -234,7 +234,8 @@ function fits(
       case DOC_TYPE_ARRAY:
       case DOC_TYPE_FILL: {
         const parts = docType === DOC_TYPE_ARRAY ? doc : doc.parts;
-        for (let i = parts.length - 1; i >= 0; i--) {
+        const end = doc[DOC_FILL_PRINTED_LENGTH] ?? 0;
+        for (let i = parts.length - 1; i >= end; i--) {
           cmds.push({ mode, doc: parts[i] });
         }
         break;

--- a/tests/format/jsx/text-wrap/__snapshots__/format.test.js.snap
+++ b/tests/format/jsx/text-wrap/__snapshots__/format.test.js.snap
@@ -21,35 +21,7 @@ function HelloWorld(   ) {
   )
 }
 
-function HelloWorld() {
-  return (
-    <div>
-      <div>
-        foo
-        <br />
-        bar{' '}
-        <span className="font-semibold">foobar foobar foobar foobar 12345</span>
-        , foobar foobar foobar
-      </div>
-    </div>
-  )
-}
-
 =====================================output=====================================
-function HelloWorld() {
-  return (
-    <div>
-      <div>
-        foo
-        <br />
-        bar{" "}
-        <span className="font-semibold">foobar foobar foobar foobar 12345</span>
-        , foobar foobar foobar
-      </div>
-    </div>
-  );
-}
-
 function HelloWorld() {
   return (
     <div>

--- a/tests/format/jsx/text-wrap/__snapshots__/format.test.js.snap
+++ b/tests/format/jsx/text-wrap/__snapshots__/format.test.js.snap
@@ -1,5 +1,72 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`issue-16897.js format 1`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function HelloWorld(   ) {
+  return (
+    <div>
+      <div>
+        foo
+        <br />
+        bar{' '}
+        <span className="font-semibold">
+          foobar foobar foobar foobar 12345
+        </span>, foobar foobar foobar
+      </div>
+    </div>
+  )
+}
+
+function HelloWorld() {
+  return (
+    <div>
+      <div>
+        foo
+        <br />
+        bar{' '}
+        <span className="font-semibold">foobar foobar foobar foobar 12345</span>
+        , foobar foobar foobar
+      </div>
+    </div>
+  )
+}
+
+=====================================output=====================================
+function HelloWorld() {
+  return (
+    <div>
+      <div>
+        foo
+        <br />
+        bar{" "}
+        <span className="font-semibold">foobar foobar foobar foobar 12345</span>
+        , foobar foobar foobar
+      </div>
+    </div>
+  );
+}
+
+function HelloWorld() {
+  return (
+    <div>
+      <div>
+        foo
+        <br />
+        bar{" "}
+        <span className="font-semibold">foobar foobar foobar foobar 12345</span>
+        , foobar foobar foobar
+      </div>
+    </div>
+  );
+}
+
+================================================================================
+`;
+
 exports[`test.js format 1`] = `
 ====================================options=====================================
 parsers: ["flow", "typescript"]

--- a/tests/format/jsx/text-wrap/issue-16897.js
+++ b/tests/format/jsx/text-wrap/issue-16897.js
@@ -12,17 +12,3 @@ function HelloWorld(   ) {
     </div>
   )
 }
-
-function HelloWorld() {
-  return (
-    <div>
-      <div>
-        foo
-        <br />
-        bar{' '}
-        <span className="font-semibold">foobar foobar foobar foobar 12345</span>
-        , foobar foobar foobar
-      </div>
-    </div>
-  )
-}

--- a/tests/format/jsx/text-wrap/issue-16897.js
+++ b/tests/format/jsx/text-wrap/issue-16897.js
@@ -1,0 +1,28 @@
+function HelloWorld(   ) {
+  return (
+    <div>
+      <div>
+        foo
+        <br />
+        bar{' '}
+        <span className="font-semibold">
+          foobar foobar foobar foobar 12345
+        </span>, foobar foobar foobar
+      </div>
+    </div>
+  )
+}
+
+function HelloWorld() {
+  return (
+    <div>
+      <div>
+        foo
+        <br />
+        bar{' '}
+        <span className="font-semibold">foobar foobar foobar foobar 12345</span>
+        , foobar foobar foobar
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Description

Fixes #16897
It was caused by https://github.com/prettier/prettier/pull/16595. I forgot to reflect change in fill doc to fit().

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] ~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).~
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
