### PR TITLE
Remove `stdin` mock

### DIFF
--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import getStdin from "get-stdin";
 import * as prettier from "../index.js";
 import { expandPatterns } from "./expand-patterns.js";
 import findCacheFile from "./find-cache-file.js";
@@ -15,7 +16,7 @@ import {
 } from "./prettier-internal.js";
 import { normalizeToPosix, statSafe } from "./utils.js";
 
-const { getStdin, writeFormattedFile } = mockable;
+const { writeFormattedFile } = mockable;
 
 function diff(a, b) {
   return createTwoFilesPatch("", "", a, b, "", "", { context: 2 });

--- a/src/common/mockable.js
+++ b/src/common/mockable.js
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
 import { isCI } from "ci-info";
-import getStdin from "get-stdin";
 
 function writeFormattedFile(file, data) {
   return fs.writeFile(file, data);
@@ -8,7 +7,6 @@ function writeFormattedFile(file, data) {
 
 const mockable = {
   getPrettierConfigSearchStopDirectory: () => undefined,
-  getStdin,
   isCI: () => isCI,
   writeFormattedFile,
 };

--- a/tests/integration/cli-worker.js
+++ b/tests/integration/cli-worker.js
@@ -55,11 +55,6 @@ async function run(options) {
   const prettier = await import(url.pathToFileURL(prettierMainEntry));
   const { mockable } = prettier.__debug;
 
-  // We cannot use `jest.setMock("get-stream", impl)` here, because in the
-  // production build everything is bundled into one file so there is no
-  // "get-stream" module to mock.
-  // eslint-disable-next-line require-await
-  mockable.getStdin = async () => options.input || "";
   mockable.isCI = () => Boolean(options.ci);
   mockable.getPrettierConfigSearchStopDirectory = () =>
     url.fileURLToPath(new URL("./cli", import.meta.url));

--- a/tests/integration/run-cli.js
+++ b/tests/integration/run-cli.js
@@ -69,10 +69,6 @@ function runCliWorker(dir, args, options) {
     });
   }
 
-  if (options.input) {
-    worker.stdin.end(options.input);
-  }
-
   const removeStdioFinalNewLine = () => {
     for (const stream of ["stdout", "stderr"]) {
       result[stream] = removeFinalNewLine(result[stream]);
@@ -90,26 +86,32 @@ function runCliWorker(dir, args, options) {
       reject(error);
     });
 
-    worker.send(options, (error) => {
-      if (!error) {
-        return;
+    worker.once("spawn", () => {
+      if (options.input) {
+        worker.stdin.end(options.input);
       }
 
-      // It can fail with `write EPIPE` error when running node with unsupported flags like `--experimental-strip-types`
-      // Let's ignore and wait for the `close` event
-      if (
-        error.code === "EPIPE" &&
-        error.syscall === "write" &&
-        nodeOptions.length > 0
-      ) {
-        if (IS_CI) {
-          // eslint-disable-next-line no-console
-          console.error(Object.assign(error, { dir, args, options, worker }));
+      worker.send(options, (error) => {
+        if (!error) {
+          return;
         }
-        return;
-      }
 
-      reject(error);
+        // It can fail with `write EPIPE` error when running node with unsupported flags like `--experimental-strip-types`
+        // Let's ignore and wait for the `close` event
+        if (
+          error.code === "EPIPE" &&
+          error.syscall === "write" &&
+          nodeOptions.length > 0
+        ) {
+          if (IS_CI) {
+            // eslint-disable-next-line no-console
+            console.error(Object.assign(error, { dir, args, options, worker }));
+          }
+          return;
+        }
+
+        reject(error);
+      });
     });
   });
 }

--- a/tests/integration/run-cli.js
+++ b/tests/integration/run-cli.js
@@ -50,7 +50,7 @@ function runCliWorker(dir, args, options) {
         : []),
       ...nodeOptions,
     ],
-    stdio: "pipe",
+    stdio: [options.input ? "pipe" : "ignore", "pipe", "pipe", "ipc"],
     env: {
       ...process.env,
       NO_COLOR: "1",

--- a/tests/integration/run-cli.js
+++ b/tests/integration/run-cli.js
@@ -86,8 +86,11 @@ function runCliWorker(dir, args, options) {
       reject(error);
     });
 
-    worker.once("spawn", () => {
+    worker.once("spawn", async () => {
       if (options.input) {
+        if (process.platform === "darwin") {
+          await new Promise((resolve) => worker.stdin.once("finish", resolve));
+        }
         worker.stdin.end(options.input);
       }
 

--- a/tests/integration/run-cli.js
+++ b/tests/integration/run-cli.js
@@ -86,11 +86,8 @@ function runCliWorker(dir, args, options) {
       reject(error);
     });
 
-    worker.once("spawn", async () => {
+    worker.once("spawn", () => {
       if (options.input) {
-        if (process.platform === "darwin") {
-          await new Promise((resolve) => worker.stdin.once("finish", resolve));
-        }
         worker.stdin.end(options.input);
       }
 

--- a/tests/integration/run-cli.js
+++ b/tests/integration/run-cli.js
@@ -2,6 +2,17 @@ import childProcess from "node:child_process";
 import path from "node:path";
 import url from "node:url";
 
+/**
+@typedef {{
+  isTTY?: boolean,
+  stdoutIsTTY?: boolean,
+  ci?: boolean,
+  mockWriteFileErrors?: Record<string, string>,
+  nodeOptions?: string[],
+  input?: string,
+}} CliTestOptions
+*/
+
 // Though the doc says `childProcess.fork` accepts `URL`, but seems not true
 // TODO: Use `URL` directly when we drop support for Node.js v14
 const CLI_WORKER_FILE = url.fileURLToPath(
@@ -16,6 +27,11 @@ const removeFinalNewLine = (string) =>
 const SUPPORTS_DISABLE_WARNING_FLAG =
   Number(process.versions.node.split(".")[0]) >= 20;
 
+/**
+ * @param {string} dir
+ * @param {string[]} args
+ * @param {CliTestOptions} options
+ */
 function runCliWorker(dir, args, options) {
   const result = {
     status: undefined,
@@ -51,6 +67,10 @@ function runCliWorker(dir, args, options) {
     worker[stream].on("data", (data) => {
       result[stream] += data.toString();
     });
+  }
+
+  if (options.input) {
+    worker.stdin.end(options.input);
   }
 
   const removeStdioFinalNewLine = () => {
@@ -101,6 +121,11 @@ function runPrettierCli(dir, args, options) {
   return runCliWorker(dir, args, options);
 }
 
+/**
+ * @param {string} dir
+ * @param {string[]} [args]
+ * @param {CliTestOptions} [options]
+ */
 function runCli(dir, args = [], options = {}) {
   const promise = runPrettierCli(dir, args, options);
   const getters = {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

We run tests in `child_process` now, so we can use `stdin` directly without mocking.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
