### PR TITLE
[V4] Replace `get-stdin` with native alternative

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "find-cache-directory": "6.0.0",
     "flow-parser": "0.266.1",
     "get-east-asian-width": "1.3.0",
-    "get-stdin": "9.0.0",
     "graphql": "16.10.0",
     "hermes-parser": "0.27.0",
     "html-element-attributes": "3.4.0",

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import getStdin from "get-stdin";
 import * as prettier from "../index.js";
 import { expandPatterns } from "./expand-patterns.js";
 import findCacheFile from "./find-cache-file.js";
@@ -13,6 +12,7 @@ import {
   errors,
   picocolors,
 } from "./prettier-internal.js";
+import getStdin from "./utilities/get-stdin.js";
 import { normalizeToPosix, statSafe } from "./utils.js";
 
 function diff(a, b) {

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import streamConsumers from "node:stream/consumers";
 import * as prettier from "../index.js";
 import { expandPatterns } from "./expand-patterns.js";
 import findCacheFile from "./find-cache-file.js";
@@ -12,7 +13,6 @@ import {
   errors,
   picocolors,
 } from "./prettier-internal.js";
-import getStdin from "./utilities/get-stdin.js";
 import { normalizeToPosix, statSafe } from "./utils.js";
 
 function diff(a, b) {
@@ -230,7 +230,7 @@ async function formatStdin(context) {
   const { filepath } = context.argv;
 
   try {
-    const input = await getStdin();
+    const input = await streamConsumers.text(process.stdin);
     // TODO[@fisker]: Exit if no input.
     // `prettier --config-precedence cli-override`
 

--- a/src/cli/utilities/get-stdin.js
+++ b/src/cli/utilities/get-stdin.js
@@ -1,0 +1,9 @@
+/* c8 ignore start */
+import streamConsumers from "node:stream/consumers";
+
+function getStdin() {
+  return streamConsumers.text(process.stdin);
+}
+
+export default getStdin;
+/* c8 ignore end */

--- a/src/cli/utilities/get-stdin.js
+++ b/src/cli/utilities/get-stdin.js
@@ -1,9 +1,0 @@
-/* c8 ignore start */
-import streamConsumers from "node:stream/consumers";
-
-function getStdin() {
-  return streamConsumers.text(process.stdin);
-}
-
-export default getStdin;
-/* c8 ignore end */

--- a/yarn.lock
+++ b/yarn.lock
@@ -4627,7 +4627,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stdin@npm:9.0.0, get-stdin@npm:^9.0.0":
+"get-stdin@npm:^9.0.0":
   version: 9.0.0
   resolution: "get-stdin@npm:9.0.0"
   checksum: 10/5972bc34d05932b45512c8e2d67b040f1c1ca8afb95c56cbc480985f2d761b7e37fe90dc8abd22527f062cc5639a6930ff346e9952ae4c11a2d4275869459594
@@ -7133,7 +7133,6 @@ __metadata:
     find-cache-directory: "npm:6.0.0"
     flow-parser: "npm:0.266.1"
     get-east-asian-width: "npm:1.3.0"
-    get-stdin: "npm:9.0.0"
     globals: "npm:16.0.0"
     graphql: "npm:16.10.0"
     hermes-parser: "npm:0.27.0"


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

<https://github.com/sindresorhus/get-stdin#tip>

Requires Node.js v16

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
