### PR TITLE
Fix #17255: Assign template literals more like string literals

### DIFF
--- a/changelog_unreleased/javascript/17255.md
+++ b/changelog_unreleased/javascript/17255.md
@@ -1,0 +1,60 @@
+#### #17255 by @calvinjuarez
+
+Allow adding a newline between before a template literal when assigning a
+variable or object property if the template literal contains no newlines.
+
+_Applies to JavaScript, TypeScript._
+
+<!-- prettier-ignore -->
+```js
+// Input
+const stringLongEnoughToWrap =
+  'The variable name and string are long enough that it wants a line break.';
+const templateLongEnoughToWrap =
+  `The variable name and string are long enough that it wants a line break.`;
+const multilineTemplatesStillNeverBreakAfterAssignment =
+`White space within a template literal is significant,
+so changing how multiline templates work is risky.`;
+
+const InObjectLiteral = {
+  STRING_LONG_ENOUGH_TO_WRAP:
+    'The key name and string are long enough that it wants a line break.',
+  TEMPLATE_LONG_ENOUGH_TO_WRAP:
+    `The key name and string are long enough that it wants a line break.`,
+  MULTILINE_TEMPLATES_STILL_NEVER_BREAK_AFTER_ASSIGNMENT:
+`White space within a template literal is significant,
+so changing how multiline templates work is risky.`,
+};
+
+// Prettier stable
+const stringLongEnoughToWrap =
+  'The variable name and string are long enough that it wants a line break.';
+const templateLongEnoughToWrap = `The variable name and string are long enough that it wants a line break.`;
+const multilineTemplatesStillNeverBreakAfterAssignment = `White space within a template literal is significant,
+so changing how multiline templates work is risky.`;
+
+const InObjectLiteral = {
+  STRING_LONG_ENOUGH_TO_WRAP:
+    'The key name and string are long enough that it wants a line break.',
+  TEMPLATE_LONG_ENOUGH_TO_WRAP: `The key name and string are long enough that it wants a line break.`,
+  MULTILINE_TEMPLATE_IS_UNCHANGED: `White space within a template literal is significant,
+so changing how multiline templates work is risky.`,
+};
+
+// Prettier main
+const stringLongEnoughToWrap =
+  'The variable name and string are long enough that it wants a line break.';
+const templateLongEnoughToWrap =
+  `The variable name and string are long enough that it wants a line break.`;
+const multilineTemplatesStillNeverBreakAfterAssignment = `White space within a template literal is significant,
+so changing how multiline templates work is risky.`;
+
+const InObjectLiteral = {
+  STRING_LONG_ENOUGH_TO_WRAP:
+    'The key name and string are long enough that it wants a line break.',
+  TEMPLATE_LONG_ENOUGH_TO_WRAP:
+    `The key name and string are long enough that it wants a line break.`,
+  MULTILINE_TEMPLATE_IS_UNCHANGED: `White space within a template literal is significant,
+so changing how multiline templates work is risky.`,
+};
+```

--- a/src/language-js/print/assignment.js
+++ b/src/language-js/print/assignment.js
@@ -20,6 +20,7 @@ import {
   isNumericLiteral,
   isObjectProperty,
   isStringLiteral,
+  isTemplateWithLineBreaks,
   isUnionType,
 } from "../utils/index.js";
 import { shouldInlineLogicalExpression } from "./binaryish.js";
