### PR TITLE
Docs: update cli commands

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,7 +11,7 @@ prettier [options] [file/dir/glob ...]
 
 :::note
 
-To run your locally installed version of Prettier, prefix the command with `npx` or `yarn exec` (if you use Yarn), i.e. `npx prettier --help`, or `yarn exec prettier --help`.
+To run your locally installed version of Prettier, prefix the command with `npx`, `yarn exec`, `pnpm exec`, or `bun exec`, i.e. `npx prettier --help`, `yarn exec prettier --help`, `pnpm exec prettier --help`, or `bun exec prettier --help`.
 
 :::
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,7 +11,7 @@ prettier [options] [file/dir/glob ...]
 
 :::note
 
-To run your locally installed version of Prettier, prefix the command with `npx` or `yarn` (if you use Yarn), i.e. `npx prettier --help`, or `yarn prettier --help`.
+To run your locally installed version of Prettier, prefix the command with `npx` or `yarn exec` (if you use Yarn), i.e. `npx prettier --help`, or `yarn exec prettier --help`.
 
 :::
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -83,7 +83,11 @@ npx prettier . --write
 
 What is that `npx` thing? `npx` ships with `npm` and lets you run locally installed tools. We’ll leave off the `npx` part for brevity throughout the rest of this file!
 
-Note: If you forget to install Prettier first, `npx` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
+:::
+
+:::warning
+
+If you forget to install Prettier first, `npx` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
 
 :::
 
@@ -98,7 +102,11 @@ yarn exec prettier . --write
 
 What is `yarn exec` doing at the start? `yarn exec prettier` runs the locally installed version of Prettier. We’ll leave off the `yarn exec` part for brevity throughout the rest of this file!
 
-Note: If you forget to install Prettier first, `yarn exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
+:::
+
+:::warning
+
+If you forget to install Prettier first, `yarn exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
 
 :::
 
@@ -113,7 +121,11 @@ pnpm exec prettier . --write
 
 What is `pnpm exec` doing at the start? `pnpm exec prettier` runs the locally installed version of Prettier. We’ll leave off the `pnpm exec` part for brevity throughout the rest of this file!
 
-Note: If you forget to install Prettier first, `pnpm exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
+:::
+
+:::warning
+
+If you forget to install Prettier first, `pnpm exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
 
 :::
 
@@ -128,7 +140,11 @@ bun exec prettier . --write
 
 What is `bun exec` doing at the start? `bun exec prettier` runs the locally installed version of Prettier. We’ll leave off the `bun exec` part for brevity throughout the rest of this file!
 
-Note: If you forget to install Prettier first, `bun exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
+:::
+
+:::warning
+
+If you forget to install Prettier first, `bun exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
 
 :::
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -96,7 +96,7 @@ yarn exec prettier . --write
 
 :::info
 
-What is `yarn` doing at the start? `yarn exec prettier` runs the locally installed version of Prettier. We’ll leave off the `yarn` part for brevity throughout the rest of this file!
+What is `yarn exec` doing at the start? `yarn exec prettier` runs the locally installed version of Prettier. We’ll leave off the `yarn exec` part for brevity throughout the rest of this file!
 
 :::
 
@@ -109,7 +109,7 @@ pnpm exec prettier . --write
 
 :::info
 
-What is `pnpm` doing at the start? `pnpm exec prettier` runs the locally installed version of Prettier. We’ll leave off the `pnpm` part for brevity throughout the rest of this file!
+What is `pnpm exec` doing at the start? `pnpm exec prettier` runs the locally installed version of Prettier. We’ll leave off the `pnpm exec` part for brevity throughout the rest of this file!
 
 :::
 
@@ -122,7 +122,7 @@ bun exec prettier . --write
 
 :::info
 
