### PR TITLE
Make `prettier.util` and `prettier.doc` available in development cjs version on Node.js>=22

### DIFF
--- a/src/index.cjs
+++ b/src/index.cjs
@@ -45,6 +45,12 @@ if (process.env.NODE_ENV === "production") {
   Object.defineProperties(prettier, {
     util: {
       get() {
+        try {
+          return require("./utils/public.js");
+        } catch {
+          // No op
+        }
+
         throw new Error(
           "prettier.util is not available in development CommonJS version",
         );
@@ -52,6 +58,12 @@ if (process.env.NODE_ENV === "production") {
     },
     doc: {
       get() {
+        try {
+          return require("./document/public.js");
+        } catch {
+          // No op
+        }
+
         throw new Error(
           "prettier.doc is not available in development CommonJS version",
         );


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Note this change only effect `yarn add prettier@prettier/prettier`, the bundled version already available.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
