### PR TITLE
Support `cursorOffset` in `prettier.__debug.printToDoc()`

### DIFF
--- a/src/main/core.js
+++ b/src/main/core.js
@@ -392,6 +392,14 @@ async function formatDoc(doc, options) {
 async function printToDoc(originalText, options) {
   options = await normalizeFormatOptions(options);
   const { ast } = await parseText(originalText, options);
+
+  if (options.cursorOffset >= 0) {
+    options = {
+      ...options,
+      ...getCursorLocation(ast, options),
+    };
+  }
+
   return printAstToDoc(ast, options);
 }
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->
I don't think users really need it, so I'm not going to add changelog for it.

Adding this making us easier to debug in playground.

For example: https://github.com/prettier/prettier/issues/17227

![image](https://github.com/user-attachments/assets/3b7ffe1d-a9ab-4455-9a7f-998c7e3590d9)

[Link](https://deploy-preview-17256--prettier.netlify.app/playground/#N4Igxg9gdgLgprEAuEBiABAQSgcwK4A2AhgE7pQTwA6UNABgzAJ4AOcAzmCQJYsw3p03ALYsIJGOmABhCKOgIYAX3QAzEnPQByAAJFchUgHpIJOFoDcA9NZ2z5URQApg1wezgE4YGOKTaiFhYAWg1KLQAaN3R2GH0AEyICBX8YEjw4KKhBQRExCXZ-AG0AXSyc9HhRYnh-OmjBAB4ACwBGAD4Gm2yKqWBK7hgvdCUlRqM2zp7BOnKc2KYvAFUSAkL0Iq0AOiNAli3IB0UD9nYtMuslAEprOAAPfMkwYlOsIPsxR1gpaJhB4YAvNp4nBVERCDBLJd6AwQBEQBA+NxoOxkKBSBoAO4ABVICFRKCSmKITFR8IARiQiGAANZwGAAZSIwjgABluI5kGC1pkEeSAFbeGAAdSpLGQIBYZg8JAAbnA4SBKdS6YyWNSOThkGkMvCPMJuNr0rz7mweCzYEkAPJmoi+EjYiDsQbIqAShDxRWmuDmxRJAAqPqgpG4HC5SQ8es1XgAinhKAqkNzIyB+ew7gzo3A4wnwzz4QBHePwbEaFgEkBEdjBRxwEGe+FpIjcAia+zCIgSpIERXO3BeTAwNLccl4Es+9mcpMR3nNGDCAjC5qDDjqsBwBn4l2ywZMCVgU6K2UZACSUBBsAZXF4MGw8QZzC8eZTUqdcFFgQlUo4Pvlio5MowKWRA4B2z68uqJAyhKHYkDS8QQJibrwlKHIitw8QwM0yAABwAAzwmYRbcGYwGgZ2075iAcTksKGFYcgABM8J4B4-pEOSBLJiawjknW9asvo+AgXAABi4gdkOmpdmOECKmAeBQeIVqqKoHgwMgrSjEAA)



## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
