### PR TITLE
Suppport const type params in Flow

### DIFF
--- a/changelog_unreleased/flow/16947.md
+++ b/changelog_unreleased/flow/16947.md
@@ -1,0 +1,12 @@
+#### Support `const` type parameters in Flow (#16947 by @gkz)
+
+<!-- prettier-ignore -->
+```jsx
+function f<const T>(): void {}
+
+// Prettier stable
+// Parse error
+
+// Prettier main
+function f<const T>(): void {}
+```

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "fast-json-stable-stringify": "2.1.0",
     "file-entry-cache": "9.1.0",
     "find-cache-dir": "5.0.0",
-    "flow-parser": "0.255.0",
+    "flow-parser": "0.257.0",
     "get-east-asian-width": "1.3.0",
     "get-stdin": "9.0.0",
     "graphql": "16.10.0",

--- a/src/language-js/print/type-parameters.js
+++ b/src/language-js/print/type-parameters.js
@@ -132,7 +132,7 @@ function printTypeParameter(path, options, print) {
   /**
    * @type {Doc[]}
    */
-  const parts = [node.type === "TSTypeParameter" && node.const ? "const " : ""];
+  const parts = [node.const ? "const " : ""];
 
   const name = node.type === "TSTypeParameter" ? print("name") : node.name;
 

--- a/tests/format/flow/type-parameters/flow-only/__snapshots__/format.test.js.snap
+++ b/tests/format/flow/type-parameters/flow-only/__snapshots__/format.test.js.snap
@@ -23,3 +23,48 @@ type A</* comment */ T: string> = B;
 
 ================================================================================
 `;
+
+exports[`const-type-params.js [babel-flow] format 1`] = `
+"Unexpected token, expected "," (2:14)
+  1 | // Simple
+> 2 | type T<const X> = X;
+    |              ^
+  3 | function f<const T>(): void {}
+  4 | <const T>(x: T) => {}
+  5 | class C<const T>{}
+Cause: Unexpected token, expected "," (2:13)"
+`;
+
+exports[`const-type-params.js format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// Simple
+type T<const X> = X;
+function f<const T>(): void {}
+<const T>(x: T) => {}
+class C<const T>{}
+
+// With variance
+type T<const +X> = X;
+function f<const +T>(): void {}
+<const +T>(x: T) => {}
+class C<const +T>{}
+
+=====================================output=====================================
+// Simple
+type T<const X> = X;
+function f<const T>(): void {}
+<const T>(x: T) => {};
+class C<const T> {}
+
+// With variance
+type T<const +X> = X;
+function f<const +T>(): void {}
+<const +T>(x: T) => {};
+class C<const +T> {}
+
+================================================================================
+`;

--- a/tests/format/flow/type-parameters/flow-only/const-type-params.js
+++ b/tests/format/flow/type-parameters/flow-only/const-type-params.js
@@ -1,0 +1,11 @@
+// Simple
+type T<const X> = X;
+function f<const T>(): void {}
+<const T>(x: T) => {}
+class C<const T>{}
+
+// With variance
+type T<const +X> = X;
+function f<const +T>(): void {}
+<const +T>(x: T) => {}
+class C<const +T>{}

--- a/tests/format/flow/type-parameters/flow-only/format.test.js
+++ b/tests/format/flow/type-parameters/flow-only/format.test.js
@@ -1,1 +1,5 @@
-runFormatTest(import.meta, ["flow"]);
+runFormatTest(import.meta, ["flow"], {
+  errors: {
+    "babel-flow": ["const-type-params.js"],
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4341,10 +4341,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-parser@npm:0.255.0":
-  version: 0.255.0
-  resolution: "flow-parser@npm:0.255.0"
-  checksum: 10/7570e9a2256086d3d011707822315695e1107665b81e30919347cea7db1d95ad0dd8bc33e0fcce114b35dcadbb614e8f2604647f8f856afdb4eefc3f6755e666
+"flow-parser@npm:0.257.0":
+  version: 0.257.0
+  resolution: "flow-parser@npm:0.257.0"
+  checksum: 10/5b175d25264a1a9ec393f240042c4e4de131be3df6b2fef73ac4f0ded44e3cf7f95d0a2783a78110aabf8bcb72728e6baa9d059ff826f79f79976328926ff742
   languageName: node
   linkType: hard
 
@@ -7313,7 +7313,7 @@ __metadata:
     fast-json-stable-stringify: "npm:2.1.0"
     file-entry-cache: "npm:9.1.0"
     find-cache-dir: "npm:5.0.0"
-    flow-parser: "npm:0.255.0"
+    flow-parser: "npm:0.257.0"
     get-east-asian-width: "npm:1.3.0"
     get-stdin: "npm:9.0.0"
     globals: "npm:15.12.0"


### PR DESCRIPTION
## Description

Adds support for `const` type params in Flow.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
