### PR TITLE
Fix JSDoc `@param` comments broken by shifted parentheses

### DIFF
--- a/changelog_unreleased/javascript/17373.md
+++ b/changelog_unreleased/javascript/17373.md
@@ -1,0 +1,17 @@
+#### Fix JSDoc `@param` comments broken by shifted parentheses (#17373 by @k-yle)
+
+Fixed a bug that caused Prettier to move JSDoc comments containing `/** @param */` in rare cases.
+Prettier previously moved the JSDoc comment outside of the parentheses, causing the comment to be
+disassociated from the function. This affects TypeScript's [`checkJs`](https://typescriptlang.org/tsconfig/#checkJs) mode.
+
+<!-- prettier-ignore -->
+```js
+// Input
+(/** @param {string} x */ function (x) {});
+
+// Prettier stable
+/** @param {string} x */ (function (x) {});
+
+// Prettier main
+(/** @param {string} x */ function (x) {});
+```

--- a/src/language-js/print/comment.js
+++ b/src/language-js/print/comment.js
@@ -1,8 +1,14 @@
 import { hardline, join, replaceEndOfLine } from "../../document/index.js";
+import { printComments } from "../../main/comments/print.js";
 import { locEnd, locStart } from "../loc.js";
 import isBlockComment from "../utilities/is-block-comment.js";
 import isIndentableBlockComment from "../utilities/is-indentable-block-comment.js";
 import isLineComment from "../utilities/is-line-comment.js";
+import { getComments } from "../utilities/index.js";
+import isJsdocParamComment from "../utilities/is-jsdoc-param-comment.js";
+
+/** @import AstPath from "../../common/ast-path.js" */
+/** @import { Doc } from "../../index.js" */
 
 function printComment(path, options) {
   const comment = path.node;
@@ -26,6 +32,28 @@ function printComment(path, options) {
   throw new Error("Not a comment: " + JSON.stringify(comment));
 }
 
+/**
+ * Some comments need to stay attached to their original AST node, for
+ * example JSDoc's `@param`. These comments are printed early, before
+ * parentheses are inserted.
+ * @param {AstPath} path
+ * @param {Doc} doc
+ * @param {*} options
+ */
+function printUnmovableComments(path, doc, options) {
+  const comments = getComments(path.node);
+  const hasUnmovableComments = comments.some(isJsdocParamComment);
+
+  if (hasUnmovableComments) {
+    doc = printComments(path, doc, options);
+    for (const comment of comments) {
+      options[Symbol.for("printedComments")].add(comment);
+    }
+  }
+
+  return doc;
+}
+
 function printIndentableBlockComment(comment) {
   const lines = comment.value.split("\n");
 
@@ -43,4 +71,4 @@ function printIndentableBlockComment(comment) {
   ];
 }
 
-export { printComment };
+export { printComment, printUnmovableComments };

--- a/src/language-js/print/index.js
+++ b/src/language-js/print/index.js
@@ -6,6 +6,7 @@ import { shouldPrintLeadingSemicolon } from "../semicolon/semicolon.js";
 import { createTypeCheckFunction } from "../utilities/index.js";
 import isIgnored from "../utilities/is-ignored.js";
 import { printAngular } from "./angular.js";
+import { printUnmovableComments } from "./comment.js";
 import { printDecorators } from "./decorators.js";
 import { printEstree } from "./estree.js";
 import { printFlow } from "./flow.js";
@@ -93,7 +94,7 @@ function print(path, options, print, args) {
     needsParens ? "(" : "",
     needsParens && isClassExpression && hasDecorators
       ? [indent([line, decoratorsDoc, doc]), line]
-      : [decoratorsDoc, doc],
+      : [decoratorsDoc, printUnmovableComments(path, doc, options)],
     needsParens ? ")" : "",
   ]);
 }

