### PR TITLE
Rename Prettier+ to Prettier⁺

### DIFF
--- a/website/data/editors.yml
+++ b/website/data/editors.yml
@@ -12,7 +12,7 @@
   name: Nova
   content: |
     [`Prettier`](https://extensions.panic.com/extensions/alexanderweiss/alexanderweiss.prettier/)
-    [`Prettier+`](https://extensions.panic.com/extensions/stonerl/stonerl.prettier/)
+    [`Prettier⁺`](https://extensions.panic.com/extensions/stonerl/stonerl.prettier/)
 - image: /images/editors/editor_sublime.svg
   name: Sublime Text
   content: |


### PR DESCRIPTION
## Description

I renamed the extension to Prettier⁺ – because it just looks better 😎.

Sorry for the fuzz.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