-What is `bun` doing at the start? `bun exec prettier` runs the locally installed version of Prettier. We’ll leave off the `bun` part for brevity throughout the rest of this file!
+What is `bun exec` doing at the start? `bun exec prettier` runs the locally installed version of Prettier. We’ll leave off the `bun exec` part for brevity throughout the rest of this file!
 
 :::
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -104,12 +104,6 @@ What is `yarn exec` doing at the start? `yarn exec prettier` runs the locally in
 
 :::
 
-:::warning
-
-If you forget to install Prettier first, `yarn exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
-
-:::
-
 </TabItem>
 <TabItem value="pnpm">
 
@@ -123,12 +117,6 @@ What is `pnpm exec` doing at the start? `pnpm exec prettier` runs the locally in
 
 :::
 
-:::warning
-
-If you forget to install Prettier first, `pnpm exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
-
-:::
-
 </TabItem>
 <TabItem value="bun">
 
@@ -139,12 +127,6 @@ bun exec prettier . --write
 :::info
 
 What is `bun exec` doing at the start? `bun exec prettier` runs the locally installed version of Prettier. We’ll leave off the `bun exec` part for brevity throughout the rest of this file!
-
-:::
-
-:::warning
-
-If you forget to install Prettier first, `bun exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
 
 :::
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -98,6 +98,8 @@ yarn exec prettier . --write
 
 What is `yarn exec` doing at the start? `yarn exec prettier` runs the locally installed version of Prettier. We’ll leave off the `yarn exec` part for brevity throughout the rest of this file!
 
+Note: If you forget to install Prettier first, `yarn exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
+
 :::
 
 </TabItem>
@@ -111,6 +113,8 @@ pnpm exec prettier . --write
 
 What is `pnpm exec` doing at the start? `pnpm exec prettier` runs the locally installed version of Prettier. We’ll leave off the `pnpm exec` part for brevity throughout the rest of this file!
 
+Note: If you forget to install Prettier first, `pnpm exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
+
 :::
 
 </TabItem>
@@ -123,6 +127,8 @@ bun exec prettier . --write
 :::info
 
 What is `bun exec` doing at the start? `bun exec prettier` runs the locally installed version of Prettier. We’ll leave off the `bun exec` part for brevity throughout the rest of this file!
+
+Note: If you forget to install Prettier first, `bun exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
 
 :::
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -104,7 +104,7 @@ What is `yarn` doing at the start? `yarn prettier` runs the locally installed ve
 <TabItem value="pnpm">
 
 ```bash
-pnpm exec prettier . --write
+pnpm prettier . --write
 ```
 
 :::info

--- a/docs/install.md
+++ b/docs/install.md
@@ -91,12 +91,12 @@ Note: If you forget to install Prettier first, `npx` will temporarily download t
 <TabItem value="yarn">
 
 ```bash
-yarn prettier . --write
+yarn exec prettier . --write
 ```
 
 :::info
 
-What is `yarn` doing at the start? `yarn prettier` runs the locally installed version of Prettier. We’ll leave off the `yarn` part for brevity throughout the rest of this file!
+What is `yarn` doing at the start? `yarn exec prettier` runs the locally installed version of Prettier. We’ll leave off the `yarn` part for brevity throughout the rest of this file!
 
 :::
 
@@ -104,12 +104,12 @@ What is `yarn` doing at the start? `yarn prettier` runs the locally installed ve
 <TabItem value="pnpm">
 
 ```bash
-pnpm prettier . --write
+pnpm exec prettier . --write
 ```
 
 :::info
 
-What is `pnpm` doing at the start? `pnpm prettier` runs the locally installed version of Prettier. We’ll leave off the `pnpm` part for brevity throughout the rest of this file!
+What is `pnpm` doing at the start? `pnpm exec prettier` runs the locally installed version of Prettier. We’ll leave off the `pnpm` part for brevity throughout the rest of this file!
 
 :::
 
@@ -117,12 +117,12 @@ What is `pnpm` doing at the start? `pnpm prettier` runs the locally installed ve
 <TabItem value="bun">
 
 ```bash
-bun prettier . --write
+bun exec prettier . --write
 ```
 
 :::info
 
