### PR TITLE
Minor improvement to config loader

### DIFF
--- a/src/config/prettier-config/loaders.js
+++ b/src/config/prettier-config/loaders.js
@@ -20,7 +20,7 @@ async function importModuleDefault(file) {
   return module.default;
 }
 
-async function readPackageJson(file) {
+async function readBunPackageJson(file) {
   try {
     return await readJson(file);
   } catch (error) {
@@ -28,22 +28,25 @@ async function readPackageJson(file) {
     // Bun supports comments and trialing comma in `package.json`
     // And it can load via `import()`
     // https://bun.sh/blog/bun-v1.2#jsonc-support-in-package-json
-    if (process.versions.bun) {
-      try {
-        return await importModuleDefault(file);
-      } catch {
-        // No op
-      }
+    try {
+      return await importModuleDefault(file);
+    } catch {
+      // No op
     }
 
     throw error;
   }
 }
 
-async function loadConfigFromPackageJson(file) {
-  const { prettier } = await readPackageJson(file);
-  return prettier;
-}
+const loadConfigFromPackageJson = process.versions.bun
+  ? async function loadConfigFromPackageJson(file) {
+      const { prettier } = await readJson(file);
+      return prettier;
+    }
+  : async function loadConfigFromBunPackageJson(file) {
+      const { prettier } = await readBunPackageJson(file);
+      return prettier;
+    };
 
 async function loadConfigFromPackageYaml(file) {
   const { prettier } = await loadYaml(file);
@@ -60,25 +63,29 @@ async function loadYaml(file) {
   }
 }
 
+async function loadToml(file) {
+  const content = await readFile(file);
+  try {
+    return parseToml(content);
+  } catch (/** @type {any} */ error) {
+    error.message = `TOML Error in ${file}:\n${error.message}`;
+    throw error;
+  }
+}
+
+async function loadJson5(file) {
+  const content = await readFile(file);
+  try {
+    return json5.parse(content);
+  } catch (/** @type {any} */ error) {
+    error.message = `JSON5 Error in ${file}:\n${error.message}`;
+    throw error;
+  }
+}
+
 const loaders = {
-  async ".toml"(file) {
-    const content = await readFile(file);
-    try {
-      return parseToml(content);
-    } catch (/** @type {any} */ error) {
-      error.message = `TOML Error in ${file}:\n${error.message}`;
-      throw error;
-    }
-  },
-  async ".json5"(file) {
-    const content = await readFile(file);
-    try {
-      return json5.parse(content);
-    } catch (/** @type {any} */ error) {
-      error.message = `JSON5 Error in ${file}:\n${error.message}`;
-      throw error;
-    }
-  },
+  ".toml": loadToml,
+  ".json5": loadJson5,
   ".json": readJson,
   ".js": importModuleDefault,
   ".mjs": importModuleDefault,

--- a/src/config/prettier-config/loaders.js
+++ b/src/config/prettier-config/loaders.js
@@ -39,12 +39,12 @@ async function readBunPackageJson(file) {
 }
 
 const loadConfigFromPackageJson = process.versions.bun
-  ? async function loadConfigFromPackageJson(file) {
-      const { prettier } = await readJson(file);
+  ? async function loadConfigFromBunPackageJson(file) {
+      const { prettier } = await readBunPackageJson(file);
       return prettier;
     }
-  : async function loadConfigFromBunPackageJson(file) {
-      const { prettier } = await readBunPackageJson(file);
+  : async function loadConfigFromPackageJson(file) {
+      const { prettier } = await readJson(file);
       return prettier;
     };
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

`loadConfigFromPackageJson` is a hot path.
Check `process.versions.bun` when define it, instead of checking it in every call, .

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
