### PR TITLE
Add missing option `experimentalOperatorPosition` types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -442,6 +442,11 @@ export interface RequiredOptions extends doc.printer.Options {
    */
   jsxBracketSameLine?: boolean;
   /**
+   * Where to print operators when binary expressions wrap lines.
+   * @default "end"
+   */
+  experimentalOperatorPosition?: "start" | "end";
+  /**
    * Arbitrary additional values on an options object are always allowed.
    */
   [_: string]: unknown;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -430,6 +430,11 @@ export interface RequiredOptions extends doc.printer.Options {
    */
   singleAttributePerLine: boolean;
   /**
+   * Where to print operators when binary expressions wrap lines.
+   * @default "end"
+   */
+  experimentalOperatorPosition: "start" | "end";
+  /**
    * Use curious ternaries, with the question mark after the condition, instead
    * of on the same line as the consequent.
    * @default false
@@ -441,11 +446,6 @@ export interface RequiredOptions extends doc.printer.Options {
    * @deprecated use bracketSameLine instead
    */
   jsxBracketSameLine?: boolean;
-  /**
-   * Where to print operators when binary expressions wrap lines.
-   * @default "end"
-   */
-  experimentalOperatorPosition?: "start" | "end";
   /**
    * Arbitrary additional values on an options object are always allowed.
    */

--- a/tests/dts/unit/cases/parsers.ts
+++ b/tests/dts/unit/cases/parsers.ts
@@ -25,6 +25,7 @@ const options: prettier.ParserOptions = {
   vueIndentScriptAndStyle: false,
   arrowParens: "always",
   semi: true,
+  experimentalOperatorPosition: "end",
   experimentalTernaries: false,
   jsxSingleQuote: false,
   quoteProps: "as-needed",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

This PR adds missing types for options `experimentalOperatorPosition`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
