### PR TITLE
Remove special logic in comment attach

### DIFF
--- a/src/main/comments/attach.js
+++ b/src/main/comments/attach.js
@@ -142,8 +142,6 @@ function attachComments(ast, options) {
 
   const tiesToBreak = [];
   const {
-    locStart,
-    locEnd,
     printer: {
       experimentalFeatures: {
         // TODO: Make this as default behavior

--- a/src/main/comments/attach.js
+++ b/src/main/comments/attach.js
@@ -180,25 +180,6 @@ function attachComments(ast, options) {
       isLastComment,
     } = context;
 
-    if (
-      options.parser === "json" ||
-      options.parser === "json5" ||
-      options.parser === "jsonc" ||
-      options.parser === "__js_expression" ||
-      options.parser === "__ts_expression" ||
-      options.parser === "__vue_expression" ||
-      options.parser === "__vue_ts_expression"
-    ) {
-      if (locStart(comment) - locStart(ast) <= 0) {
-        addLeadingComment(ast, comment);
-        continue;
-      }
-      if (locEnd(comment) - locEnd(ast) >= 0) {
-        addTrailingComment(ast, comment);
-        continue;
-      }
-    }
-
     let args;
     if (avoidAstMutation) {
       args = [context];


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

I guess this logic exists because the `JsonRoot` and `JsExpressionRoot` has wrong location before.

First introduced in https://github.com/prettier/prettier/pull/3187

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
