### PR TITLE
Improve playground when using `doc-explorer` parser

### DIFF
--- a/website/playground/Playground.jsx
+++ b/website/playground/Playground.jsx
@@ -337,7 +337,7 @@ class Playground extends React.Component {
                                 }))
                               }
                             />
-                            {options.cursorOffset >= 0 && (
+                            {options.cursorOffset >= 0 ? (
                               <>
                                 <Button
                                   onClick={() => {
@@ -351,7 +351,7 @@ class Playground extends React.Component {
                                 </Button>
                                 <label>Result: {cursorOffset}</label>
                               </>
-                            )}
+                            ) : null}
                           </div>
                         </SidebarCategory>
                       ) : null}

--- a/website/playground/Playground.jsx
+++ b/website/playground/Playground.jsx
@@ -365,11 +365,13 @@ class Playground extends React.Component {
                           checked={editorState.showAst}
                           onChange={editorState.toggleAst}
                         />
-                        <Checkbox
-                          label="show preprocessed AST"
-                          checked={editorState.showPreprocessedAst}
-                          onChange={editorState.togglePreprocessedAst}
-                        />
+                        {options.parser === "doc-explorer" ? null : (
+                          <Checkbox
+                            label="show preprocessed AST"
+                            checked={editorState.showPreprocessedAst}
+                            onChange={editorState.togglePreprocessedAst}
+                          />
+                        )}
                         {options.parser == "doc-explorer" ? null : (
                           <Checkbox
                             label="show doc"
@@ -377,11 +379,13 @@ class Playground extends React.Component {
                             onChange={editorState.toggleDoc}
                           />
                         )}
-                        <Checkbox
-                          label="show comments"
-                          checked={editorState.showComments}
-                          onChange={editorState.toggleComments}
-                        />
+                        {options.parser === "doc-explorer" ? null : (
+                          <Checkbox
+                            label="show comments"
+                            checked={editorState.showComments}
+                            onChange={editorState.toggleComments}
+                          />
+                        )}
                         <Checkbox
                           label="show output"
                           checked={editorState.showOutput}
@@ -441,7 +445,8 @@ class Playground extends React.Component {
                           autoFold={util.getAstAutoFold(options.parser)}
                         />
                       ) : null}
-                      {editorState.showPreprocessedAst ? (
+                      {editorState.showPreprocessedAst &&
+                      options.parser !== "doc-explorer" ? (
                         <DebugPanel
                           value={debug.preprocessedAst || ""}
                           autoFold={util.getAstAutoFold(options.parser)}
@@ -451,7 +456,8 @@ class Playground extends React.Component {
                       options.parser !== "doc-explorer" ? (
                         <DebugPanel value={debug.doc || ""} />
                       ) : null}
-                      {editorState.showComments ? (
+                      {editorState.showComments &&
+                      options.parser !== "doc-explorer" ? (
                         <DebugPanel
                           value={debug.comments || ""}
                           autoFold={util.getAstAutoFold(options.parser)}

--- a/website/playground/Playground.jsx
+++ b/website/playground/Playground.jsx
@@ -269,7 +269,7 @@ class Playground extends React.Component {
               const showFullReport =
                 encodeURIComponent(fullReport).length < MAX_LENGTH;
               return (
-                <React.Fragment>
+                <>
                   <div className="editors-container">
                     <Sidebar visible={editorState.showSidebar}>
                       <SidebarOptions
@@ -278,78 +278,82 @@ class Playground extends React.Component {
                         optionValues={options}
                         onOptionValueChange={this.handleOptionValueChange}
                       />
-                      <SidebarCategory title="Range">
-                        <label>
-                          The selected range will be highlighted in yellow in
-                          the input editor
-                        </label>
-                        <Option
-                          option={this.rangeStartOption}
-                          value={
-                            typeof options.rangeStart === "number"
-                              ? options.rangeStart
-                              : ""
-                          }
-                          onChange={this.handleOptionValueChange}
-                        />
-                        <Option
-                          option={this.rangeEndOption}
-                          value={
-                            typeof options.rangeEnd === "number"
-                              ? options.rangeEnd
-                              : ""
-                          }
-                          overrideMax={content.length}
-                          onChange={this.handleOptionValueChange}
-                        />
-
-                        <Button onClick={this.setSelectionAsRange}>
-                          Set selected text as range
-                        </Button>
-                      </SidebarCategory>
-                      <SidebarCategory title="Cursor">
-                        <Option
-                          option={this.cursorOffsetOption}
-                          value={
-                            options.cursorOffset >= 0
-                              ? options.cursorOffset
-                              : ""
-                          }
-                          onChange={this.handleOptionValueChange}
-                        />
-                        <div
-                          style={{
-                            display: "flex",
-                            alignItems: "baseline",
-                            gap: "10px",
-                          }}
-                        >
-                          <Checkbox
-                            label="track"
-                            checked={Boolean(this.state.trackCursorOffset)}
-                            onChange={() =>
-                              this.setState((state) => ({
-                                trackCursorOffset: !state.trackCursorOffset,
-                              }))
+                      {options.parser == "doc-explorer" ? null : (
+                        <SidebarCategory title="Range">
+                          <label>
+                            The selected range will be highlighted in yellow in
+                            the input editor
+                          </label>
+                          <Option
+                            option={this.rangeStartOption}
+                            value={
+                              typeof options.rangeStart === "number"
+                                ? options.rangeStart
+                                : ""
                             }
+                            onChange={this.handleOptionValueChange}
                           />
-                          {options.cursorOffset >= 0 && (
-                            <>
-                              <Button
-                                onClick={() => {
-                                  this.handleOptionValueChange(
-                                    this.cursorOffsetOption,
-                                    -1,
-                                  );
-                                }}
-                              >
-                                Reset
-                              </Button>
-                              <label>Result: {cursorOffset}</label>
-                            </>
-                          )}
-                        </div>
-                      </SidebarCategory>
+                          <Option
+                            option={this.rangeEndOption}
+                            value={
+                              typeof options.rangeEnd === "number"
+                                ? options.rangeEnd
+                                : ""
+                            }
+                            overrideMax={content.length}
+                            onChange={this.handleOptionValueChange}
+                          />
+
+                          <Button onClick={this.setSelectionAsRange}>
+                            Set selected text as range
+                          </Button>
+                        </SidebarCategory>
+                      )}
+                      {options.parser == "doc-explorer" ? null : (
+                        <SidebarCategory title="Cursor">
+                          <Option
+                            option={this.cursorOffsetOption}
+                            value={
+                              options.cursorOffset >= 0
+                                ? options.cursorOffset
+                                : ""
+                            }
+                            onChange={this.handleOptionValueChange}
+                          />
+                          <div
+                            style={{
+                              display: "flex",
+                              alignItems: "baseline",
+                              gap: "10px",
+                            }}
+                          >
+                            <Checkbox
+                              label="track"
+                              checked={Boolean(this.state.trackCursorOffset)}
+                              onChange={() =>
+                                this.setState((state) => ({
+                                  trackCursorOffset: !state.trackCursorOffset,
+                                }))
+                              }
+                            />
+                            {options.cursorOffset >= 0 && (
+                              <>
+                                <Button
+                                  onClick={() => {
+                                    this.handleOptionValueChange(
+                                      this.cursorOffsetOption,
+                                      -1,
+                                    );
+                                  }}
+                                >
+                                  Reset
+                                </Button>
+                                <label>Result: {cursorOffset}</label>
+                              </>
+                            )}
+                          </div>
+                        </SidebarCategory>
+                      )}
                       <SidebarCategory title="Debug">
                         <Checkbox
                           label="show input"
@@ -366,11 +370,13 @@ class Playground extends React.Component {
                           checked={editorState.showPreprocessedAst}
                           onChange={editorState.togglePreprocessedAst}
                         />
-                        <Checkbox
-                          label="show doc"
-                          checked={editorState.showDoc}
-                          onChange={editorState.toggleDoc}
-                        />
+                        {options.parser == "doc-explorer" ? null : (
+                          <Checkbox
+                            label="show doc"
+                            checked={editorState.showDoc}
+                            onChange={editorState.toggleDoc}
+                          />
+                        )}
                         <Checkbox
                           label="show comments"
                           checked={editorState.showComments}
@@ -381,16 +387,20 @@ class Playground extends React.Component {
                           checked={editorState.showOutput}
                           onChange={editorState.toggleOutput}
                         />
-                        <Checkbox
-                          label="show second format"
-                          checked={editorState.showSecondFormat}
-                          onChange={editorState.toggleSecondFormat}
-                        />
-                        <Checkbox
-                          label="rethrow embed errors"
-                          checked={editorState.rethrowEmbedErrors}
-                          onChange={editorState.toggleEmbedErrors}
-                        />
+                        {options.parser === "doc-explorer" ? null : (
+                          <Checkbox
+                            label="show second format"
+                            checked={editorState.showSecondFormat}
+                            onChange={editorState.toggleSecondFormat}
+                          />
+                        )}
+                        {options.parser === "doc-explorer" ? null : (
+                          <Checkbox
+                            label="rethrow embed errors"
+                            checked={editorState.rethrowEmbedErrors}
+                            onChange={editorState.toggleEmbedErrors}
+                          />
+                        )}
                         {editorState.showDoc && (
                           <ClipboardButton
                             copy={() => this.getMarkdown({ doc: debug.doc })}
@@ -437,7 +447,8 @@ class Playground extends React.Component {
                           autoFold={util.getAstAutoFold(options.parser)}
                         />
                       ) : null}
-                      {editorState.showDoc ? (
+                      {editorState.showDoc &&
+                      options.parser !== "doc-explorer" ? (
                         <DebugPanel value={debug.doc || ""} />
                       ) : null}
                       {editorState.showComments ? (
@@ -484,7 +495,8 @@ class Playground extends React.Component {
                           />
                         )
                       ) : null}
-                      {editorState.showSecondFormat ? (
+                      {editorState.showSecondFormat &&
+                      options.parser !== "doc-explorer" ? (
                         <OutputPanel
                           mode={util.getCodemirrorMode(options.parser)}
                           value={getSecondFormat(formatted, debug.reformatted)}
@@ -550,7 +562,7 @@ class Playground extends React.Component {
                       </a>
                     </div>
                   </div>
-                </React.Fragment>
+                </>
               );
             }}
           </PrettierFormat>

--- a/website/playground/Playground.jsx
+++ b/website/playground/Playground.jsx
@@ -278,7 +278,7 @@ class Playground extends React.Component {
                         optionValues={options}
                         onOptionValueChange={this.handleOptionValueChange}
                       />
-                      {options.parser == "doc-explorer" ? null : (
+                      {options.parser !== "doc-explorer" && (
                         <SidebarCategory title="Range">
                           <label>
                             The selected range will be highlighted in yellow in
@@ -309,7 +309,7 @@ class Playground extends React.Component {
                           </Button>
                         </SidebarCategory>
                       )}
-                      {options.parser == "doc-explorer" ? null : (
+                      {options.parser !== "doc-explorer" && (
                         <SidebarCategory title="Cursor">
                           <Option
                             option={this.cursorOffsetOption}
@@ -365,21 +365,21 @@ class Playground extends React.Component {
                           checked={editorState.showAst}
                           onChange={editorState.toggleAst}
                         />
-                        {options.parser === "doc-explorer" ? null : (
+                        {options.parser !== "doc-explorer" && (
                           <Checkbox
                             label="show preprocessed AST"
                             checked={editorState.showPreprocessedAst}
                             onChange={editorState.togglePreprocessedAst}
                           />
                         )}
-                        {options.parser == "doc-explorer" ? null : (
+                        {options.parser !== "doc-explorer" && (
                           <Checkbox
                             label="show doc"
                             checked={editorState.showDoc}
                             onChange={editorState.toggleDoc}
                           />
                         )}
-                        {options.parser === "doc-explorer" ? null : (
+                        {options.parser !== "doc-explorer" && (
                           <Checkbox
                             label="show comments"
                             checked={editorState.showComments}
@@ -391,28 +391,29 @@ class Playground extends React.Component {
                           checked={editorState.showOutput}
                           onChange={editorState.toggleOutput}
                         />
-                        {options.parser === "doc-explorer" ? null : (
+                        {options.parser !== "doc-explorer" && (
                           <Checkbox
                             label="show second format"
                             checked={editorState.showSecondFormat}
                             onChange={editorState.toggleSecondFormat}
                           />
                         )}
-                        {options.parser === "doc-explorer" ? null : (
+                        {options.parser !== "doc-explorer" && (
                           <Checkbox
                             label="rethrow embed errors"
                             checked={editorState.rethrowEmbedErrors}
                             onChange={editorState.toggleEmbedErrors}
                           />
                         )}
-                        {editorState.showDoc && (
-                          <ClipboardButton
-                            copy={() => this.getMarkdown({ doc: debug.doc })}
-                            disabled={!debug.doc}
-                          >
-                            Copy doc
-                          </ClipboardButton>
-                        )}
+                        {editorState.showDoc &&
+                          options.parser !== "doc-explorer" && (
+                            <ClipboardButton
+                              copy={() => this.getMarkdown({ doc: debug.doc })}
+                              disabled={!debug.doc}
+                            >
+                              Copy doc
+                            </ClipboardButton>
+                          )}
                       </SidebarCategory>
                       <div className="sub-options">
                         <Button onClick={this.resetOptions}>
@@ -421,7 +422,7 @@ class Playground extends React.Component {
                       </div>
                     </Sidebar>
                     <div className="editors">
-                      {editorState.showInput ? (
+                      {editorState.showInput && (
                         <InputPanel
                           mode={util.getCodemirrorMode(options.parser)}
                           ruler={options.printWidth}
@@ -438,33 +439,33 @@ class Playground extends React.Component {
                           }}
                           foldGutter={options.parser === "doc-explorer"}
                         />
-                      ) : null}
-                      {editorState.showAst ? (
+                      )}
+                      {editorState.showAst && (
                         <DebugPanel
                           value={debug.ast || ""}
                           autoFold={util.getAstAutoFold(options.parser)}
                         />
-                      ) : null}
+                      )}
                       {editorState.showPreprocessedAst &&
-                      options.parser !== "doc-explorer" ? (
-                        <DebugPanel
-                          value={debug.preprocessedAst || ""}
-                          autoFold={util.getAstAutoFold(options.parser)}
-                        />
-                      ) : null}
+                        options.parser !== "doc-explorer" && (
+                          <DebugPanel
+                            value={debug.preprocessedAst || ""}
+                            autoFold={util.getAstAutoFold(options.parser)}
+                          />
+                        )}
                       {editorState.showDoc &&
-                      options.parser !== "doc-explorer" ? (
-                        <DebugPanel value={debug.doc || ""} />
-                      ) : null}
+                        options.parser !== "doc-explorer" && (
+                          <DebugPanel value={debug.doc || ""} />
+                        )}
                       {editorState.showComments &&
-                      options.parser !== "doc-explorer" ? (
-                        <DebugPanel
-                          value={debug.comments || ""}
-                          autoFold={util.getAstAutoFold(options.parser)}
-                        />
-                      ) : null}
-                      {editorState.showOutput ? (
-                        this.state.needsClickForFirstRun ? (
+                        options.parser !== "doc-explorer" && (
+                          <DebugPanel
+                            value={debug.comments || ""}
+                            autoFold={util.getAstAutoFold(options.parser)}
+                          />
+                        )}
+                      {editorState.showOutput &&
+                        (this.state.needsClickForFirstRun ? (
                           <div className="editor disabled-output-panel">
                             <div className="explanation">
                               <code>doc-explorer</code> involves running code
@@ -499,16 +500,18 @@ class Playground extends React.Component {
                               cursorOffset === -1 ? undefined : cursorOffset + 1
                             }
                           />
-                        )
-                      ) : null}
+                        ))}
                       {editorState.showSecondFormat &&
-                      options.parser !== "doc-explorer" ? (
-                        <OutputPanel
-                          mode={util.getCodemirrorMode(options.parser)}
-                          value={getSecondFormat(formatted, debug.reformatted)}
-                          ruler={options.printWidth}
-                        />
-                      ) : null}
+                        options.parser !== "doc-explorer" && (
+                          <OutputPanel
+                            mode={util.getCodemirrorMode(options.parser)}
+                            value={getSecondFormat(
+                              formatted,
+                              debug.reformatted,
+                            )}
+                            ruler={options.printWidth}
+                          />
+                        )}
                     </div>
                   </div>
                   <div className="bottom-bar">

--- a/website/playground/Playground.jsx
+++ b/website/playground/Playground.jsx
@@ -94,8 +94,8 @@ class Playground extends React.Component {
 
     const codeSample = getCodeSample(options.parser);
     const content = original.content || codeSample;
-    const needsClickForFirstRun =
-      options.parser === "doc-explorer" && content !== codeSample;
+    const isDocExplorer = options.parser === "doc-explorer";
+    const needsClickForFirstRun = isDocExplorer && content !== codeSample;
     const selection = {};
 
     this.state = { content, options, selection, needsClickForFirstRun };
@@ -268,6 +268,7 @@ class Playground extends React.Component {
               });
               const showFullReport =
                 encodeURIComponent(fullReport).length < MAX_LENGTH;
+              const isDocExplorer = options.parser === "doc-explorer";
 
               return (
                 <>
@@ -279,7 +280,7 @@ class Playground extends React.Component {
                         optionValues={options}
                         onOptionValueChange={this.handleOptionValueChange}
                       />
-                      {options.parser === "doc-explorer" ? (
+                      {isDocExplorer ? null : (
                         <SidebarCategory title="Range">
                           <label>
                             The selected range will be highlighted in yellow in
@@ -309,8 +310,8 @@ class Playground extends React.Component {
                             Set selected text as range
                           </Button>
                         </SidebarCategory>
-                      ) : null}
-                      {options.parser === "doc-explorer" ? (
+                      )}
+                      {isDocExplorer ? null : (
                         <SidebarCategory title="Cursor">
                           <Option
                             option={this.cursorOffsetOption}
@@ -354,7 +355,7 @@ class Playground extends React.Component {
                             ) : null}
                           </div>
                         </SidebarCategory>
-                      ) : null}
+                      )}
                       <SidebarCategory title="Debug">
                         <Checkbox
                           label="show input"
@@ -366,48 +367,47 @@ class Playground extends React.Component {
                           checked={editorState.showAst}
                           onChange={editorState.toggleAst}
                         />
-                        {options.parser === "doc-explorer" ? (
+                        {isDocExplorer ? null : (
                           <Checkbox
                             label="show preprocessed AST"
                             checked={editorState.showPreprocessedAst}
                             onChange={editorState.togglePreprocessedAst}
                           />
-                        ) : null}
-                        {options.parser === "doc-explorer" ? (
+                        )}
+                        {isDocExplorer ? null : (
                           <Checkbox
                             label="show doc"
                             checked={editorState.showDoc}
                             onChange={editorState.toggleDoc}
                           />
-                        ) : null}
-                        {options.parser === "doc-explorer" ? (
+                        )}
+                        {isDocExplorer ? null : (
                           <Checkbox
                             label="show comments"
                             checked={editorState.showComments}
                             onChange={editorState.toggleComments}
                           />
-                        ) : null}
+                        )}
                         <Checkbox
                           label="show output"
                           checked={editorState.showOutput}
                           onChange={editorState.toggleOutput}
                         />
-                        {options.parser === "doc-explorer" ? (
+                        {isDocExplorer ? null : (
                           <Checkbox
                             label="show second format"
                             checked={editorState.showSecondFormat}
                             onChange={editorState.toggleSecondFormat}
                           />
-                        ) : null}
-                        {options.parser === "doc-explorer" ? (
+                        )}
+                        {isDocExplorer ? null : (
                           <Checkbox
                             label="rethrow embed errors"
                             checked={editorState.rethrowEmbedErrors}
                             onChange={editorState.toggleEmbedErrors}
                           />
-                        ) : null}
-                        {editorState.showDoc &&
-                        options.parser !== "doc-explorer" ? (
+                        )}
+                        {editorState.showDoc && !isDocExplorer ? (
                           <ClipboardButton
                             copy={() => this.getMarkdown({ doc: debug.doc })}
                             disabled={!debug.doc}
@@ -447,19 +447,16 @@ class Playground extends React.Component {
                           autoFold={util.getAstAutoFold(options.parser)}
                         />
                       ) : null}
-                      {editorState.showPreprocessedAst &&
-                      options.parser !== "doc-explorer" ? (
+                      {editorState.showPreprocessedAst && !isDocExplorer ? (
                         <DebugPanel
                           value={debug.preprocessedAst || ""}
                           autoFold={util.getAstAutoFold(options.parser)}
                         />
                       ) : null}
-                      {editorState.showDoc &&
-                      options.parser !== "doc-explorer" ? (
+                      {editorState.showDoc && !isDocExplorer ? (
                         <DebugPanel value={debug.doc || ""} />
                       ) : null}
-                      {editorState.showComments &&
-                      options.parser !== "doc-explorer" ? (
+                      {editorState.showComments && !isDocExplorer ? (
                         <DebugPanel
                           value={debug.comments || ""}
                           autoFold={util.getAstAutoFold(options.parser)}
@@ -503,8 +500,7 @@ class Playground extends React.Component {
                           />
                         )
                       ) : null}
-                      {editorState.showSecondFormat &&
-                      options.parser !== "doc-explorer" ? (
+                      {editorState.showSecondFormat && !isDocExplorer ? (
                         <OutputPanel
                           mode={util.getCodemirrorMode(options.parser)}
                           value={getSecondFormat(formatted, debug.reformatted)}

--- a/website/playground/Playground.jsx
+++ b/website/playground/Playground.jsx
@@ -268,6 +268,7 @@ class Playground extends React.Component {
               });
               const showFullReport =
                 encodeURIComponent(fullReport).length < MAX_LENGTH;
+
               return (
                 <>
                   <div className="editors-container">
@@ -278,7 +279,7 @@ class Playground extends React.Component {
                         optionValues={options}
                         onOptionValueChange={this.handleOptionValueChange}
                       />
-                      {options.parser !== "doc-explorer" && (
+                      {options.parser === "doc-explorer" ? (
                         <SidebarCategory title="Range">
                           <label>
                             The selected range will be highlighted in yellow in
@@ -308,8 +309,8 @@ class Playground extends React.Component {
                             Set selected text as range
                           </Button>
                         </SidebarCategory>
-                      )}
-                      {options.parser !== "doc-explorer" && (
+                      ) : null}
+                      {options.parser === "doc-explorer" ? (
                         <SidebarCategory title="Cursor">
                           <Option
                             option={this.cursorOffsetOption}
@@ -353,7 +354,7 @@ class Playground extends React.Component {
                             )}
                           </div>
                         </SidebarCategory>
-                      )}
+                      ) : null}
                       <SidebarCategory title="Debug">
                         <Checkbox
                           label="show input"
@@ -365,55 +366,55 @@ class Playground extends React.Component {
                           checked={editorState.showAst}
                           onChange={editorState.toggleAst}
                         />
-                        {options.parser !== "doc-explorer" && (
+                        {options.parser === "doc-explorer" ? (
                           <Checkbox
                             label="show preprocessed AST"
                             checked={editorState.showPreprocessedAst}
                             onChange={editorState.togglePreprocessedAst}
                           />
-                        )}
-                        {options.parser !== "doc-explorer" && (
+                        ) : null}
+                        {options.parser === "doc-explorer" ? (
                           <Checkbox
                             label="show doc"
                             checked={editorState.showDoc}
                             onChange={editorState.toggleDoc}
                           />
-                        )}
-                        {options.parser !== "doc-explorer" && (
+                        ) : null}
+                        {options.parser === "doc-explorer" ? (
                           <Checkbox
                             label="show comments"
                             checked={editorState.showComments}
                             onChange={editorState.toggleComments}
                           />
-                        )}
+                        ) : null}
                         <Checkbox
                           label="show output"
                           checked={editorState.showOutput}
                           onChange={editorState.toggleOutput}
                         />
-                        {options.parser !== "doc-explorer" && (
+                        {options.parser === "doc-explorer" ? (
                           <Checkbox
                             label="show second format"
                             checked={editorState.showSecondFormat}
                             onChange={editorState.toggleSecondFormat}
                           />
-                        )}
-                        {options.parser !== "doc-explorer" && (
+                        ) : null}
+                        {options.parser === "doc-explorer" ? (
                           <Checkbox
                             label="rethrow embed errors"
                             checked={editorState.rethrowEmbedErrors}
                             onChange={editorState.toggleEmbedErrors}
                           />
-                        )}
+                        ) : null}
                         {editorState.showDoc &&
-                          options.parser !== "doc-explorer" && (
-                            <ClipboardButton
-                              copy={() => this.getMarkdown({ doc: debug.doc })}
-                              disabled={!debug.doc}
-                            >
-                              Copy doc
-                            </ClipboardButton>
-                          )}
+                        options.parser !== "doc-explorer" ? (
+                          <ClipboardButton
+                            copy={() => this.getMarkdown({ doc: debug.doc })}
+                            disabled={!debug.doc}
+                          >
+                            Copy doc
+                          </ClipboardButton>
+                        ) : null}
                       </SidebarCategory>
                       <div className="sub-options">
                         <Button onClick={this.resetOptions}>
@@ -422,7 +423,7 @@ class Playground extends React.Component {
                       </div>
                     </Sidebar>
                     <div className="editors">
-                      {editorState.showInput && (
+                      {editorState.showInput ? (
                         <InputPanel
                           mode={util.getCodemirrorMode(options.parser)}
                           ruler={options.printWidth}
@@ -439,33 +440,33 @@ class Playground extends React.Component {
                           }}
                           foldGutter={options.parser === "doc-explorer"}
                         />
-                      )}
-                      {editorState.showAst && (
+                      ) : null}
+                      {editorState.showAst ? (
                         <DebugPanel
                           value={debug.ast || ""}
                           autoFold={util.getAstAutoFold(options.parser)}
                         />
-                      )}
+                      ) : null}
                       {editorState.showPreprocessedAst &&
-                        options.parser !== "doc-explorer" && (
-                          <DebugPanel
-                            value={debug.preprocessedAst || ""}
-                            autoFold={util.getAstAutoFold(options.parser)}
-                          />
-                        )}
+                      options.parser !== "doc-explorer" ? (
+                        <DebugPanel
+                          value={debug.preprocessedAst || ""}
+                          autoFold={util.getAstAutoFold(options.parser)}
+                        />
+                      ) : null}
                       {editorState.showDoc &&
-                        options.parser !== "doc-explorer" && (
-                          <DebugPanel value={debug.doc || ""} />
-                        )}
+                      options.parser !== "doc-explorer" ? (
+                        <DebugPanel value={debug.doc || ""} />
+                      ) : null}
                       {editorState.showComments &&
-                        options.parser !== "doc-explorer" && (
-                          <DebugPanel
-                            value={debug.comments || ""}
-                            autoFold={util.getAstAutoFold(options.parser)}
-                          />
-                        )}
-                      {editorState.showOutput &&
-                        (this.state.needsClickForFirstRun ? (
+                      options.parser !== "doc-explorer" ? (
+                        <DebugPanel
+                          value={debug.comments || ""}
+                          autoFold={util.getAstAutoFold(options.parser)}
+                        />
+                      ) : null}
+                      {editorState.showOutput ? (
+                        this.state.needsClickForFirstRun ? (
                           <div className="editor disabled-output-panel">
                             <div className="explanation">
                               <code>doc-explorer</code> involves running code
@@ -500,18 +501,16 @@ class Playground extends React.Component {
                               cursorOffset === -1 ? undefined : cursorOffset + 1
                             }
                           />
-                        ))}
+                        )
+                      ) : null}
                       {editorState.showSecondFormat &&
-                        options.parser !== "doc-explorer" && (
-                          <OutputPanel
-                            mode={util.getCodemirrorMode(options.parser)}
-                            value={getSecondFormat(
-                              formatted,
-                              debug.reformatted,
-                            )}
-                            ruler={options.printWidth}
-                          />
-                        )}
+                      options.parser !== "doc-explorer" ? (
+                        <OutputPanel
+                          mode={util.getCodemirrorMode(options.parser)}
+                          value={getSecondFormat(formatted, debug.reformatted)}
+                          ruler={options.printWidth}
+                        />
+                      ) : null}
                     </div>
                   </div>
                   <div className="bottom-bar">

--- a/website/playground/index.jsx
+++ b/website/playground/index.jsx
@@ -37,14 +37,14 @@ class App extends React.Component {
     }
 
     return (
-      <React.Fragment>
+      <>
         <VersionLink version={version} />
         <Playground
           worker={this.worker}
           availableOptions={availableOptions}
           version={version}
         />
-      </React.Fragment>
+      </>
     );
   }
 }

--- a/website/static/worker.mjs
+++ b/website/static/worker.mjs
@@ -199,6 +199,15 @@ async function handleFormatMessage(message) {
 }
 
 async function formatCode(text, options, rethrowEmbedErrors) {
+  if (options.parser === "doc-explorer") {
+    options = {
+      ...options,
+      cursorOffset: undefined,
+      rangeStart: undefined,
+      rangeEnd: undefined,
+    };
+  }
+
   try {
     self.PRETTIER_DEBUG = rethrowEmbedErrors;
     return await prettier.formatWithCursor(text, options);

--- a/website/static/worker.mjs
+++ b/website/static/worker.mjs
@@ -113,6 +113,8 @@ async function handleFormatMessage(message) {
   delete options.doc;
   delete options.output2;
 
+  const isDocExplorer = options.parser === "doc-explorer";
+
   const formatResult = await formatCode(
     message.code,
     options,
@@ -138,7 +140,7 @@ async function handleFormatMessage(message) {
 
     const preprocessForPrint = key === "preprocessedAst";
 
-    if (options.parser === "doc-explorer" && preprocessForPrint) {
+    if (isDocExplorer && preprocessForPrint) {
       continue;
     }
 
@@ -164,7 +166,7 @@ async function handleFormatMessage(message) {
     response.debug[key] = ast;
   }
 
-  if (options.parser !== "doc-explorer" && message.debug.doc) {
+  if (!isDocExplorer && message.debug.doc) {
     try {
       response.debug.doc = await prettier.__debug.formatDoc(
         await prettier.__debug.printToDoc(message.code, options),
@@ -175,7 +177,7 @@ async function handleFormatMessage(message) {
     }
   }
 
-  if (options.parser !== "doc-explorer" && message.debug.comments) {
+  if (!isDocExplorer && message.debug.comments) {
     response.debug.comments = (
       await formatCode(JSON.stringify(formatResult.comments || []), {
         parser: "json",
@@ -184,7 +186,7 @@ async function handleFormatMessage(message) {
     ).formatted;
   }
 
-  if (options.parser !== "doc-explorer" && message.debug.reformat) {
+  if (!isDocExplorer && message.debug.reformat) {
     response.debug.reformatted = (
       await formatCode(response.formatted, options)
     ).formatted;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

When set cursorOffset and range, there will be errors.
Also hide "doc" and "second output" panel.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
