### PR TITLE
[WIP] Use `printObject` to print import attributes

### DIFF
--- a/src/language-js/print/module.js
+++ b/src/language-js/print/module.js
@@ -23,11 +23,15 @@ import {
 } from "../utils/index.js";
 import { printDecoratorsBeforeExport } from "./decorators.js";
 import { printDeclareToken } from "./misc.js";
+import { printObject } from "./object.js";
 
 /**
  * @import {Doc} from "../../document/builders.js"
  */
 
+/*
+- `ImportDeclaration`
+*/
 function printImportDeclaration(path, options, print) {
   const { node } = path;
   /** @type{Doc[]} */
@@ -49,8 +53,8 @@ const isDefaultExport = (node) =>
 /*
 - `ExportDefaultDeclaration`
 - `ExportNamedDeclaration`
-- `DeclareExportDeclaration`(flow)
 - `ExportAllDeclaration`
+- `DeclareExportDeclaration`(flow)
 - `DeclareExportAllDeclaration`(flow)
 */
 function printExportDeclaration(path, options, print) {
@@ -274,6 +278,14 @@ function getImportAttributesKeyword(node, options) {
   return isNonEmptyArray(node.attributes) ? "with" : undefined;
 }
 
+/*
+- `ImportDeclaration`
+- `ExportDefaultDeclaration`
+- `ExportNamedDeclaration`
+- `ExportAllDeclaration`
+- `DeclareExportDeclaration`(flow)
+- `DeclareExportAllDeclaration`(flow)
+*/
 function printImportAttributes(path, options, print) {
   const { node } = path;
 
@@ -286,23 +298,7 @@ function printImportAttributes(path, options, print) {
     return "";
   }
 
-  /** @type{Doc[]} */
-  const parts = [` ${keyword} {`];
-
-  if (isNonEmptyArray(node.attributes)) {
-    if (options.bracketSpacing) {
-      parts.push(" ");
-    }
-
-    parts.push(join(", ", path.map(print, "attributes")));
-
-    if (options.bracketSpacing) {
-      parts.push(" ");
-    }
-  }
-  parts.push("}");
-
-  return parts;
+  return [` ${keyword} `, printObject(path, options, print)];
 }
 
 function printModuleSpecifier(path, options, print) {

--- a/src/language-js/print/object.js
+++ b/src/language-js/print/object.js
@@ -26,11 +26,31 @@ import { printTypeAnnotationProperty } from "./type-annotation.js";
 
 /** @import {Doc} from "../../document/builders.js" */
 
+/*
+- `ObjectExpression`
+- `ObjectPattern`
+- `RecordExpression`
+- `ImportDeclaration`
+- `ExportDefaultDeclaration`
+- `ExportNamedDeclaration`
+- `ExportAllDeclaration`
+- `ObjectTypeAnnotation` (Flow)
+- `EnumBooleanBody`(flow)
+- `EnumNumberBody`(flow)
+- `EnumBigIntBody`(flow)
+- `EnumStringBody`(flow)
+- `EnumSymbolBody`(flow)
+- `DeclareExportDeclaration`(flow)
+- `DeclareExportAllDeclaration`(flow)
+- `TSInterfaceBody` (TypeScript)
+- `TSTypeLiteral` (TypeScript)
+- `TSEnumDeclaration`(TypeScript)
+*/
 function printObject(path, options, print) {
   const semi = options.semi ? ";" : "";
   const { node } = path;
 
-  const isTypeAnnotation = node.type === "ObjectTypeAnnotation";
+  const isFlowTypeAnnotation = node.type === "ObjectTypeAnnotation";
   const isEnumBody =
     node.type === "TSEnumDeclaration" ||
     node.type === "EnumBooleanBody" ||
@@ -38,15 +58,28 @@ function printObject(path, options, print) {
     node.type === "EnumBigIntBody" ||
     node.type === "EnumStringBody" ||
     node.type === "EnumSymbolBody";
-  const fields = [
-    node.type === "TSTypeLiteral" || isEnumBody
-      ? "members"
-      : node.type === "TSInterfaceBody"
-        ? "body"
-        : "properties",
-  ];
-  if (isTypeAnnotation) {
-    fields.push("indexers", "callProperties", "internalSlots");
+  const isInterfaceBody = node.type === "TSInterfaceBody";
+  const isImportAttributes =
+    node.type === "ImportDeclaration" ||
+    node.type === "ExportDefaultDeclaration" ||
+    node.type === "ExportNamedDeclaration" ||
+    node.type === "ExportAllDeclaration" ||
+    node.type === "DeclareExportDeclaration" ||
+    node.type === "DeclareExportAllDeclaration";
+
+  const fields = [];
+  if (node.type === "TSTypeLiteral" || isEnumBody) {
+    fields.push("members");
+  } else if (isInterfaceBody) {
+    fields.push("body");
+  } else if (isImportAttributes) {
+    fields.push("attributes");
+  } else {
+    fields.push("properties");
+
+    if (isFlowTypeAnnotation) {
+      fields.push("indexers", "callProperties", "internalSlots");
+    }
   }
 
   // Unfortunately, things grouped together in the ast can be
@@ -69,13 +102,13 @@ function printObject(path, options, print) {
 
   const { parent, key } = path;
   const isFlowInterfaceLikeBody =
-    isTypeAnnotation &&
+    isFlowTypeAnnotation &&
     key === "body" &&
     (parent.type === "InterfaceDeclaration" ||
       parent.type === "DeclareInterface" ||
       parent.type === "DeclareClass");
   const shouldBreak =
-    node.type === "TSInterfaceBody" ||
+    isInterfaceBody ||
     isEnumBody ||
     isFlowInterfaceLikeBody ||
     (node.type === "ObjectPattern" &&
@@ -104,7 +137,7 @@ function printObject(path, options, print) {
 
   const separator = isFlowInterfaceLikeBody
     ? ";"
-    : node.type === "TSInterfaceBody" || node.type === "TSTypeLiteral"
+    : isInterfaceBody || node.type === "TSTypeLiteral"
       ? ifBreak(semi, ";")
       : ",";
   const leftBrace =

--- a/tests/format/js/import-attributes/multiple.js
+++ b/tests/format/js/import-attributes/multiple.js
@@ -1,0 +1,3 @@
+import syntaxImportAssertions from "@babel/plugin-syntax-import-assertions" with {
+  BABEL_8_BREAKING: "false",
+  USE_ESM: "true", IS_STANDALONE: "false" };


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

Fixes #17071

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
