### PR TITLE
Replace `chalk` with `node-style-text` in release script

### DIFF
--- a/scripts/release/package.json
+++ b/scripts/release/package.json
@@ -5,15 +5,15 @@
     "test": "node --test"
   },
   "dependencies": {
-    "chalk": "5.3.0",
     "enquirer": "2.4.1",
     "execa": "9.5.1",
     "fast-glob": "3.3.3",
+    "node-style-text": "0.0.6",
     "outdent": "0.8.0",
     "semver": "7.6.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "packageManager": "yarn@4.6.0"
 }

--- a/scripts/release/steps/generate-bundles.js
+++ b/scripts/release/steps/generate-bundles.js
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import styleText from "node-style-text";
 import { logPromise, readJson, runYarn } from "../utils.js";
 
 export default async function generateBundles({ dry, version, manual }) {
@@ -24,5 +24,5 @@ export default async function generateBundles({ dry, version, manual }) {
     /* shouldSkip */ dry,
   );
 
-  console.log(chalk.green.bold("Build successful!\n"));
+  console.log(styleText.green.bold("Build successful!\n"));
 }

--- a/scripts/release/steps/post-publish-steps.js
+++ b/scripts/release/steps/post-publish-steps.js
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import styleText from "node-style-text";
 import outdent from "outdent";
 import { fetchText, logPromise, writeFile } from "../utils.js";
 
@@ -27,11 +27,11 @@ async function checkSchema() {
   );
 
   return outdent`
-    ${chalk.bold.underline(
+    ${styleText.bold.underline(
       "The schema in {yellow SchemaStore",
     )} needs an update.}
-    - Open ${chalk.cyan.underline(EDIT_URL)}
-    - Open ${chalk.cyan.underline("/.tmp/schema/prettierrc.json")} file and copy the content
+    - Open ${styleText.cyan.underline(EDIT_URL)}
+    - Open ${styleText.cyan.underline("/.tmp/schema/prettierrc.json")} file and copy the content
     - Paste it on GitHub interface
     - Open a PR
   `;
