### PR TITLE
Add tests for `import.defer()`

### DIFF
--- a/tests/format/js/deferred-import-evaluation/__snapshots__/format.test.js.snap
+++ b/tests/format/js/deferred-import-evaluation/__snapshots__/format.test.js.snap
@@ -1,5 +1,81 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`dynamic-import.js [acorn] format 1`] = `
+"The only valid meta property for import is 'import.meta' (1:8)
+> 1 | import.defer("foo");
+    |        ^
+  2 |
+Cause: The only valid meta property for import is 'import.meta' (1:7)"
+`;
+
+exports[`dynamic-import.js [espree] format 1`] = `
+"The only valid meta property for import is 'import.meta' (1:8)
+> 1 | import.defer("foo");
+    |        ^
+  2 |
+Cause: The only valid meta property for import is 'import.meta'"
+`;
+
+exports[`dynamic-import.js [meriyah] format 1`] = `
+"The only valid meta property for import is 'import.meta' (1:8)
+> 1 | import.defer("foo");
+    |        ^^^^^
+  2 |
+Cause: [1:7-1:12]: The only valid meta property for import is 'import.meta'"
+`;
+
+exports[`dynamic-import.js format 1`] = `
+====================================options=====================================
+parsers: ["babel"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+import.defer("foo");
+
+=====================================output=====================================
+import.defer("foo");
+
+================================================================================
+`;
+
+exports[`dynamic-import-attributes-expression.js [acorn] format 1`] = `
+"The only valid meta property for import is 'import.meta' (1:8)
+> 1 | import.defer("x", { with: { attr: "val" } });
+    |        ^
+  2 |
+Cause: The only valid meta property for import is 'import.meta' (1:7)"
+`;
+
+exports[`dynamic-import-attributes-expression.js [espree] format 1`] = `
+"The only valid meta property for import is 'import.meta' (1:8)
+> 1 | import.defer("x", { with: { attr: "val" } });
+    |        ^
+  2 |
+Cause: The only valid meta property for import is 'import.meta'"
+`;
+
+exports[`dynamic-import-attributes-expression.js [meriyah] format 1`] = `
+"The only valid meta property for import is 'import.meta' (1:8)
+> 1 | import.defer("x", { with: { attr: "val" } });
+    |        ^^^^^
+  2 |
+Cause: [1:7-1:12]: The only valid meta property for import is 'import.meta'"
+`;
+
+exports[`dynamic-import-attributes-expression.js format 1`] = `
+====================================options=====================================
+parsers: ["babel"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+import.defer("x", { with: { attr: "val" } });
+
+=====================================output=====================================
+import.defer("x", { with: { attr: "val" } });
+
+================================================================================
+`;
+
 exports[`import-defer.js [acorn] format 1`] = `
 "Unexpected token (1:14)
 > 1 | import defer * as ns from "x";

--- a/tests/format/js/deferred-import-evaluation/dynamic-import-attributes-expression.js
+++ b/tests/format/js/deferred-import-evaluation/dynamic-import-attributes-expression.js
@@ -1,0 +1,1 @@
+import.defer("x", { with: { attr: "val" } });

--- a/tests/format/js/deferred-import-evaluation/dynamic-import.js
+++ b/tests/format/js/deferred-import-evaluation/dynamic-import.js
@@ -1,0 +1,1 @@
+import.defer("foo");

--- a/tests/format/js/deferred-import-evaluation/format.test.js
+++ b/tests/format/js/deferred-import-evaluation/format.test.js
@@ -1,6 +1,8 @@
 const importDeferTests = [
   "import-defer.js",
   "import-defer-attributes-declaration.js",
+  "dynamic-import.js",
+  "dynamic-import-attributes-expression.js",
 ];
 const invalidSyntaxTests = ["no-default.js", "no-named.js"];
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixtures copied from https://github.com/babel/babel/tree/6516c18c825249c0d44179c9ec8745544e1a638b/packages/babel-parser/test/fixtures/experimental/deferred-import-evaluation

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
