### PR TITLE
Fix ReDoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "smol-toml": "1.3.1",
     "strip-ansi": "7.1.0",
     "to-fast-properties": "4.0.0",
+    "trim-newlines": "5.0.0",
     "typescript": "5.8.2",
     "unicode-regex": "4.1.2",
     "unified": "9.2.2",

--- a/src/document/utils.js
+++ b/src/document/utils.js
@@ -1,3 +1,4 @@
+import { trimNewlinesEnd } from "trim-newlines";
 import { join, literalline } from "./builders.js";
 import {
   DOC_TYPE_ALIGN,
@@ -235,7 +236,7 @@ function stripTrailingHardlineFromDoc(doc) {
       return stripTrailingHardlineFromParts(doc);
 
     case DOC_TYPE_STRING:
-      return doc.replace(/[\n\r]*$/u, "");
+      return trimNewlinesEnd(doc);
 
     case DOC_TYPE_ALIGN:
     case DOC_TYPE_CURSOR:

--- a/yarn.lock
+++ b/yarn.lock
@@ -6979,6 +6979,7 @@ __metadata:
     tempy: "npm:3.1.0"
     tinybench: "npm:3.1.1"
     to-fast-properties: "npm:4.0.0"
+    trim-newlines: "npm:5.0.0"
     ts-expect: "npm:1.3.0"
     typescript: "npm:5.8.2"
     unicode-regex: "npm:4.1.2"
@@ -7934,6 +7935,13 @@ __metadata:
   dependencies:
     is-number: "npm:^7.0.0"
   checksum: 10/10dda13571e1f5ad37546827e9b6d4252d2e0bc176c24a101252153ef435d83696e2557fe128c4678e4e78f5f01e83711c703eef9814eb12dab028580d45980a
+  languageName: node
+  linkType: hard
+
+"trim-newlines@npm:5.0.0":
+  version: 5.0.0
+  resolution: "trim-newlines@npm:5.0.0"
+  checksum: 10/028a42134d05f732808da53c9613091392cd8a345b38d481fa202dba35a5806b0bbdeaffa8a256b772efb03b7f22cdaa49883421d49c730c5b80d9acf0a65ecd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

Fix Security issue https://github.com/prettier/prettier/security/code-scanning/5

If non dependency solution is prefered, I can change it to 

```js
doc.replace(/(^|[^\n\r])[\n\r]*$/u, "$1");
```

Should be equivalent.

![image](https://github.com/user-attachments/assets/0bc9119e-64b1-4a6c-89ca-423ca1fd9f57)

![image](https://github.com/user-attachments/assets/7775a948-0240-467f-9b3a-8bb2097ab5fe)

https://devina.io/redos-checker

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