@@ -178,8 +179,7 @@ function chooseLayout(path, options, print, leftDoc, rightPropertyName) {
   if (
     !canBreakLeftDoc &&
     (hasShortKey ||
-      rightNode.type === "TemplateLiteral" ||
-      rightNode.type === "TaggedTemplateExpression" ||
+      isTemplateWithLineBreaks(rightNode) ||
       rightNode.type === "BooleanLiteral" ||
       isNumericLiteral(rightNode) ||
       rightNode.type === "ClassExpression")

--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -506,14 +506,24 @@ function templateLiteralHasNewLines(template) {
 
 /**
  * @param {Estree.TemplateLiteral | Estree.TaggedTemplateExpression} node
+ * @returns {boolean}
+ */
+function isTemplateWithLineBreaks(node) {
+  return (
+    (node.type === "TemplateLiteral" && templateLiteralHasNewLines(node)) ||
+    (node.type === "TaggedTemplateExpression" &&
+      templateLiteralHasNewLines(node.quasi))
+  );
+}
+
+/**
+ * @param {Estree.TemplateLiteral | Estree.TaggedTemplateExpression} node
  * @param {string} text
  * @returns {boolean}
  */
 function isTemplateOnItsOwnLine(node, text) {
   return (
-    ((node.type === "TemplateLiteral" && templateLiteralHasNewLines(node)) ||
-      (node.type === "TaggedTemplateExpression" &&
-        templateLiteralHasNewLines(node.quasi))) &&
+    isTemplateWithLineBreaks(node) &&
     !hasNewline(text, locStart(node), { backwards: true })
   );
 }
@@ -1124,6 +1134,7 @@ export {
   isSimpleType,
   isStringLiteral,
   isTemplateOnItsOwnLine,
+  isTemplateWithLineBreaks,
   isTestCall,
   isTypeAnnotationAFunction,
   isUnionType,

--- a/tests/format/js/assignment/__snapshots__/format.test.js.snap
+++ b/tests/format/js/assignment/__snapshots__/format.test.js.snap
@@ -811,6 +811,148 @@ params.redirectTo.bar.bar.ba.barab["foo"].abr =
 ================================================================================
 `;
 
+exports[`issue-17255.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+/**
+ * Template literals and string literals should format similarly.
+ *
+ * @see https://github.com/prettier/prettier/issues/17255
+ * @see tests/format/js/strings/
+ * @see tests/format/js/template-literals/
+ * @see tests/format/typescript/satisfies-operators/
+ * @see tests/format/typescript/template-literals/
+ */
+
+const stringLongEnoughToWrap = 'The variable name and string are long enough that it wants a line break.';
+const stringLongEnoughToWrapWrapped =
+  'The variable name and string are long enough that it wants a line break.';
+const templateLongEnoughToWrap = \`The variable name and string are long enough that it wants a line break.\`;
+const templateLongEnoughToWrapWrapped =
+  \`The variable name and string are long enough that it wants a line break.\`;
+const taggedTemplateLongEnoughToWrap = tagged\`The variable name and string are long enough that it wants a line break.\`;
+const taggedTemplateLongEnoughToWrapWrapped =
+  tagged\`The variable name and string are long enough that it wants a line break.\`;
+
+const stringWithInternalNewLine = 'The variable name and string are long \\
+enough that it wants a line break.';
+const stringWithInternalNewLineWrapped =
+  'The variable name and string are long \\
+enough that it wants a line break.';
+const templateWithInternalNewLine = \`The variable name and string are long
+enough that it wants a line break.\`;
+const templateWithInternalNewLineWrapped =
+  \`The variable name and string are long
+enough that it wants a line break.\`;
+const taggedTemplateWithInternalNewLine = tagged\`The variable name and string
+  are long enough that it wants a line break.\`;
+const taggedTemplateWithInternalNewLineWrapped =
+  tagged\`The variable name and string are long
+  enough that it wants a line break.\`;
+
+const InObjectLiteral = {
+  STRING_LONG_ENOUGH_TO_WRAP: 'The key name and string are long enough that it wants a line break.',
+  STRING_LONG_ENOUGH_TO_WRAP_WRAPPED:
+    'The key name and string are long enough that it wants a line break.',
+  TEMPLATE_LONG_ENOUGH_TO_WRAP: \`The key name and string are long enough that it wants a line break.\`,
+  TEMPLATE_LONG_ENOUGH_TO_WRAP_WRAPPED:
+    \`The key name and string are long enough that it wants a line break.\`,
+  TAGGED_TEMPLATE_LONG_ENOUGH_TO_WRAP: tagged\`The key name and string are long enough that it wants a line break.\`,
+  TAGGED_TEMPLATE_LONG_ENOUGH_TO_WRAP_WRAPPED:
+    tagged\`The key name and string are long enough that it wants a line break.\`,
+
+  STRING_WITH_INTERNAL_NEW_LINE: 'The variable name and string are long \\
+enough that it wants a line break.',
+  STRING_WITH_INTERNAL_NEW_LINE_WRAPPED:
+    'The variable name and string are long \\
+enough that it wants a line break.',
+  TEMPLATE_WITH_INTERNAL_NEW_LINE: \`The key name and string
+are long enough that it wants a line break.\`,
+  TEMPLATE_WITH_INTERNAL_NEW_LINE_WRAPPED:
+    \`The key name and string
+are long enough that it wants a line break.\`,
+  TAGGED_TEMPLATE_WITH_INTERNAL_NEW_LINE: tagged\`The key name and string
+are long enough that it wants a line break.\`,
+  TAGGED_TEMPLATE_WITH_INTERNAL_NEW_LINE_WRAPPED:
+    tagged\`The key name and string
+are long enough that it wants a line break.\`,
+};
+
+=====================================output=====================================
+/**
+ * Template literals and string literals should format similarly.
+ *
+ * @see https://github.com/prettier/prettier/issues/17255
+ * @see tests/format/js/strings/
+ * @see tests/format/js/template-literals/
+ * @see tests/format/typescript/satisfies-operators/
+ * @see tests/format/typescript/template-literals/
+ */
+
+const stringLongEnoughToWrap =
+  "The variable name and string are long enough that it wants a line break.";
+const stringLongEnoughToWrapWrapped =
+  "The variable name and string are long enough that it wants a line break.";
+const templateLongEnoughToWrap =
+  \`The variable name and string are long enough that it wants a line break.\`;
+const templateLongEnoughToWrapWrapped =
+  \`The variable name and string are long enough that it wants a line break.\`;
+const taggedTemplateLongEnoughToWrap =
+  tagged\`The variable name and string are long enough that it wants a line break.\`;
+const taggedTemplateLongEnoughToWrapWrapped =
+  tagged\`The variable name and string are long enough that it wants a line break.\`;
+
+const stringWithInternalNewLine =
+  "The variable name and string are long \\
+enough that it wants a line break.";
+const stringWithInternalNewLineWrapped =
+  "The variable name and string are long \\
+enough that it wants a line break.";
+const templateWithInternalNewLine = \`The variable name and string are long
+enough that it wants a line break.\`;
+const templateWithInternalNewLineWrapped = \`The variable name and string are long
+enough that it wants a line break.\`;
+const taggedTemplateWithInternalNewLine = tagged\`The variable name and string
+  are long enough that it wants a line break.\`;
+const taggedTemplateWithInternalNewLineWrapped = tagged\`The variable name and string are long
+  enough that it wants a line break.\`;
+
+const InObjectLiteral = {
+  STRING_LONG_ENOUGH_TO_WRAP:
+    "The key name and string are long enough that it wants a line break.",
+  STRING_LONG_ENOUGH_TO_WRAP_WRAPPED:
+    "The key name and string are long enough that it wants a line break.",
+  TEMPLATE_LONG_ENOUGH_TO_WRAP:
+    \`The key name and string are long enough that it wants a line break.\`,
+  TEMPLATE_LONG_ENOUGH_TO_WRAP_WRAPPED:
+    \`The key name and string are long enough that it wants a line break.\`,
+  TAGGED_TEMPLATE_LONG_ENOUGH_TO_WRAP:
+    tagged\`The key name and string are long enough that it wants a line break.\`,
+  TAGGED_TEMPLATE_LONG_ENOUGH_TO_WRAP_WRAPPED:
+    tagged\`The key name and string are long enough that it wants a line break.\`,
+
+  STRING_WITH_INTERNAL_NEW_LINE:
+    "The variable name and string are long \\
+enough that it wants a line break.",
+  STRING_WITH_INTERNAL_NEW_LINE_WRAPPED:
+    "The variable name and string are long \\
+enough that it wants a line break.",
+  TEMPLATE_WITH_INTERNAL_NEW_LINE: \`The key name and string
+are long enough that it wants a line break.\`,
+  TEMPLATE_WITH_INTERNAL_NEW_LINE_WRAPPED: \`The key name and string
+are long enough that it wants a line break.\`,
+  TAGGED_TEMPLATE_WITH_INTERNAL_NEW_LINE: tagged\`The key name and string
+are long enough that it wants a line break.\`,
+  TAGGED_TEMPLATE_WITH_INTERNAL_NEW_LINE_WRAPPED: tagged\`The key name and string
+are long enough that it wants a line break.\`,
+};
+
+================================================================================
+`;
+
 exports[`lone-arg.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]

--- a/tests/format/js/assignment/issue-17255.js
+++ b/tests/format/js/assignment/issue-17255.js
@@ -1,0 +1,63 @@
+/**
+ * Template literals and string literals should format similarly.
+ *
+ * @see https://github.com/prettier/prettier/issues/17255
+ * @see tests/format/js/strings/
+ * @see tests/format/js/template-literals/
+ * @see tests/format/typescript/satisfies-operators/
+ * @see tests/format/typescript/template-literals/
+ */
+
+const stringLongEnoughToWrap = 'The variable name and string are long enough that it wants a line break.';
+const stringLongEnoughToWrapWrapped =
+  'The variable name and string are long enough that it wants a line break.';
+const templateLongEnoughToWrap = `The variable name and string are long enough that it wants a line break.`;
+const templateLongEnoughToWrapWrapped =
+  `The variable name and string are long enough that it wants a line break.`;
+const taggedTemplateLongEnoughToWrap = tagged`The variable name and string are long enough that it wants a line break.`;
+const taggedTemplateLongEnoughToWrapWrapped =
+  tagged`The variable name and string are long enough that it wants a line break.`;
+
+const stringWithInternalNewLine = 'The variable name and string are long \
+enough that it wants a line break.';
+const stringWithInternalNewLineWrapped =
+  'The variable name and string are long \
+enough that it wants a line break.';
+const templateWithInternalNewLine = `The variable name and string are long
+enough that it wants a line break.`;
+const templateWithInternalNewLineWrapped =
+  `The variable name and string are long
+enough that it wants a line break.`;
+const taggedTemplateWithInternalNewLine = tagged`The variable name and string
+  are long enough that it wants a line break.`;
+const taggedTemplateWithInternalNewLineWrapped =
+  tagged`The variable name and string are long
+  enough that it wants a line break.`;
+
+const InObjectLiteral = {
+  STRING_LONG_ENOUGH_TO_WRAP: 'The key name and string are long enough that it wants a line break.',
+  STRING_LONG_ENOUGH_TO_WRAP_WRAPPED:
+    'The key name and string are long enough that it wants a line break.',
+  TEMPLATE_LONG_ENOUGH_TO_WRAP: `The key name and string are long enough that it wants a line break.`,
+  TEMPLATE_LONG_ENOUGH_TO_WRAP_WRAPPED:
+    `The key name and string are long enough that it wants a line break.`,
+  TAGGED_TEMPLATE_LONG_ENOUGH_TO_WRAP: tagged`The key name and string are long enough that it wants a line break.`,
+  TAGGED_TEMPLATE_LONG_ENOUGH_TO_WRAP_WRAPPED:
+    tagged`The key name and string are long enough that it wants a line break.`,
+
+  STRING_WITH_INTERNAL_NEW_LINE: 'The variable name and string are long \
+enough that it wants a line break.',
+  STRING_WITH_INTERNAL_NEW_LINE_WRAPPED:
+    'The variable name and string are long \
+enough that it wants a line break.',
+  TEMPLATE_WITH_INTERNAL_NEW_LINE: `The key name and string
+are long enough that it wants a line break.`,
+  TEMPLATE_WITH_INTERNAL_NEW_LINE_WRAPPED:
+    `The key name and string
+are long enough that it wants a line break.`,
+  TAGGED_TEMPLATE_WITH_INTERNAL_NEW_LINE: tagged`The key name and string
+are long enough that it wants a line break.`,
+  TAGGED_TEMPLATE_WITH_INTERNAL_NEW_LINE_WRAPPED:
+    tagged`The key name and string
+are long enough that it wants a line break.`,
+};

--- a/tests/format/js/strings/__snapshots__/format.test.js.snap
+++ b/tests/format/js/strings/__snapshots__/format.test.js.snap
@@ -572,7 +572,8 @@ const Bar = styled.div\`
 \`;
 
 // https://github.com/prettier/prettier/issues/3368
-let message = \`this is a long message which contains an interpolation: \${format(data)} <- like this\`;
+let message =
+  \`this is a long message which contains an interpolation: \${format(data)} <- like this\`;
 
 let otherMessage = \`this template contains two interpolations: \${this(one)}, which should be kept on its line,
 and this other one: \${this(
@@ -582,7 +583,8 @@ which already had a linebreak so can be broken up
 \`;
 
 // https://github.com/prettier/prettier/issues/16114
-message = \`this is a long messsage a simple interpolation without a linebreak \${foo} <- like this\`;
+message =
+  \`this is a long messsage a simple interpolation without a linebreak \${foo} <- like this\`;
 
 message = \`whereas this messsage has a linebreak in the interpolation \${
   foo
@@ -785,7 +787,8 @@ const Bar = styled.div\`
 \`;
 
 // https://github.com/prettier/prettier/issues/3368
-let message = \`this is a long message which contains an interpolation: \${format(data)} <- like this\`;
+let message =
+  \`this is a long message which contains an interpolation: \${format(data)} <- like this\`;
 
 let otherMessage = \`this template contains two interpolations: \${this(one)}, which should be kept on its line,
 and this other one: \${this(
@@ -795,7 +798,8 @@ which already had a linebreak so can be broken up
 \`;
 
 // https://github.com/prettier/prettier/issues/16114
-message = \`this is a long messsage a simple interpolation without a linebreak \${foo} <- like this\`;
+message =
+  \`this is a long messsage a simple interpolation without a linebreak \${foo} <- like this\`;
 
 message = \`whereas this messsage has a linebreak in the interpolation \${
   foo

--- a/tests/format/js/template-literals/__snapshots__/format.test.js.snap
+++ b/tests/format/js/template-literals/__snapshots__/format.test.js.snap
@@ -128,9 +128,9 @@ const description =
 
 const foo = \`such a long template string \${foo.bar.baz} that prettier will want to wrap it\`;
 
-const shouldWrapForNow = \`such a long template string \${foo().bar.baz} that prettier will want to wrap it\`;
+const shouldThisWrapAndWhere = \`such a long template string \${foo().bar.baz} that prettier will want to wrap it\`;
 
-const shouldNotWrap = \`simple expressions should not break \${this} \${variable} \${a.b.c} \${this.b.c} \${a[b].c} \${a.b[c]} \${a.b['c']} \${a?.b?.c}\`;
+const shouldNotWrapInside = \`simple expressions should not break \${this} \${variable} \${a.b.c} \${this.b.c} \${a[b].c} \${a.b[c]} \${a.b['c']} \${a?.b?.c}\`;
 
 console.log(chalk.white(\`Covered Lines below threshold: \${coverageSettings.lines}%. Actual: \${coverageSummary.total.lines.pct}%\`))
 
@@ -170,17 +170,23 @@ a = \`\${[[1, 2, 3], [4, 5, 6]]}\`
 const long1 = \`long \${
   a.b //comment
 } long longlong \${a.b.c.d.e} long longlong \${a.b.c.d.e} long longlong \${a.b.c.d.e} long long\`;
-const long2 = \`long \${a.b.c.d.e} long longlong \${loooooooooooooooooong} long longlong \${loooooooooooooooooong} long longlong \${loooooooooooooooooong} long long\`;
+const long2 =
+  \`long \${a.b.c.d.e} long longlong \${loooooooooooooooooong} long longlong \${loooooooooooooooooong} long longlong \${loooooooooooooooooong} long long\`;
 
-const long3 = \`long long long long long long long long long long long \${a.b.c.d.e} long long long long long long long long long long long long long\`;
+const long3 =
+  \`long long long long long long long long long long long \${a.b.c.d.e} long long long long long long long long long long long long long\`;
 
-const description = \`The value of the \${cssName} css of the \${this._name} element\`;
+const description =
+  \`The value of the \${cssName} css of the \${this._name} element\`;
 
-const foo = \`such a long template string \${foo.bar.baz} that prettier will want to wrap it\`;
+const foo =
+  \`such a long template string \${foo.bar.baz} that prettier will want to wrap it\`;
 
-const shouldWrapForNow = \`such a long template string \${foo().bar.baz} that prettier will want to wrap it\`;
+const shouldThisWrapAndWhere =
+  \`such a long template string \${foo().bar.baz} that prettier will want to wrap it\`;
 
-const shouldNotWrap = \`simple expressions should not break \${this} \${variable} \${a.b.c} \${this.b.c} \${a[b].c} \${a.b[c]} \${a.b["c"]} \${a?.b?.c}\`;
+const shouldNotWrapInside =
+  \`simple expressions should not break \${this} \${variable} \${a.b.c} \${this.b.c} \${a[b].c} \${a.b[c]} \${a.b["c"]} \${a?.b?.c}\`;
 
 console.log(
   chalk.white(

--- a/tests/format/js/template-literals/expressions.js
+++ b/tests/format/js/template-literals/expressions.js
@@ -9,9 +9,9 @@ const description =
 
 const foo = `such a long template string ${foo.bar.baz} that prettier will want to wrap it`;
 
-const shouldWrapForNow = `such a long template string ${foo().bar.baz} that prettier will want to wrap it`;
+const shouldThisWrapAndWhere = `such a long template string ${foo().bar.baz} that prettier will want to wrap it`;
 
-const shouldNotWrap = `simple expressions should not break ${this} ${variable} ${a.b.c} ${this.b.c} ${a[b].c} ${a.b[c]} ${a.b['c']} ${a?.b?.c}`;
+const shouldNotWrapInside = `simple expressions should not break ${this} ${variable} ${a.b.c} ${this.b.c} ${a[b].c} ${a.b[c]} ${a.b['c']} ${a?.b?.c}`;
 
 console.log(chalk.white(`Covered Lines below threshold: ${coverageSettings.lines}%. Actual: ${coverageSummary.total.lines.pct}%`))
 

--- a/tests/format/typescript/satisfies-operators/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/satisfies-operators/__snapshots__/format.test.js.snap
@@ -1026,10 +1026,14 @@ const b = \`\${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + veryVe
 
 =====================================output=====================================
 const a = \`\${(foo + bar) satisfies baz}\`
-const b = \`\${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + bar) satisfies baz}\`
-const b = \`\${(foo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) satisfies baz}\`
-const b = \`\${(foo + bar) satisfies veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz}\`
-const b = \`\${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) satisfies veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz}\`
+const b =
+  \`\${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + bar) satisfies baz}\`
+const b =
+  \`\${(foo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) satisfies baz}\`
+const b =
+  \`\${(foo + bar) satisfies veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz}\`
+const b =
+  \`\${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) satisfies veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz}\`
 
 ================================================================================
 `;
@@ -1048,10 +1052,14 @@ const b = \`\${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + veryVe
 
 =====================================output=====================================
 const a = \`\${(foo + bar) satisfies baz}\`;
-const b = \`\${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + bar) satisfies baz}\`;
-const b = \`\${(foo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) satisfies baz}\`;
-const b = \`\${(foo + bar) satisfies veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz}\`;
-const b = \`\${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) satisfies veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz}\`;
+const b =
+  \`\${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + bar) satisfies baz}\`;
+const b =
+  \`\${(foo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) satisfies baz}\`;
+const b =
+  \`\${(foo + bar) satisfies veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz}\`;
+const b =
+  \`\${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) satisfies veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz}\`;
 
 ================================================================================
 `;

--- a/tests/format/typescript/template-literals/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/template-literals/__snapshots__/format.test.js.snap
@@ -14,10 +14,14 @@ const b = \`\${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + veryVe
 
 =====================================output=====================================
 const a = \`\${(foo + bar) as baz}\`;
-const b = \`\${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + bar) as baz}\`;
-const b = \`\${(foo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) as baz}\`;
-const b = \`\${(foo + bar) as veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz}\`;
-const b = \`\${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) as veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz}\`;
+const b =
+  \`\${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + bar) as baz}\`;
+const b =
+  \`\${(foo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) as baz}\`;
+const b =
+  \`\${(foo + bar) as veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz}\`;
+const b =
+  \`\${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) as veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz}\`;
 
 ================================================================================
 `;
@@ -30,7 +34,8 @@ printWidth: 80
 =====================================input======================================
 const bar = tag<number>\`but where will prettier wrap such a long tagged template literal? \${foo.bar.baz} long long long long long long long long long long long long long long\`;
 =====================================output=====================================
-const bar = tag<number>\`but where will prettier wrap such a long tagged template literal? \${foo.bar.baz} long long long long long long long long long long long long long long\`;
+const bar =
+  tag<number>\`but where will prettier wrap such a long tagged template literal? \${foo.bar.baz} long long long long long long long long long long long long long long\`;
 
 ================================================================================
 `;


### PR DESCRIPTION
## Description

Allow newlines after assignment operators before single-line template literals.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