--- a/src/language-js/utilities/is-jsdoc-param-comment.js
+++ b/src/language-js/utilities/is-jsdoc-param-comment.js
@@ -1,0 +1,19 @@
+import isBlockComment from "./is-block-comment.js";
+
+/**
+ * @import {Comment} from "../types/estree.js"
+ */
+
+/**
+ * @param {Comment} comment
+ * @returns {boolean}
+ */
+function isJsdocParamComment(comment) {
+  return (
+    isBlockComment(comment) &&
+    comment.value[0] === "*" &&
+    /@param\b/u.test(comment.value)
+  );
+}
+
+export default isJsdocParamComment;

--- a/tests/format/js/comments-closure-typecast/__snapshots__/format.test.js.snap
+++ b/tests/format/js/comments-closure-typecast/__snapshots__/format.test.js.snap
@@ -308,11 +308,24 @@ const helpers2 = /** @type {Helpers} */ ((
   function() { return something }
 )());
 
-// TODO: @param is misplaced https://github.com/prettier/prettier/issues/5850
 const helpers = /** @type {Helpers} */ ((
   /** @param {Partial<Helpers>} helpers */
   (helpers = {}) => helpers
 )());
+
+!(/** @param {number} x */ (x) => x);
+
+(/** @param {string} x */ function (x) {});
+
+
+( /** @param {string} x */// another comment
+  function (x){ });
+
+( /** @param {string} x */// prettier-ignore
+  function (x){    });
+
+// valid use-case with TypeScript's stripInternal option
+( /** @param {string} x */ /* @internal */ function (x){    });
 
 =====================================output=====================================
 const helpers1 = /** @type {Helpers} */ (((helpers = {}) => helpers)());
@@ -323,11 +336,23 @@ const helpers2 = /** @type {Helpers} */ (
   })()
 );
 
-// TODO: @param is misplaced https://github.com/prettier/prettier/issues/5850
 const helpers = /** @type {Helpers} */ (
-  /** @param {Partial<Helpers>} helpers */
-  ((helpers = {}) => helpers)()
+  (/** @param {Partial<Helpers>} helpers */
+  (helpers = {}) => helpers)()
 );
+
+!((/** @param {number} x */ (x) => x));
+
+(/** @param {string} x */ function (x) {});
+
+(/** @param {string} x */ // another comment
+function (x) {});
+
+(/** @param {string} x */ // prettier-ignore
+function (x){    });
+
+// valid use-case with TypeScript's stripInternal option
+(/** @param {string} x */ /* @internal */ function (x) {});
 
 ================================================================================
 `;

--- a/tests/format/js/comments-closure-typecast/iife.js
+++ b/tests/format/js/comments-closure-typecast/iife.js
@@ -6,8 +6,21 @@ const helpers2 = /** @type {Helpers} */ ((
   function() { return something }
 )());
 
-// TODO: @param is misplaced https://github.com/prettier/prettier/issues/5850
 const helpers = /** @type {Helpers} */ ((
   /** @param {Partial<Helpers>} helpers */
   (helpers = {}) => helpers
 )());
+
+!(/** @param {number} x */ (x) => x);
+
+(/** @param {string} x */ function (x) {});
+
+
+( /** @param {string} x */// another comment
+  function (x){ });
+
+( /** @param {string} x */// prettier-ignore
+  function (x){    });
+
+// valid use-case with TypeScript's stripInternal option
+( /** @param {string} x */ /* @internal */ function (x){    });


### PR DESCRIPTION
Closes #5850, Closes #12967, Does not close #14564

## Description

Fixed a bug that caused Prettier to move JSDoc comments containing `/** @param */` in rare cases.
Prettier previously moved the JSDoc comment outside of the parentheses, causing the comment to be
disassociated from the function. This affects TypeScript's [`checkJs`](https://typescriptlang.org/tsconfig/#checkJs) mode.

<!-- prettier-ignore -->
```js
// Input
(/** @param {string} x */ function (x) {});

// Prettier stable
/** @param {string} x */ (function (x) {});

// Prettier main
(/** @param {string} x */ function (x) {});
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).~~
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
