### PR TITLE
docs: avoid using `.html` extension for blog posts

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,10 @@
   NODE_VERSION = "lts/*"
   YARN_VERSION = "1.22.22"
 
+# Fix for https://github.com/facebook/docusaurus/issues/10053
+[build.processing.html]
+  pretty_urls = true
+
 [[headers]]
   for = "/worker.js"
   [headers.values]

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,10 +6,6 @@
   NODE_VERSION = "lts/*"
   YARN_VERSION = "1.22.22"
 
-# Fix for https://github.com/facebook/docusaurus/issues/10053
-[build.processing.html]
-  pretty_urls = true
-
 [[headers]]
   for = "/worker.js"
   [headers.values]

--- a/scripts/release/tests/publish-to-npm.test.js
+++ b/scripts/release/tests/publish-to-npm.test.js
@@ -40,7 +40,7 @@ describe("publish-to-npm", () => {
             "[diff](https://github.com/prettier/prettier/compare/2.3.0...2.4.0)",
             `🔗 [Release note](https://prettier.io/blog/${getDateParts().join(
               "/",
-            )}/2.4.0.html)`,
+            )}/2.4.0)`,
           ].join("\n\n"),
         }),
       );
@@ -57,7 +57,7 @@ describe("publish-to-npm", () => {
             "[diff](https://github.com/prettier/prettier/compare/2.2.0...2.3.0)",
             `🔗 [Release note](https://prettier.io/blog/${getDateParts().join(
               "/",
-            )}/2.3.0.html)`,
+            )}/2.3.0)`,
           ].join("\n\n"),
         }),
       );

--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -129,7 +129,7 @@ function getBlogPostInfo(version) {
 
   return {
     file: `website/blog/${year}-${month}-${day}-${version}.md`,
-    path: `blog/${year}/${month}/${day}/${version}.html`,
+    path: `blog/${year}/${month}/${day}/${version}`,
   };
 }
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Similar to https://github.com/prettier/prettier/pull/17079/ which removes the `.html` extension from a lot of existing URLs, this PR aims to remove that for new release blog posts.

This is important, because otherwise opening the blog posts from the GitHub release notes renders the page twice. This is known issue in docusaurus that will be fixed in later versions: https://github.com/facebook/docusaurus/issues/10053

For handling old URLs with the `.html` extension, I enabled Netlify's "Pretty URLs" option, recommended here: https://github.com/facebook/docusaurus/issues/9552#issuecomment-1821481582

As an example, opening the blog post for the 3.5 release now in the deploy preview works even with the `.html` in the URL: https://deploy-preview-17090--prettier.netlify.app/blog/2025/02/09/3.5.0.html

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
