### PR TITLE
Fix detection of both minify and no-minify

### DIFF
--- a/scripts/build/parse-arguments.js
+++ b/scripts/build/parse-arguments.js
@@ -18,7 +18,7 @@ function parseArguments() {
     strict: true,
   });
 
-  if (values.minify && values.noMinify) {
+  if (values.minify && values["no-minify"]) {
     throw new Error("'--minify' and '--no-minify' can't be used together.");
   }
 


### PR DESCRIPTION
## Description

This fixes what I think is a mistake, in what is supposed to be detection of two conflicting CLI arguments.

The existing code is wrong because the `noMinify` key never exists. Instead it should be `no-minify` as can be also seen on the existing line 30.

## Checklist

Sorry I haven't done any of this, just wanted to get this suggestion out there.

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
