### PR TITLE
Prevent reading `.editorconfig` in `getParser`

### DIFF
--- a/src/common/get-file-info.js
+++ b/src/common/get-file-info.js
@@ -46,7 +46,7 @@ async function getParser(file, options) {
   let config;
   if (options.resolveConfig !== false) {
     config = await resolveConfig(file, {
-      // No need read editorconfig
+      // No need read `.editorconfig`
       editorconfig: false,
     });
   }

--- a/src/common/get-file-info.js
+++ b/src/common/get-file-info.js
@@ -45,7 +45,10 @@ async function getFileInfo(file, options) {
 async function getParser(file, options) {
   let config;
   if (options.resolveConfig !== false) {
-    config = await resolveConfig(file);
+    config = await resolveConfig(file, {
+      // No need read editorconfig
+      editorconfig: false,
+    });
   }
 
   return config?.parser ?? inferParser(options, { physicalFile: file });


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

parser can't config via `.editorconfig`, no need read it in `getParser`

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
