### PR TITLE
Playground: Enable v3.5.0 features

### DIFF
--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -36,8 +36,7 @@ const ENABLED_OPTIONS = [
   "singleQuote",
   "bracketSpacing",
   "jsxSingleQuote",
-  // TODO: remove this comment out when 3.5.0 is released
-  // "objectWrap",
+  "objectWrap",
   "quoteProps",
   "arrowParens",
   "trailingComma",
@@ -50,6 +49,7 @@ const ENABLED_OPTIONS = [
   "bracketSameLine",
   "singleAttributePerLine",
   "experimentalTernaries",
+  "experimentalOperatorPosition",
 ];
 
 class Playground extends React.Component {


### PR DESCRIPTION
## Description

v3.5.0 introduced these 2 options.

- `objectWrap`
- `experimentalOperatorPosition`

This PR allows playground to use them.

## Checklist

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
