### PR TITLE
Remove reference to non-existent config option

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -55,7 +55,7 @@ const formatted = await prettier.format(text, {
 });
 ```
 
-If `options.editorconfig` is `true` and an [`.editorconfig` file](https://editorconfig.org/) is in your project, Prettier will parse it and convert its properties to the corresponding Prettier configuration. This configuration will be overridden by `.prettierrc`, etc. Currently, the following EditorConfig properties are supported:
+If an [`.editorconfig` file](https://editorconfig.org/) is in your project, Prettier will parse it and convert its properties to the corresponding Prettier configuration. This configuration will be overridden by `.prettierrc`, etc. Currently, the following EditorConfig properties are supported:
 
 - `end_of_line`
 - `indent_style`


### PR DESCRIPTION
## Description

Fixes #15255 

Continuing the changes in https://github.com/prettier/prettier/pull/16335, this removes the mention of the non-existent `options.editorconfig` in the docs.

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
