### PR TITLE
Fix an edge case that `indentIfBreak` or `isBreak` won't print

### DIFF
--- a/src/document/printer.js
+++ b/src/document/printer.js
@@ -544,7 +544,10 @@ function printDocToString(doc, options) {
       }
       case DOC_TYPE_IF_BREAK:
       case DOC_TYPE_INDENT_IF_BREAK: {
-        const groupMode = doc.groupId ? groupModeMap[doc.groupId] : mode;
+        const groupMode =
+          doc.groupId && groupModeMap[doc.groupId]
+            ? groupModeMap[doc.groupId]
+            : mode;
         if (groupMode === MODE_BREAK) {
           const breakContents =
             doc.type === DOC_TYPE_IF_BREAK
@@ -555,8 +558,7 @@ function printDocToString(doc, options) {
           if (breakContents) {
             cmds.push({ ind, mode, doc: breakContents });
           }
-        }
-        if (groupMode === MODE_FLAT) {
+        } else if (groupMode === MODE_FLAT) {
           const flatContents =
             doc.type === DOC_TYPE_IF_BREAK
               ? doc.flatContents
@@ -566,6 +568,8 @@ function printDocToString(doc, options) {
           if (flatContents) {
             cmds.push({ ind, mode, doc: flatContents });
           }
+        } else {
+          throw new Error("Unexpected doc error");
         }
 
         break;

--- a/tests/integration/__tests__/doc-indent-if-break.js
+++ b/tests/integration/__tests__/doc-indent-if-break.js
@@ -1,0 +1,25 @@
+import prettier from "../../config/prettier-entry.js";
+
+const docPrinter = prettier.doc.printer;
+const docBuilders = prettier.doc.builders;
+
+const { printDocToString } = docPrinter;
+const { softline, indentIfBreak } = docBuilders;
+
+// These tests don't use `runCli` because `trim` is not used by any
+// bundled parser (only third-party plugins).
+
+describe("trim", () => {
+  test.each([
+    [
+      "Non-exits group",
+      indentIfBreak([softline, "foo"], { groupId: Symbol("non-exits-group") }),
+      "\n  foo",
+    ],
+  ])("%s", (_, doc, expected) => {
+    const result = printDocToString(doc, { printWidth: 12, tabWidth: 2 });
+
+    expect(result).toBeDefined();
+    expect(result.formatted).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

`indentIfBreak` requires group exists, but there is still a chance that the associated group
1. gets wiped during doc manipulation
2. not printed, because of conditions
3. not printed **yet** for some reason (maybe doc build mistake)

This problem exists because `groupId` was added later in [dcf44ff](https://github.com/prettier/prettier/commit/dcf44ffbdc2f403de02f12516b0c6d5d5813b16f#diff-6ffe0e63f15d2bde411262c9dd7a96802e2a5ac2dbc5f4732f03c12dce6e5b7bR167)

//cc @thorn0 mentioning just in case you get time to review

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
