### PR TITLE
Fix embedded format with `cursorOffset`

### DIFF
--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -51,11 +51,13 @@ async function printAstToDoc(ast, options) {
 
   ensureAllCommentsPrinted(options);
 
-  if (options.nodeAfterCursor && !options.nodeBeforeCursor) {
-    return [cursor, doc];
-  }
-  if (options.nodeBeforeCursor && !options.nodeAfterCursor) {
-    return [doc, cursor];
+  if (options.cursorOffset >= 0) {
+    if (options.nodeAfterCursor && !options.nodeBeforeCursor) {
+      return [cursor, doc];
+    }
+    if (options.nodeBeforeCursor && !options.nodeAfterCursor) {
+      return [doc, cursor];
+    }
   }
 
   return doc;

--- a/src/main/multiparser.js
+++ b/src/main/multiparser.js
@@ -116,6 +116,10 @@ async function textToDoc(
       ...partialNextOptions,
       parentParser: parentOptions.parser,
       originalText: text,
+      // Improve this if we calculate the relative index
+      cursorOffset: undefined,
+      rangeStart: undefined,
+      rangeEnd: undefined,
     },
     { passThrough: true },
   );

--- a/tests/format/markdown/cursor/17227.md
+++ b/tests/format/markdown/cursor/17227.md
@@ -1,0 +1,20 @@
+#<|> Angular note
+
+```typescript
+  import {Component} from '@angular/core';
+
+  @Component({
+    selector: 'app-root',
+    standalone: true,
+    imports: [],
+    template: `
+      <h1>
+
+      {{ title }}</h1>
+    `,
+    styleUrls: ['./app.component.css'],
+  })
+  export class AppComponent {
+    title = 'default';
+  }
+```

--- a/tests/format/markdown/cursor/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/cursor/__snapshots__/format.test.js.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`17227.md format 1`] = `
+====================================options=====================================
+cursorOffset: 1
+parsers: ["markdown"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+#<|> Angular note
+
+\`\`\`typescript
+  import {Component} from '@angular/core';
+
+  @Component({
+    selector: 'app-root',
+    standalone: true,
+    imports: [],
+    template: \`
+      <h1>
+
+      {{ title }}</h1>
+    \`,
+    styleUrls: ['./app.component.css'],
+  })
+  export class AppComponent {
+    title = 'default';
+  }
+\`\`\`
+
+=====================================output=====================================
+#<|> Angular note
+
+\`\`\`typescript
+import { Component } from "@angular/core";
+
+@Component({
+  selector: "app-root",
+  standalone: true,
+  imports: [],
+  template: \`
+    <h1>
+      {{ title }}
+    </h1>
+  \`,
+  styleUrls: ["./app.component.css"],
+})
+export class AppComponent {
+  title = "default";
+}
+\`\`\`
+
+================================================================================
+`;

--- a/tests/format/markdown/cursor/format.test.js
+++ b/tests/format/markdown/cursor/format.test.js
@@ -1,0 +1,1 @@
+runFormatTest(import.meta, ["markdown"]);


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

Stop passing `cursorOffset` `rangeStart` `rangeEnd` to embedded print, since the indexes are related to parent.

Fixes #17227

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
