### PR TITLE
Measure time with `performance.now()` instead of `Date.now()`

### DIFF
--- a/src/common/mockable.js
+++ b/src/common/mockable.js
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { performance } from "node:perf_hooks";
 import { isCI } from "ci-info";
 
 function writeFormattedFile(file, data) {
@@ -9,6 +10,7 @@ const mockable = {
   getPrettierConfigSearchStopDirectory: () => undefined,
   isCI: () => isCI,
   writeFormattedFile,
+  getTimestamp: performance.now.bind(performance),
 };
 
 export default mockable;

--- a/tests/integration/cli-worker.js
+++ b/tests/integration/cli-worker.js
@@ -18,8 +18,6 @@ const replaceAll = (text, find, replacement) =>
     : text.split(find).join(replacement);
 
 async function run(options) {
-  Date.now = () => 0;
-
   readline.clearLine = (stream) => {
     stream.write(
       `\n[[called readline.clearLine(${
@@ -38,6 +36,8 @@ async function run(options) {
   const prettier = await import(url.pathToFileURL(prettierMainEntry));
   const { mockable } = prettier.__debug;
 
+  // Time measure in format test
+  mockable.getTimestamp = () => 0;
   mockable.isCI = () => Boolean(options.ci);
   mockable.getPrettierConfigSearchStopDirectory = () =>
     url.fileURLToPath(new URL("./cli", import.meta.url));


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
