### PR TITLE
Support read config from `package.json` with JSONC syntax on Bun

### DIFF
--- a/changelog_unreleased/api/17041.md
+++ b/changelog_unreleased/api/17041.md
@@ -1,0 +1,22 @@
+#### Support read config from `package.json` with JSONC syntax on Bun (#17041 by @fisker)
+
+[Bun 1.2 added JSONC support in `package.json`](https://bun.sh/blog/bun-v1.2#jsonc-support-in-package-json), in previous version of Prettier, it will ignore `prettier` config in it. Since Prettier main, we can read `prettier` config from it without error.
+
+However, since it's just a Bun feature and not supported by Node.js, it can only work when running Prettier with Bun.
+
+Important note: Prettier uses [`json-stringify` parser](https://prettier.io/docs/en/options#parser) to format `package.json` file by default, to support formatting `package.json` file with JSONC syntax, you need override the parser option
+
+```js
+export default {
+  overrides: [
+    {
+      files: ["package.json"],
+      options: {
+        parser: "jsonc",
+      },
+    },
+  ],
+};
+```
+
+If you can't upgrade Prettier for some reason, you can still use JSONC syntax in `package.json`, but don't put your `prettier` config in it, you'll have to use another [configuration file](https://prettier.io/docs/en/configuration).


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #17039

Local tested, config successfully loaded from `package.json`, and with overrides, it can be formatted.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