-What is `bun` doing at the start? `bun prettier` runs the locally installed version of Prettier. We’ll leave off the `bun` part for brevity throughout the rest of this file!
+What is `bun` doing at the start? `bun exec prettier` runs the locally installed version of Prettier. We’ll leave off the `bun` part for brevity throughout the rest of this file!
 
 :::
 

--- a/website/versioned_docs/version-stable/cli.md
+++ b/website/versioned_docs/version-stable/cli.md
@@ -11,7 +11,7 @@ prettier [options] [file/dir/glob ...]
 
 :::note
 
-To run your locally installed version of Prettier, prefix the command with `npx` or `yarn exec` (if you use Yarn), i.e. `npx prettier --help`, or `yarn exec prettier --help`.
+To run your locally installed version of Prettier, prefix the command with `npx`, `yarn exec`, `pnpm exec`, or `bun exec`, i.e. `npx prettier --help`, `yarn exec prettier --help`, `pnpm exec prettier --help`, or `bun exec prettier --help`.
 
 :::
 

--- a/website/versioned_docs/version-stable/cli.md
+++ b/website/versioned_docs/version-stable/cli.md
@@ -11,7 +11,7 @@ prettier [options] [file/dir/glob ...]
 
 :::note
 
-To run your locally installed version of Prettier, prefix the command with `npx` or `yarn` (if you use Yarn), i.e. `npx prettier --help`, or `yarn prettier --help`.
+To run your locally installed version of Prettier, prefix the command with `npx` or `yarn exec` (if you use Yarn), i.e. `npx prettier --help`, or `yarn exec prettier --help`.
 
 :::
 

--- a/website/versioned_docs/version-stable/install.md
+++ b/website/versioned_docs/version-stable/install.md
@@ -83,7 +83,11 @@ npx prettier . --write
 
 What is that `npx` thing? `npx` ships with `npm` and lets you run locally installed tools. We’ll leave off the `npx` part for brevity throughout the rest of this file!
 
-Note: If you forget to install Prettier first, `npx` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
+:::
+
+:::warning
+
+If you forget to install Prettier first, `npx` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
 
 :::
 
@@ -98,7 +102,11 @@ yarn exec prettier . --write
 
 What is `yarn exec` doing at the start? `yarn exec prettier` runs the locally installed version of Prettier. We’ll leave off the `yarn exec` part for brevity throughout the rest of this file!
 
-Note: If you forget to install Prettier first, `yarn exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
+:::
+
+:::warning
+
+If you forget to install Prettier first, `yarn exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
 
 :::
 
@@ -113,7 +121,11 @@ pnpm exec prettier . --write
 
 What is `pnpm exec` doing at the start? `pnpm exec prettier` runs the locally installed version of Prettier. We’ll leave off the `pnpm exec` part for brevity throughout the rest of this file!
 
-Note: If you forget to install Prettier first, `pnpm exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
+:::
+
+:::warning
+
+If you forget to install Prettier first, `pnpm exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
 
 :::
 
@@ -128,7 +140,11 @@ bun exec prettier . --write
 
 What is `bun exec` doing at the start? `bun exec prettier` runs the locally installed version of Prettier. We’ll leave off the `bun exec` part for brevity throughout the rest of this file!
 
-Note: If you forget to install Prettier first, `bun exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
+:::
+
+:::warning
+
+If you forget to install Prettier first, `bun exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
 
 :::
 

--- a/website/versioned_docs/version-stable/install.md
+++ b/website/versioned_docs/version-stable/install.md
@@ -104,12 +104,6 @@ What is `yarn exec` doing at the start? `yarn exec prettier` runs the locally in
 
 :::
 
-:::warning
-
-If you forget to install Prettier first, `yarn exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
-
-:::
-
 </TabItem>
 <TabItem value="pnpm">
 
@@ -123,12 +117,6 @@ What is `pnpm exec` doing at the start? `pnpm exec prettier` runs the locally in
 
 :::
 
-:::warning
-
-If you forget to install Prettier first, `pnpm exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
-
-:::
-
 </TabItem>
 <TabItem value="bun">
 
