### PR TITLE
Fix string-width handling for Variation Selector characters

### DIFF
--- a/src/utils/get-string-width.js
+++ b/src/utils/get-string-width.js
@@ -4,6 +4,20 @@ import { _isNarrowWidth as isNarrowWidth } from "get-east-asian-width";
 
 const notAsciiRegex = /[^\x20-\x7F]/u;
 
+let segmenter;
+
+/**
+ * @param {string} text
+ * @yields {string}
+ */
+function* splitString(text) {
+  segmenter ??= new Intl.Segmenter();
+
+  for (const { segment: character } of segmenter.segment(text)) {
+    yield character;
+  }
+}
+
 // Similar to https://github.com/sindresorhus/string-width
 // We don't strip ansi, always treat ambiguous width characters as having narrow width.
 /**
@@ -23,10 +37,7 @@ function getStringWidth(text) {
   text = text.replace(emojiRegex(), "  ");
   let width = 0;
 
-  // Use `Intl.Segmenter` when we drop support for Node.js v14
-  // https://github.com/prettier/prettier/pull/14793#discussion_r1185840038
-  // https://github.com/sindresorhus/string-width/pull/47
-  for (const character of text) {
+  for (const character of splitString(text)) {
     const codePoint = character.codePointAt(0);
 
     // Ignore control characters

--- a/tests/integration/__tests__/util-shared.js
+++ b/tests/integration/__tests__/util-shared.js
@@ -71,9 +71,7 @@ test("sharedUtil.getStringWidth", () => {
   expect(getStringWidth("\u{2194}\u{FE0F}")).toBe(2);
   expect(getStringWidth("\u{1F469}")).toBe(2);
   expect(getStringWidth("\u{1F469}\u{1F3FF}")).toBe(2);
-  // Ideally this should be `2`, switch to use `Intl.Segmenter` will fix it
-  // https://github.com/prettier/prettier/pull/14793#discussion_r1185840038
-  expect(getStringWidth("\u{845B}\u{E0100}")).toBe(3);
+  expect(getStringWidth("\u{845B}\u{E0100}")).toBe(2);
 
   expect(getStringWidth(String.fromCharCode(0))).toBe(0);
   expect(getStringWidth(String.fromCharCode(31))).toBe(0);


### PR DESCRIPTION
## Description

Fixes string-width handling of Variation Selector characters.

This change addresses the issue first discussed in https://github.com/prettier/prettier/pull/14793#discussion_r1185840038 and follows the approach introduced in https://github.com/prettier/prettier/commit/4a7ca276fda982dfe44daf478caf4a7b43e95fc2

It updates Util.getStringWidth to use `Intl.Segmenter` for splitting strings into individual grapheme clusters (characters), improving accuracy when measuring string width, especially for complex Unicode characters.

```js
stringWidth('\u{845B}\u{E0100}')
// -> 3 (Before)
// -> 2 (After)
```

Aside from two TODOs in the codebase, I couldn’t find an existing GitHub issue related to this, but I hope this contribution is helpful. Feedback is welcome!

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
