### PR TITLE
Share `picocolors` and `leven` with CLI

### DIFF
--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import picocolors from "picocolors";
 import * as prettier from "../index.js";
 import { expandPatterns } from "./expand-patterns.js";
 import findCacheFile from "./find-cache-file.js";
@@ -12,6 +11,7 @@ import {
   createTwoFilesPatch,
   errors,
   mockable,
+  picocolors,
 } from "./prettier-internal.js";
 import { normalizeToPosix, statSafe } from "./utils.js";
 

--- a/src/cli/logger.js
+++ b/src/cli/logger.js
@@ -1,7 +1,7 @@
 import readline from "node:readline";
-import picocolors from "picocolors";
 import stripAnsi from "strip-ansi";
 import wcwidth from "wcwidth.js";
+import { picocolors } from "./prettier-internal.js";
 
 const countLines = (stream, text) => {
   const columns = stream.columns || 80;

--- a/src/cli/options/normalize-cli-options.js
+++ b/src/cli/options/normalize-cli-options.js
@@ -1,6 +1,9 @@
-import leven from "leven";
-import picocolors from "picocolors";
-import { normalizeOptions, vnopts } from "../prettier-internal.js";
+import {
+  leven,
+  normalizeOptions,
+  picocolors,
+  vnopts,
+} from "../prettier-internal.js";
 
 const descriptor = {
   key: (key) => (key.length === 1 ? `-${key}` : `--${key}`),

--- a/src/cli/prettier-internal.js
+++ b/src/cli/prettier-internal.js
@@ -13,4 +13,6 @@ export const {
   fastGlob,
   createTwoFilesPatch,
   mockable,
+  picocolors,
+  leven,
 } = sharedWithCli;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,14 @@
-// "fast-glob" and `createTwoFilesPatch` are bundled here since the API uses `micromatch` and `diff` too
+/*
+The following are bundled here since they are used in API too
+- fast-glob
+- createTwoFilesPatch
+- leven
+- picocolors
+*/
 import { createTwoFilesPatch } from "diff";
 import fastGlob from "fast-glob";
+import leven from "leven";
+import picocolors from "picocolors";
 import * as vnopts from "vnopts";
 import * as errors from "./common/errors.js";
 import getFileInfoWithoutPlugins from "./common/get-file-info.js";
@@ -95,6 +103,8 @@ const sharedWithCli = {
   },
   fastGlob,
   createTwoFilesPatch,
+  picocolors,
+  leven,
   utils: {
     omit,
   },


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

Reduce size of CLI, not much since they are quite small.

**Size Change:** -4.76 kB (-0.06%) 

**Total Size:** 7.87 MB

| Filename | Size | Change |
| :--- | :---: | :---: |
| `./dist/index.mjs` | 730 kB | +73 B (+0.01%) |
| `./dist/internal/cli.mjs` | 130 kB | -4.84 kB (-3.59%) |

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
