### PR TITLE
Support dockercompose and github-actions-workflow

### DIFF
--- a/changelog_unreleased/yaml/17101.md
+++ b/changelog_unreleased/yaml/17101.md
@@ -1,0 +1,3 @@
+#### Support dockercompose and github-actions-workflow (#17101 by @remcohaszing)
+
+Prettier now supports the `dockercompose` and `github-actions-workflow` languages in Visual Studio Code.

--- a/changelog_unreleased/yaml/17101.md
+++ b/changelog_unreleased/yaml/17101.md
@@ -1,3 +1,3 @@
-#### Support dockercompose and github-actions-workflow (#17101 by @remcohaszing)
+#### Support dockercompose and github-actions-workflow in VSCode (#17101 by @remcohaszing)
 
 Prettier now supports the `dockercompose` and `github-actions-workflow` languages in Visual Studio Code.

--- a/cspell.json
+++ b/cspell.json
@@ -64,6 +64,7 @@
         "devcontainer",
         "devs",
         "docblocks",
+        "dockercompose",
         "doctag",
         "Dodds",
         "Dolzhykov",

--- a/src/language-yaml/languages.evaluate.js
+++ b/src/language-yaml/languages.evaluate.js
@@ -4,7 +4,13 @@ import createLanguage from "../utils/create-language.js";
 const languages = [
   createLanguage(linguistLanguages.YAML, (data) => ({
     parsers: ["yaml"],
-    vscodeLanguageIds: ["yaml", "ansible", "home-assistant"],
+    vscodeLanguageIds: [
+      "yaml",
+      "ansible",
+      "dockercompose",
+      "github-actions-workflow",
+      "home-assistant",
+    ],
     // yarn.lock is not YAML: https://github.com/yarnpkg/yarn/issues/5629
     filenames: [
       ...data.filenames.filter((filename) => filename !== "yarn.lock"),

--- a/tests/integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests/integration/__tests__/__snapshots__/support-info.js.snap
@@ -771,7 +771,13 @@ exports[`CLI --support-info (stdout) 1`] = `
       "parsers": ["yaml"],
       "tmScope": "source.yaml",
       "type": "data",
-      "vscodeLanguageIds": ["yaml", "ansible", "home-assistant"]
+      "vscodeLanguageIds": [
+        "yaml",
+        "ansible",
+        "dockercompose",
+        "github-actions-workflow",
+        "home-assistant"
+      ]
     }
   ],
   "options": [


### PR DESCRIPTION
## Description

This adds support for the `dockercompose` and `github-actions-workflow` languages in VSCode. The `dockercompose` language is registered by https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker. The `github-actions-workflow` language is registered by https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-github-actions. Both these languages apply to regular YAML files that can be formatted with Prettier.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
