### PR TITLE
docs: fix spacing issues on the home page

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -178,9 +178,8 @@ const config = {
               },
               {
                 html: /*html*/ `
-                  <br />
                   <a href="https://www.netlify.com" target="_blank" rel="noreferrer noopener" aria-label="Deploys by Netlify">
-                    <img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" alt="Deploys by Netlify" width="114" height="51" />
+                    <img src="https://www.netlify.com/img/global/badges/netlify-color-accent.svg" alt="Deploys by Netlify" width="114" height="51" style="margin-top: 8px;" />
                   </a>
                 `,
               },
@@ -227,7 +226,7 @@ const config = {
                     aria-label="Star this project on GitHub"
                     class="footer__github-stars"
                   >
-                    <img src="https://img.shields.io/github/stars/prettier/prettier?style=social" alt="Star this project on GitHub" />
+                    <img src="https://img.shields.io/github/stars/prettier/prettier?style=social" loading="lazy" alt="Star this project on GitHub" />
                   </a>
                 `,
               },

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -71,6 +71,7 @@
 
 .footer {
   --ifm-footer-background-color: #20232a;
+  --ifm-heading-margin-bottom: 1rem;
 }
 
 .header-github-link::before {

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -27,6 +27,7 @@
 
 @media screen and (max-width: 996px) {
   .heroBanner {
+    padding-top: 4rem;
     padding-bottom: 2.5rem;
   }
 }


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

While playing around with the spacing during the docusaurus migration, some places were left with too much, or too little whitespace. This PR fixes them.

#### Tidelift badge is colliding with the logo on mobile

Before:
![image](https://github.com/user-attachments/assets/2a210480-02a0-4d75-b770-f5eaf0f8fc19)

After:
![image](https://github.com/user-attachments/assets/d90d024e-2d55-4db7-8333-78af4b163cc2)

#### Too much whitespace around footer titles and the Netlify logo

Before:
![image](https://github.com/user-attachments/assets/82975df3-e0c8-4562-9dd9-c7ddaf48a11d)

After:
![image](https://github.com/user-attachments/assets/25669e99-16b8-4554-a1dc-024f965c28a4)


## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
