### PR TITLE
Remove extra colon after `track` in angular `@for` control-flow

### DIFF
--- a/changelog_unreleased/angular/17280.md
+++ b/changelog_unreleased/angular/17280.md
@@ -1,0 +1,13 @@
+#### Do not add colon after track in angular @for control-flow (#17280 by @claudio-herger)
+
+<!-- prettier-ignore -->
+```angular
+// Input
+@for (item of items; let i = $index; let count = $count; track block) {}
+
+// Prettier stable
+@for (item of items; let i = $index; let count = $count; track: block) {}
+
+// Prettier main
+@for (item of items; let i = $index; let count = $count; track block) {}
+```

--- a/changelog_unreleased/angular/17280.md
+++ b/changelog_unreleased/angular/17280.md
@@ -1,4 +1,4 @@
-#### Do not add colon after track in angular @for control-flow (#17280 by @claudio-herger)
+#### Remove extra colon after `track` in angular `@for` control-flow (#17280 by @claudio-herger)
 
 <!-- prettier-ignore -->
 ```angular

--- a/src/language-js/print/angular.js
+++ b/src/language-js/print/angular.js
@@ -62,11 +62,12 @@ function printAngular(path, options, print) {
       // https://github.com/prettier/angular-estree-parser/issues/267
       const shouldNotPrintColon =
         isNgForOf(path) ||
+        isNgForOfTrack(path) ||
         (((index === 1 &&
           (node.key.name === "then" ||
             node.key.name === "else" ||
             node.key.name === "as")) ||
-          ((index === 2 || index === 3) &&
+          ((index === 2) &&
             ((node.key.name === "else" &&
               parent.body[index - 1].type === "NGMicrosyntaxKeyedExpression" &&
               parent.body[index - 1].key.name === "then") ||
@@ -97,6 +98,16 @@ function isNgForOf({ node, index }) {
     node.type === "NGMicrosyntaxKeyedExpression" &&
     node.key.name === "of" &&
     index === 1
+  );
+}
+
+function isNgForOfTrack(path) {
+  const {node} = path
+  return (
+    path.parent.body[1].key.name === "of" &&
+    node.type === "NGMicrosyntaxKeyedExpression" &&
+    node.key.name === "track" &&
+    node.key.type === "NGMicrosyntaxKey"
   );
 }
 

--- a/tests/format/angular/control-flow/__snapshots__/format.test.js.snap
+++ b/tests/format/angular/control-flow/__snapshots__/format.test.js.snap
@@ -291,6 +291,12 @@ item of
   <div *ngFor="item of items; let i = $index; track block"></div>
 </div>
 
+<div>
+  @for (item of items; let i = $index; let count = $count; track block) {}
+
+  <div *ngFor="item of items; let i = $index; let count = $count; track block"></div>
+</div>
+
 =====================================output=====================================
 <ul>
   @for (let item of items; index as i; trackBy: trackByFn) {
@@ -342,6 +348,14 @@ item of
   @for (item of items; let i = $index; track block) {}
 
   <div *ngFor="item of items; let i = $index; track block"></div>
+</div>
+
+<div>
+  @for (item of items; let i = $index; let count = $count; track block) {}
+
+  <div
+    *ngFor="item of items; let i = $index; let count = $count; track block"
+  ></div>
 </div>
 
 ================================================================================

--- a/tests/format/angular/control-flow/for.html
+++ b/tests/format/angular/control-flow/for.html
@@ -58,3 +58,9 @@ item of
 
   <div *ngFor="item of items; let i = $index; track block"></div>
 </div>
+
+<div>
+  @for (item of items; let i = $index; let count = $count; track block) {}
+
+  <div *ngFor="item of items; let i = $index; let count = $count; track block"></div>
+</div>


### PR DESCRIPTION
## Description

Previously prettier appended a colon to the 'track' in an angular @for-of control-flow, if the index of the 'track' (a 'NGMicrosyntaxKey') was not 2 or 3. 
This means that
`@for (item of items; let i = $index; let count = $count; track block) {}`
would still be formatted to 
`@for (item of items; let i = $index; let count = $count; track: block) {}`.
I.e. a colon would be inserted after the 'track'. 

I have removed the `index === 3` check, because, as I see it, this was specifically added to fix the same problem. (In [pr-15887](https://github.com/prettier/prettier/pull/15887) here, but it is not a complete fix, as discussed in [#15698](https://github.com/prettier/prettier/issues/15698).)

fixes #15698

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
