### PR TITLE
Use ESM entrypoint for `require(ESM)`

### DIFF
--- a/changelog_unreleased/misc/16958.md
+++ b/changelog_unreleased/misc/16958.md
@@ -1,4 +1,4 @@
-#### Use ESM entrypoint for require if require(ESM) is enabled (#16958 bu @tats-u)
+#### Use ESM entrypoint for require if require(ESM) is enabled (#16958 by @tats-u)
 
 Node.js 22.12 or later can (experimentally) load ESM modules with `require` function. This change enables `require` to load Prettier without the CommonJS entrypoint with almost only the ability to import the ESM entrypoint.
 

--- a/changelog_unreleased/misc/16958.md
+++ b/changelog_unreleased/misc/16958.md
@@ -1,4 +1,4 @@
-#### Use ESM entrypoint for require if require(ESM) is enabled (#16958 by @tats-u)
+#### Use ESM entrypoint for `require(ESM)` (#16958 by @tats-u)
 
 Node.js 22.12 or later [can (experimentally) load ESM modules with `require` function](https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require) without runtime flags. This change enables `require` to load Prettier without the CommonJS entrypoint with almost only the ability to import the ESM entrypoint.
 

--- a/changelog_unreleased/misc/16958.md
+++ b/changelog_unreleased/misc/16958.md
@@ -1,11 +1,5 @@
 #### Use ESM entrypoint for require if require(ESM) is enabled (#16958 by @tats-u)
 
-Node.js 22.12 or later can (experimentally) load ESM modules with `require` function. This change enables `require` to load Prettier without the CommonJS entrypoint with almost only the ability to import the ESM entrypoint.
+Node.js 22.12 or later [can (experimentally) load ESM modules with `require` function](https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require). This change enables `require` to load Prettier without the CommonJS entrypoint with almost only the ability to import the ESM entrypoint.
 
-The feature to load ES modules with `require` is not completely stable yet (but thought to be more stable than other experimental features that require flag arguments), so the following warning is now displayed when you load Prettier with `require`:
-
-```
-(node:23928) ExperimentalWarning: The REPL is loading ES Module path/to/node_modules/prettier/index.mjs using require().
-Support for loading ES Module in require() is an experimental feature and might change at any time
-(Use `node --trace-warnings ...` to show where the warning was created)
-```
+The feature to load ES modules with `require` is not completely stable but can be used without ExperimentalWarning as of Node 22.13.

--- a/changelog_unreleased/misc/16958.md
+++ b/changelog_unreleased/misc/16958.md
@@ -1,0 +1,11 @@
+#### Use ESM entrypoint for require if require(ESM) is enabled (#16958 bu @tats-u)
+
+Node.js 22.12 or later can (experimentally) load ESM modules with `require` function. This change enables `require` to load Prettier without the CommonJS entrypoint with almost only the ability to import the ESM entrypoint.
+
+The feature to load ES modules with `require` is not completely stable yet (but thought to be more stable than other experimental features that require flag arguments), so the following warning is now displayed when you load Prettier with `require`:
+
+```
+(node:23928) ExperimentalWarning: The REPL is loading ES Module path/to/node_modules/prettier/index.mjs using require().
+Support for loading ES Module in require() is an experimental feature and might change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+```

--- a/changelog_unreleased/misc/16958.md
+++ b/changelog_unreleased/misc/16958.md
@@ -1,5 +1,5 @@
 #### Use ESM entrypoint for require if require(ESM) is enabled (#16958 by @tats-u)
 
-Node.js 22.12 or later [can (experimentally) load ESM modules with `require` function](https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require). This change enables `require` to load Prettier without the CommonJS entrypoint with almost only the ability to import the ESM entrypoint.
+Node.js 22.12 or later [can (experimentally) load ESM modules with `require` function](https://nodejs.org/api/modules.html#loading-ecmascript-modules-using-require) without runtime flags. This change enables `require` to load Prettier without the CommonJS entrypoint with almost only the ability to import the ESM entrypoint.
 
 The feature to load ES modules with `require` is not completely stable but can be used without ExperimentalWarning as of Node 22.13.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./src/index.d.ts",
+      "module-sync": "./src/index.js",
       "require": "./src/index.cjs",
       "default": "./src/index.js"
     },

--- a/scripts/build/build-package-json.js
+++ b/scripts/build/build-package-json.js
@@ -56,12 +56,14 @@ async function buildPackageJson({ file, files }) {
           .filter((file) => file.output.format === "umd")
           .map((file) => {
             const basename = path.basename(file.output.file, ".js");
+            const mjsPath = `./${file.output.file.replace(/\.js$/u, ".mjs")}`;
             return [
               file.isPlugin ? `./plugins/${basename}` : `./${basename}`,
               {
                 types: `./${file.output.file.replace(/\.js$/u, ".d.ts")}`,
+                "module-sync": mjsPath,
                 require: `./${file.output.file}`,
-                default: `./${file.output.file.replace(/\.js$/u, ".mjs")}`,
+                default: mjsPath,
               },
             ];
           }),

--- a/scripts/build/build-package-json.js
+++ b/scripts/build/build-package-json.js
@@ -42,6 +42,7 @@ async function buildPackageJson({ file, files }) {
     exports: {
       ".": {
         types: "./index.d.ts",
+        "module-sync": "./index.mjs",
         require: "./index.cjs",
         browser: {
           import: "./standalone.mjs",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Pros:

- The extra process in `index.cjs` will be skipped for Node 22.12 or later or bundlers supporting sync ESMs.
- Can be clarify that Prettier can be `require(ESM)`ed because it doesn't contain top-level awaits.

Cons:

~~The following unpleasant warning will be out when we run `require("prettier")`:~~ Only 22.12.x

```
(node:23928) ExperimentalWarning: The REPL is loading ES Module I:\prettier\src\index.js using require().
Support for loading ES Module in require() is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
```

~~We may not be possible to accept this PR now due to this.~~
~~If require(ESM) is stable in the future (Node 24?), we will be able to merge without hesitation.~~
The warning is not shown since 22.13, so we don't have to care about this now.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- ~~I’ve added tests to confirm my change works.~~
- ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).~~
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
