### PR TITLE
Disable CI on MacOS x Node.js

### DIFF
--- a/.github/workflows/prod-test.yml
+++ b/.github/workflows/prod-test.yml
@@ -74,9 +74,10 @@ jobs:
             node: "18"
           - os: "ubuntu-latest"
             node: "16"
-          # Tests on Intel Mac x Node.js 14
-          - os: "macos-13"
-            node: "14"
+          # Tests on Intel Mac x Node.js 14 ( https://github.com/prettier/prettier/issues/16248 )
+          # We are disabling MacOS x Node.js 14 temporary ( https://github.com/prettier/prettier/issues/16964 )
+          # - os: "macos-13"
+          #   node: "14"
         # setup-node does not support Node.js 14 x M1 Mac
         exclude:
           - os: "macos-latest"


### PR DESCRIPTION
## Description

Consistently failing CI are harmful

context: https://github.com/prettier/prettier/issues/16964

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
