### PR TITLE
[V4] Use legacy CLI by default during development

### DIFF
--- a/bin/prettier.cjs
+++ b/bin/prettier.cjs
@@ -14,11 +14,12 @@ var packageJson = require("../package.json");
 pleaseUpgradeNode(packageJson);
 
 var dynamicImport = new Function("module", "return import(module)");
-if (process.env.PRETTIER_LEGACY_CLI) {
+
+if (process.env.PRETTIER_EXPERIMENTAL_CLI) {
+  dynamicImport("@prettier/cli/bin");
+} else {
   var promise = dynamicImport("../src/cli/index.js").then(function runCli(cli) {
     return cli.run();
   });
   module.exports.__promise = promise;
-} else {
-  dynamicImport("@prettier/cli/bin");
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,10 @@ const INSTALL_PACKAGE = Boolean(process.env.INSTALL_PACKAGE);
 // When debugging production test, this flag can skip installing package
 const SKIP_PRODUCTION_INSTALL = Boolean(process.env.SKIP_PRODUCTION_INSTALL);
 
+if (PROJECT_ROOT) {
+  process.env.PRETTIER_LEGACY_CLI = "1";
+}
+
 let PRETTIER_DIR = isProduction
   ? path.join(PROJECT_ROOT, "dist/prettier")
   : PROJECT_ROOT;

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
   },
   "scripts": {
     "prepublishOnly": "echo \"Error: must publish from dist/\" && exit 1",
-    "test": "cross-env PRETTIER_LEGACY_CLI=1 jest",
+    "test": "jest",
     "test:dev-package": "cross-env INSTALL_PACKAGE=1 yarn test",
     "test:dist": "cross-env NODE_ENV=production yarn test",
     "test:dist-standalone": "cross-env TEST_STANDALONE=1 yarn test:dist",

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -791,8 +791,17 @@ const nodejsFiles = [
     replaceModule: [
       {
         module: path.join(PROJECT_ROOT, "bin/prettier.cjs"),
-        process: (text) =>
-          text.replace("../src/cli/index.js", "../internal/legacy-cli.mjs"),
+        process(text) {
+          text = text.replace(
+            "../src/cli/index.js",
+            "../internal/legacy-cli.mjs",
+          );
+          text = text.replace(
+            "process.env.PRETTIER_EXPERIMENTAL_CLI",
+            "!process.env.PRETTIER_LEGACY_CLI",
+          );
+          return text;
+        },
       },
     ],
     external: ["@prettier/cli"],


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

So we don't need set `PRETTIER_LEGACY_CLI` every time we want use CLI

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
