### PR TITLE
Support Vue `.prop` shorthand

### DIFF
--- a/changelog_unreleased/vue/16920.md
+++ b/changelog_unreleased/vue/16920.md
@@ -1,0 +1,21 @@
+#### Support `.prop` shorthand (#16920 by @fisker)
+
+`.foo` is shorthand for `v-bind:foo.prop`. See [`v-bind` builtin directive](https://vuejs.org/api/built-in-directives.html#v-bind) for details.
+
+<!-- prettier-ignore -->
+```vue
+<!-- Input -->
+<template>
+  <button .disabled="   a &&b ">Click!</button>
+</template>
+
+<!-- Prettier stable -->
+<template>
+  <button .disabled="   a &&b ">Click!</button>
+</template>
+
+<!-- Prettier main -->
+<template>
+  <button .disabled="a && b">Click!</button>
+</template>
+```

--- a/src/language-html/embed/vue-attributes.js
+++ b/src/language-html/embed/vue-attributes.js
@@ -49,10 +49,15 @@ function printVueAttribute(path, options) {
   }
 
   /**
-   *     :class="vueExpression"
-   *     v-bind:id="vueExpression"
+   *     :property="vueExpression"
+   *     .property="vueExpression"
+   *     v-bind:property="vueExpression"
    */
-  if (attributeName.startsWith(":") || attributeName.startsWith("v-bind:")) {
+  if (
+    attributeName.startsWith(":") ||
+    attributeName.startsWith(".") ||
+    attributeName.startsWith("v-bind:")
+  ) {
     return (textToDoc) =>
       printVueVBindDirective(value, textToDoc, { parseWithTs });
   }

--- a/tests/format/vue/multiparser/__snapshots__/format.test.js.snap
+++ b/tests/format/vue/multiparser/__snapshots__/format.test.js.snap
@@ -285,6 +285,11 @@ printWidth: 80
     <div v-bind:id=" &apos;&quot;&apos;   +  id "></div>
     <div v-bind:id="  rawId | formatId "></div>
     <div v-bind:id=" ok ? 'YES' : 'NO' "></div>
+
+
+    <button :disabled="   a &&b "></button>
+    <button .disabled="   a &&b "></button>
+
     <button @click=" foo ( arg, 'string' ) "></button>
 </template>
 
@@ -297,6 +302,10 @@ printWidth: 80
   <div v-bind:id="'&quot;' + id"></div>
   <div v-bind:id="rawId | formatId"></div>
   <div v-bind:id="ok ? 'YES' : 'NO'"></div>
+
+  <button :disabled="a && b"></button>
+  <button .disabled="a && b"></button>
+
   <button @click="foo(arg, 'string')"></button>
 </template>
 

--- a/tests/format/vue/multiparser/template-bind.vue
+++ b/tests/format/vue/multiparser/template-bind.vue
@@ -5,6 +5,11 @@
     <div v-bind:id=" &apos;&quot;&apos;   +  id "></div>
     <div v-bind:id="  rawId | formatId "></div>
     <div v-bind:id=" ok ? 'YES' : 'NO' "></div>
+
+
+    <button :disabled="   a &&b "></button>
+    <button .disabled="   a &&b "></button>
+
     <button @click=" foo ( arg, 'string' ) "></button>
 </template>
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

`.foo` is shorthand for `v-bind:foo.prop`. See [`v-bind` builtin directive](https://vuejs.org/api/built-in-directives.html#v-bind) for details.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
