### PR TITLE
Fix `bun exec`

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,7 +11,7 @@ prettier [options] [file/dir/glob ...]
 
 :::note
 
-To run your locally installed version of Prettier, prefix the command with `npx`, `yarn exec`, `pnpm exec`, or `bun exec`, i.e. `npx prettier --help`, `yarn exec prettier --help`, `pnpm exec prettier --help`, or `bun exec prettier --help`.
+To run your locally installed version of Prettier, prefix the command with `npx`, `yarn exec`, `pnpm exec`, or `bunx`, i.e. `npx prettier --help`, `yarn exec prettier --help`, `pnpm exec prettier --help`, or `bunx prettier --help`.
 
 :::
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -121,12 +121,12 @@ What is `pnpm exec` doing at the start? `pnpm exec prettier` runs the locally in
 <TabItem value="bun">
 
 ```bash
-bun exec prettier . --write
+bunx prettier . --write
 ```
 
 :::info
 
-What is `bun exec` doing at the start? `bun exec prettier` runs the locally installed version of Prettier. We’ll leave off the `bun exec` part for brevity throughout the rest of this file!
+What is `bunx` doing at the start? `bunx prettier` runs the locally installed version of Prettier. We’ll leave off the `bunx` part for brevity throughout the rest of this file!
 
 :::
 


### PR DESCRIPTION
`bun exec` does not work for running prettier from CLI. Even after installation. With bun, `exec`  command does not work the same way in other javascript environments. 

Bun exec:
 - does not run locally install prettier package script
 - does not download+run prettier script

Proper way to do things with bun:
 - run `bun run prettier`, or
 - run `bunx prettier`

`bunx prettier` will always use prettier package script which is what we want.

`bun run` might use local path's `package.json` script which is less predictable.

## Description

Changed `bun exec` to `bunx`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
