### PR TITLE
Fix #14567: Enable formating graphql template strings within gql method calls

### DIFF
--- a/changelog_unreleased/graphql/17288.md
+++ b/changelog_unreleased/graphql/17288.md
@@ -1,0 +1,44 @@
+#### Title (#17288 by @kirkobyte)
+
+Enables formatting of graphql code within template literals in a `gql` method call. The behavior will be the same as formatting GraphQL code in `gql` tagged template strings, or `graphql` method calls.
+
+<!-- prettier-ignore -->
+```js
+// Input
+gql(schema, `
+mutation     MarkReadNotificationMutation(
+    $input
+    : MarkReadNotificationData!
+  )
+{ markReadNotification(data: $input ) { notification {seenState} } }`)
+
+// After this PR
+gql(
+  schema,
+  `
+    mutation MarkReadNotificationMutation($input: MarkReadNotificationData!) {
+      markReadNotification(data: $input) {
+        notification {
+          seenState
+        }
+      }
+    }
+  `,
+);
+
+// Prettier stable
+gql(schema, `
+mutation     MarkReadNotificationMutation(
+    $input
+    : MarkReadNotificationData!
+  )
+{ markReadNotification(data: $input ) { notification {seenState} } }`)
+
+// Prettier main
+gql(schema, `
+mutation     MarkReadNotificationMutation(
+    $input
+    : MarkReadNotificationData!
+  )
+{ markReadNotification(data: $input ) { notification {seenState} } }`)
+```

--- a/src/language-js/clean.js
+++ b/src/language-js/clean.js
@@ -188,7 +188,8 @@ function clean(original, cloned, parent) {
     );
     if (
       hasLanguageComment ||
-      (parent.type === "CallExpression" && parent.callee.name === "graphql") ||
+      (parent.type === "CallExpression" &&
+        (parent.callee.name === "graphql" || parent.callee.name === "gql")) ||
       // TODO: check parser
       // `flow` and `typescript` don't have `leadingComments`
       !original.leadingComments

--- a/src/language-js/embed/graphql.js
+++ b/src/language-js/embed/graphql.js
@@ -111,13 +111,14 @@ function isGraphQL({ node, parent }) {
     (parent &&
       ((parent.type === "TaggedTemplateExpression" &&
         ((parent.tag.type === "MemberExpression" &&
-          parent.tag.object.name === "graphql" &&
+          (parent.tag.object.name === "graphql" ||
+            parent.tag.object.name === "gql") &&
           parent.tag.property.name === "experimental") ||
           (parent.tag.type === "Identifier" &&
             (parent.tag.name === "gql" || parent.tag.name === "graphql")))) ||
         (parent.type === "CallExpression" &&
           parent.callee.type === "Identifier" &&
-          parent.callee.name === "graphql")))
+          (parent.callee.name === "graphql" || parent.callee.name === "gql"))))
   );
 }
 

--- a/tests/format/js/multiparser-graphql/__snapshots__/format.test.js.snap
+++ b/tests/format/js/multiparser-graphql/__snapshots__/format.test.js.snap
@@ -197,6 +197,23 @@ query allPartsByManufacturerName($name: String!) {
 \${fragments.all}
 \`)
 
+gql(schema, \`
+query allPartsByManufacturerName($name: String!) {
+  allParts(filter:{manufacturer: {name: $name}}) {
+...    PartAll
+}}
+\${fragments.all}
+\`)
+
+const veryLongVariableNameToMakeTheLineBreak2 = gql(schema, \`
+query allPartsByManufacturerName($name: String!) {
+  allParts(filter:{manufacturer: {name: $name}}) {
+...    PartAll
+}}
+\${fragments.all}
+\`)
+
+
 =====================================output=====================================
 graphql(
   schema,
@@ -211,6 +228,30 @@ graphql(
 );
 
 const veryLongVariableNameToMakeTheLineBreak = graphql(
+  schema,
+  \`
+    query allPartsByManufacturerName($name: String!) {
+      allParts(filter: { manufacturer: { name: $name } }) {
+        ...PartAll
+      }
+    }
+    \${fragments.all}
+  \`,
+);
+
+gql(
+  schema,
+  \`
+    query allPartsByManufacturerName($name: String!) {
+      allParts(filter: { manufacturer: { name: $name } }) {
+        ...PartAll
+      }
+    }
+    \${fragments.all}
+  \`,
+);
+
+const veryLongVariableNameToMakeTheLineBreak2 = gql(
   schema,
   \`
     query allPartsByManufacturerName($name: String!) {
@@ -238,8 +279,28 @@ mutation     MarkReadNotificationMutation(
   )
 { markReadNotification(data: $input ) { notification {seenState} } }\`)
 
+gql(schema, \`
+mutation     MarkReadNotificationMutation(
+    $input
+    : MarkReadNotificationData!
+  )
+{ markReadNotification(data: $input ) { notification {seenState} } }\`)
+
 =====================================output=====================================
 graphql(
+  schema,
+  \`
+    mutation MarkReadNotificationMutation($input: MarkReadNotificationData!) {
+      markReadNotification(data: $input) {
+        notification {
+          seenState
+        }
+      }
+    }
+  \`,
+);
+
+gql(
   schema,
   \`
     mutation MarkReadNotificationMutation($input: MarkReadNotificationData!) {

--- a/tests/format/js/multiparser-graphql/expressions.js
+++ b/tests/format/js/multiparser-graphql/expressions.js
@@ -13,3 +13,20 @@ query allPartsByManufacturerName($name: String!) {
 }}
 ${fragments.all}
 `)
+
+gql(schema, `
+query allPartsByManufacturerName($name: String!) {
+  allParts(filter:{manufacturer: {name: $name}}) {
+...    PartAll
+}}
+${fragments.all}
+`)
+
+const veryLongVariableNameToMakeTheLineBreak2 = gql(schema, `
+query allPartsByManufacturerName($name: String!) {
+  allParts(filter:{manufacturer: {name: $name}}) {
+...    PartAll
+}}
+${fragments.all}
+`)
+

--- a/tests/format/js/multiparser-graphql/graphql.js
+++ b/tests/format/js/multiparser-graphql/graphql.js
@@ -4,3 +4,10 @@ mutation     MarkReadNotificationMutation(
     : MarkReadNotificationData!
   )
 { markReadNotification(data: $input ) { notification {seenState} } }`)
+
+gql(schema, `
+mutation     MarkReadNotificationMutation(
+    $input
+    : MarkReadNotificationData!
+  )
+{ markReadNotification(data: $input ) { notification {seenState} } }`)


### PR DESCRIPTION
## Description

Enables formatting of graphql code within `gql` method calls. Currently, only GraphQL code within `graphql` method calls, `gql` tagged template strings, and `graphql` tagged template strings.

Some libraries, such as `graphql-codegen` output `gql` methods as their default means of injecting types into queries. To support formatting this code as-is, users would need to rename their `gql` tags to `graphql` in all uses.

Closes: #14567

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
