### PR TITLE
docs: Update Husky setup commands for PNPM users

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -151,7 +151,7 @@ For example, you can do the following to have Prettier run before each commit:
 
    ```bash
    pnpm add --save-dev husky lint-staged
-   npx husky init
+   pnpm exec husky init
    node --eval "fs.writeFileSync('.husky/pre-commit','pnpm exec lint-staged\n')"
    ```
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->
This PR adapts the Husky setup documentation for PNPM users by updating npm commands to their PNPM equivalents.

- Replace `npx husky init` with `pnpm exec husky init`

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
