### PR TITLE
Update renovate.json5 to ignore `codemirror@6.65.7`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -67,6 +67,12 @@
       groupName: "GitHub Actions",
       matchManagers: ["github-actions"],
     },
+    // Forbid codemirror@6.65.7
+    // https://github.com/prettier/prettier/pull/13171#issuecomment-1258427561
+    {
+      "matchPackageNames": ["codemirror"],
+      "allowedVersions": "!/^6\\.65\\.7$/"
+    },
   ],
   ignoreDeps: [
     // It's a dependency of `remark-parse`, use same version to reduce size

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -70,8 +70,8 @@
     // Forbid codemirror@6.65.7
     // https://github.com/prettier/prettier/pull/13171#issuecomment-1258427561
     {
-      "matchPackageNames": ["codemirror"],
-      "allowedVersions": "!/^6\\.65\\.7$/"
+      matchPackageNames: ["codemirror"],
+      allowedVersions: "!/^6\\.65\\.7$/",
     },
   ],
   ignoreDeps: [

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -65,7 +65,7 @@ jobs:
         shell: bash
 
       - name: Validate renovate config
-        run: npx --package renovate -c renovate-config-validator
+        run: npx --package renovate --call renovate-config-validator
 
       - name: Run yarn (/)
         run: |

--- a/knip.config.js
+++ b/knip.config.js
@@ -8,11 +8,7 @@ export default {
         "scripts/build/build-javascript-module.js",
         "scripts/tools/**",
       ],
-      ignoreDependencies: [
-        "eslint-formatter-friendly",
-        "ts-expect",
-        "renovate",
-      ],
+      ignoreDependencies: ["eslint-formatter-friendly", "ts-expect"],
       ignoreBinaries: [
         "test-coverage",
         "renovate-config-validator",
@@ -20,13 +16,9 @@ export default {
       ],
     },
     // TODO: Enable this after we fix https://github.com/prettier/prettier/issues/11409
-    website: {
-      ignore: ["**/*"],
-    },
+    website: { ignore: ["**/*"] },
     "scripts/tools/bundle-test": {},
     "scripts/tools/eslint-plugin-prettier-internal-rules": {},
-    "scripts/release": {
-      entry: ["release.js"],
-    },
+    "scripts/release": { entry: ["release.js"] },
   },
 };

--- a/knip.config.js
+++ b/knip.config.js
@@ -16,9 +16,13 @@ export default {
       ],
     },
     // TODO: Enable this after we fix https://github.com/prettier/prettier/issues/11409
-    website: { ignore: ["**/*"] },
+    website: {
+      ignore: ["**/*"],
+    },
     "scripts/tools/bundle-test": {},
     "scripts/tools/eslint-plugin-prettier-internal-rules": {},
-    "scripts/release": { entry: ["release.js"] },
+    "scripts/release": {
+      entry: ["release.js"],
+    },
   },
 };


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

https://github.com/prettier/prettier/pull/17070#issuecomment-2645952994

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