@@ -139,12 +127,6 @@ bun exec prettier . --write
 :::info
 
 What is `bun exec` doing at the start? `bun exec prettier` runs the locally installed version of Prettier. We’ll leave off the `bun exec` part for brevity throughout the rest of this file!
-
-:::
-
-:::warning
-
-If you forget to install Prettier first, `bun exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
 
 :::
 

--- a/website/versioned_docs/version-stable/install.md
+++ b/website/versioned_docs/version-stable/install.md
@@ -91,12 +91,12 @@ Note: If you forget to install Prettier first, `npx` will temporarily download t
 <TabItem value="yarn">
 
 ```bash
-yarn prettier . --write
+yarn exec prettier . --write
 ```
 
 :::info
 
-What is `yarn` doing at the start? `yarn prettier` runs the locally installed version of Prettier. We’ll leave off the `yarn` part for brevity throughout the rest of this file!
+What is `yarn exec` doing at the start? `yarn exec prettier` runs the locally installed version of Prettier. We’ll leave off the `yarn exec` part for brevity throughout the rest of this file!
 
 :::
 
@@ -109,7 +109,7 @@ pnpm exec prettier . --write
 
 :::info
 
-What is `pnpm` doing at the start? `pnpm prettier` runs the locally installed version of Prettier. We’ll leave off the `pnpm` part for brevity throughout the rest of this file!
+What is `pnpm exec` doing at the start? `pnpm exec prettier` runs the locally installed version of Prettier. We’ll leave off the `pnpm exec` part for brevity throughout the rest of this file!
 
 :::
 
@@ -117,12 +117,12 @@ What is `pnpm` doing at the start? `pnpm prettier` runs the locally installed ve
 <TabItem value="bun">
 
 ```bash
-bun prettier . --write
+bun exec prettier . --write
 ```
 
 :::info
 
-What is `bun` doing at the start? `bun prettier` runs the locally installed version of Prettier. We’ll leave off the `bun` part for brevity throughout the rest of this file!
+What is `bun exec` doing at the start? `bun exec prettier` runs the locally installed version of Prettier. We’ll leave off the `bun exec` part for brevity throughout the rest of this file!
 
 :::
 

--- a/website/versioned_docs/version-stable/install.md
+++ b/website/versioned_docs/version-stable/install.md
@@ -98,6 +98,8 @@ yarn exec prettier . --write
 
 What is `yarn exec` doing at the start? `yarn exec prettier` runs the locally installed version of Prettier. We’ll leave off the `yarn exec` part for brevity throughout the rest of this file!
 
+Note: If you forget to install Prettier first, `yarn exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
+
 :::
 
 </TabItem>
@@ -111,6 +113,8 @@ pnpm exec prettier . --write
 
 What is `pnpm exec` doing at the start? `pnpm exec prettier` runs the locally installed version of Prettier. We’ll leave off the `pnpm exec` part for brevity throughout the rest of this file!
 
+Note: If you forget to install Prettier first, `pnpm exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
+
 :::
 
 </TabItem>
@@ -123,6 +127,8 @@ bun exec prettier . --write
 :::info
 
 What is `bun exec` doing at the start? `bun exec prettier` runs the locally installed version of Prettier. We’ll leave off the `bun exec` part for brevity throughout the rest of this file!
+
+Note: If you forget to install Prettier first, `bun exec` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
 
 :::
 


### PR DESCRIPTION
## Description

Prettier is installed locally in the project and can be run with the `pnpm prettier` command.

And the CLI in the codeblock appears to be a typo, as the info box below uses `pnpm prettier` instead of `pnpm exec prettier`.

![스크린샷, 2025-02-22 15-13-19](https://github.com/user-attachments/assets/b5e3e66d-a332-414b-8895-fe86f786b13a)


<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
