### PR TITLE
fix(markdown): fix strong emphasis

### DIFF
--- a/changelog_unreleased/markdown/17143.md
+++ b/changelog_unreleased/markdown/17143.md
@@ -1,0 +1,18 @@
+#### fix(markdown): fix strong emph (#17143 by @fiji-flo)
+
+Most markdown implementations don't support `1**_2_**3` so prefer `1***2**3`.
+
+<!-- prettier-ignore -->
+```md
+<!-- Input -->
+1***2***3
+1**_2_**3
+
+<!-- Prettier stable -->
+1**_2_**3
+1**_2_**3
+
+<!-- Prettier main -->
+1***2***3
+1***2***3
+```

--- a/changelog_unreleased/markdown/17143.md
+++ b/changelog_unreleased/markdown/17143.md
@@ -1,4 +1,4 @@
-#### fix(markdown): fix strong emph (#17143 by @fiji-flo)
+#### Fix strong emph (#17143 by @fiji-flo)
 
 Most markdown implementations don't support `1**_2_**3` so prefer `1***2**3`.
 

--- a/changelog_unreleased/markdown/17143.md
+++ b/changelog_unreleased/markdown/17143.md
@@ -1,4 +1,4 @@
-#### Fix strong emph (#17143 by @fiji-flo)
+#### Fix strong emphasis (#17143 by @fiji-flo)
 
 Most markdown implementations don't support `1**_2_**3` so prefer `1***2**3`.
 


### PR DESCRIPTION
## Description

In most markdown implementations `1***2***3` is considered strong emphasis but `1**_2_**3` is not.

Also most guides strongly recommend `***` instead of `**_` (see https://www.markdownguide.org/basic-syntax/#bold-and-italic-best-practices).

See the issue right here on github:

`1***2***3` ➡️ 1***2***3
`1**_2_**3` ➡️ 1**_2_**3

This PR prefers`***` in the cases where needed but doesn't default to it.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