@@ -39,15 +39,15 @@ async function checkSchema() {
 
 function twitterAnnouncement() {
   return outdent`
-    ${chalk.bold.underline("Announce on Twitter")}
-    - Open ${chalk.cyan.underline("https://tweetdeck.twitter.com")}
+    ${styleText.bold.underline("Announce on Twitter")}
+    - Open ${styleText.cyan.underline("https://tweetdeck.twitter.com")}
     - Make sure you are tweeting from the {yellow @PrettierCode} account.
     - Tweet about the release, including the blog post URL.
   `;
 }
 
 export default async function postPublishSteps({ dry, next }) {
-  console.log(chalk.bold.green("The script has finished!\n"));
+  console.log(styleText.bold.green("The script has finished!\n"));
 
   if (dry || next) {
     return;
@@ -57,7 +57,7 @@ export default async function postPublishSteps({ dry, next }) {
 
   console.log(
     outdent`
-      ${chalk.yellow.bold(
+      ${styleText.yellow.bold(
         `The following ${
           steps.length === 1 ? "step is" : "steps are"
         } optional.`,

--- a/scripts/release/steps/show-instructions-after-npm-publish.js
+++ b/scripts/release/steps/show-instructions-after-npm-publish.js
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import styleText from "node-style-text";
 import outdent from "outdent";
 import semver from "semver";
 import {
@@ -39,7 +39,7 @@ export default async function showInstructionsAfterNpmPublish({
   next,
 }) {
   if (next) {
-    console.log(`${chalk.green.bold(`Prettier ${version} published!`)}`);
+    console.log(`${styleText.green.bold(`Prettier ${version} published!`)}`);
     await waitForEnter();
     return;
   }
@@ -47,13 +47,13 @@ export default async function showInstructionsAfterNpmPublish({
   const releaseUrl = getReleaseUrl(version, previousVersion);
   console.log(
     outdent`
-      ${chalk.green.bold(`Prettier ${version} published!`)}
+      ${styleText.green.bold(`Prettier ${version} published!`)}
 
-      ${chalk.yellow.bold("Some manual steps are necessary.")}
+      ${styleText.yellow.bold("Some manual steps are necessary.")}
 
-      ${chalk.bold.underline("Create a GitHub Release")}
-      - Go to ${chalk.cyan.underline(releaseUrl)}
-      - Press ${chalk.bgGreen.black("Publish release ")}
+      ${styleText.bold.underline("Create a GitHub Release")}
+      - Go to ${styleText.cyan.underline(releaseUrl)}
+      - Press ${styleText.bgGreen.black("Publish release")}
 
       After that, we can proceed to bump this repo's Prettier dependency.
     `,

--- a/scripts/release/steps/update-changelog.js
+++ b/scripts/release/steps/update-changelog.js
@@ -1,6 +1,6 @@
 import fs from "node:fs";
-import chalk from "chalk";
 import { execa } from "execa";
+import styleText from "node-style-text";
 import semver from "semver";
 import {
   getBlogPostInfo,
@@ -51,9 +51,9 @@ export default async function updateChangelog({
       return;
     }
     console.warn(
-      `${chalk.yellow("warning")} The file ${chalk.bold(
+      `${styleText.yellow("warning")} The file ${styleText.bold(
         blogPost.file,
-      )} doesn't exist, but it will be referenced in ${chalk.bold(
+      )} doesn't exist, but it will be referenced in ${styleText.bold(
         "CHANGELOG.md",
       )}. Make sure to create it later.`,
     );

--- a/scripts/release/steps/update-dependents-count.js
+++ b/scripts/release/steps/update-dependents-count.js
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import styleText from "node-style-text";
 import { fetchText, logPromise, processFile, runGit } from "../utils.js";
 
 async function update() {
@@ -79,6 +79,6 @@ export default async function updateDependentsCount({ dry, next }) {
   try {
     await update();
   } catch (error) {
-    console.log(chalk.red.bold(error.message));
+    console.log(styleText.red.bold(error.message));
   }
 }

--- a/scripts/release/steps/validate-new-version.js
+++ b/scripts/release/steps/validate-new-version.js
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import styleText from "node-style-text";
 import semver from "semver";
 
 export default function validateNewVersion({ version, previousVersion, next }) {
@@ -8,19 +8,19 @@ export default function validateNewVersion({ version, previousVersion, next }) {
 
   if (!semver.valid(version)) {
     throw new Error(
-      `Invalid version '${chalk.red.underline(version)}' specified`,
+      `Invalid version '${styleText.red.underline(version)}' specified`,
     );
   }
 
   if (!semver.gt(version, previousVersion)) {
     throw new Error(
-      `Version '${chalk.yellow.underline(version)}' has already been published`,
+      `Version '${styleText.yellow.underline(version)}' has already been published`,
     );
   }
 
   if (next && semver.prerelease(version) === null) {
     throw new Error(
-      `Version '${chalk.yellow.underline(
+      `Version '${styleText.yellow.underline(
         version,
       )}' is not a prerelease version`,
     );

--- a/scripts/release/steps/wait-for-bot-release.js
+++ b/scripts/release/steps/wait-for-bot-release.js
@@ -1,4 +1,4 @@
-import chalk from "chalk";
+import styleText from "node-style-text";
 import outdent from "outdent";
 import { logPromise, waitForEnter } from "../utils.js";
 
@@ -34,10 +34,10 @@ export default async function waitForBotRelease({ dry, version, next }) {
   if (!(await checkBotPermission())) {
     console.log(
       outdent`
-        1. Go to ${chalk.green.underline(
+        1. Go to ${styleText.green.underline(
           "https://www.npmjs.com/package/prettier/access",
         )}
-        2. Add "${chalk.yellow("prettier-bot")}" as prettier package maintainer.
+        2. Add "${styleText.yellow("prettier-bot")}" as prettier package maintainer.
       `,
     );
 
@@ -46,12 +46,12 @@ export default async function waitForBotRelease({ dry, version, next }) {
 
   console.log(
     outdent`
-      1. Go to ${chalk.green.underline(
+      1. Go to ${styleText.green.underline(
         "https://www.npmjs.com/package/prettier/access",
       )}
-      2. Make sure "${chalk.yellow(
+      2. Make sure "${styleText.yellow(
         "Publishing access",
-      )}" section is set to "${chalk.yellow(
+      )}" section is set to "${styleText.yellow(
         "Require two-factor authentication or an automation or granular access token",
       )}".
     `,
@@ -61,16 +61,16 @@ export default async function waitForBotRelease({ dry, version, next }) {
 
   console.log(
     outdent`
-      1. Go to ${chalk.green.underline(
+      1. Go to ${styleText.green.underline(
         "https://github.com/prettier/release-workflow/actions/workflows/release.yml",
       )}
-      2. Click "${chalk.green(
+      2. Click "${styleText.green(
         "Run workflow",
-      )}" button, type "${chalk.yellow.underline(
+      )}" button, type "${styleText.yellow.underline(
         version,
       )}" in "Version to release", ${
         next ? 'check only "Unstable version"' : "uncheck all checkboxes"
-      }, hit the "${chalk.bgGreen("Run workflow")}" button.
+      }, hit the "${styleText.bgGreen("Run workflow")}" button.
     `,
   );
 

--- a/scripts/release/tests/validate-new-version.test.js
+++ b/scripts/release/tests/validate-new-version.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import chalk from "chalk";
+import styleText from "node-style-text";
 import validateNewVersion from "../steps/validate-new-version.js";
 
 describe("validate-new-version", () => {
@@ -17,7 +17,9 @@ describe("validate-new-version", () => {
       () => {
         validateNewVersion({ version: "foo" });
       },
-      { message: `Invalid version '${chalk.red.underline("foo")}' specified` },
+      {
+        message: `Invalid version '${styleText.red.underline("foo")}' specified`,
+      },
     );
   });
   it("throws error when version isn't greater than prev version", () => {
@@ -26,7 +28,7 @@ describe("validate-new-version", () => {
         validateNewVersion({ version: "0.0.1", previousVersion: "0.0.2" });
       },
       {
-        message: `Version '${chalk.yellow(
+        message: `Version '${styleText.yellow(
           "0.0.1",
         )}' has already been published`,
       },

--- a/scripts/release/tests/validate-new-version.test.js
+++ b/scripts/release/tests/validate-new-version.test.js
@@ -28,7 +28,7 @@ describe("validate-new-version", () => {
         validateNewVersion({ version: "0.0.1", previousVersion: "0.0.2" });
       },
       {
-        message: `Version '${styleText.yellow(
+        message: `Version '${styleText.yellow.underline(
           "0.0.1",
         )}' has already been published`,
       },

--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -2,8 +2,8 @@ import fs from "node:fs";
 import path from "node:path";
 import readline from "node:readline";
 import url from "node:url";
-import chalk from "chalk";
 import { execa } from "execa";
+import styleText from "node-style-text";
 import outdent from "outdent";
 import getFormattedDate from "./get-formatted-date.js";
 
@@ -23,7 +23,7 @@ const padStatusText = (text) => {
 };
 const status = {};
 for (const { color, text } of statusConfig) {
-  status[text] = chalk[color].black(padStatusText(text));
+  status[text] = styleText[color].black(padStatusText(text));
 }
 
 function fitTerminal(input, suffix = "") {
@@ -31,7 +31,7 @@ function fitTerminal(input, suffix = "") {
   const WIDTH = columns - maxLength + 1;
   if (input.length < WIDTH) {
     const repeatCount = Math.max(WIDTH - input.length - 1 - suffix.length, 0);
-    input += chalk.dim(".").repeat(repeatCount) + suffix;
+    input += styleText.dim(".").repeat(repeatCount) + suffix;
   }
   return input;
 }
@@ -73,7 +73,7 @@ function runGit(args, options) {
 
 function waitForEnter() {
   console.log();
-  console.log(chalk.gray("Press ENTER to continue."));
+  console.log(styleText.gray("Press ENTER to continue."));
 
   process.stdin.setRawMode(true);
 

--- a/scripts/release/yarn.lock
+++ b/scripts/release/yarn.lock
@@ -69,13 +69,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:5.3.0":
-  version: 5.3.0
-  resolution: "chalk@npm:5.3.0"
-  checksum: 10/6373caaab21bd64c405bfc4bd9672b145647fc9482657b5ea1d549b3b2765054e9d3d928870cdf764fb4aad67555f5061538ff247b8310f110c5c888d92397ea
-  languageName: node
-  linkType: hard
-
 "cross-spawn@npm:^7.0.3":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
@@ -251,6 +244,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-style-text@npm:0.0.6":
+  version: 0.0.6
+  resolution: "node-style-text@npm:0.0.6"
+  checksum: 10/9eeb6a054597ed122f16ec1fc404a687f75c857655cc1478b0f8b6ccd14f8badfbaeacc0b9cd5dcf84b8286986e52c5feffbf070ed4568acb7f4eb2f1cb6a5a3
+  languageName: node
+  linkType: hard
+
 "npm-run-path@npm:^6.0.0":
   version: 6.0.0
   resolution: "npm-run-path@npm:6.0.0"
@@ -323,10 +323,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    chalk: "npm:5.3.0"
     enquirer: "npm:2.4.1"
     execa: "npm:9.5.1"
     fast-glob: "npm:3.3.3"
+    node-style-text: "npm:0.0.6"
     outdent: "npm:0.8.0"
     semver: "npm:7.6.3"
   languageName: unknown


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

 `node-style-text` is built on top of `node:util.styleText`, but provide chainable API, see <https://github.com/fisker/node-style-text#motivation>

It's super small (<300 B)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
