### PR TITLE
Add `shouldIgnoreByDefault` function support for language

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -675,6 +675,7 @@ export interface SupportLanguage {
   vscodeLanguageIds?: string[] | undefined;
   interpreters?: string[] | undefined;
   isSupported?: ((file: string) => boolean) | undefined;
+  shouldIgnoreByDefault?: ((file: string) => boolean) | undefined;
 }
 
 export interface SupportOptionRange {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

Allow plugin to not infer parser for specific file, eg `pnpm-lock.yml` , idea from https://github.com/prettier/prettier/pull/17331#issuecomment-2788878849.

Not sure about how it should work yet, just an idea.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
