### PR TITLE
Add more tests for reserved words

### DIFF
--- a/tests/format/js/reserved-word/__snapshots__/format.test.js.snap
+++ b/tests/format/js/reserved-word/__snapshots__/format.test.js.snap
@@ -12,7 +12,7 @@ new interface();
 ({ interface: "foo" });
 (interface, "foo");
 void interface;
-const interface = "foo";
+var interface = "foo";
 
 =====================================output=====================================
 foo.interface;
@@ -21,7 +21,7 @@ new interface();
 ({ interface: "foo" });
 (interface, "foo");
 void interface;
-const interface = "foo";
+var interface = "foo";
 
 ================================================================================
 `;

--- a/tests/format/js/reserved-word/__snapshots__/format.test.js.snap
+++ b/tests/format/js/reserved-word/__snapshots__/format.test.js.snap
@@ -25,3 +25,55 @@ const interface = "foo";
 
 ================================================================================
 `;
+
+exports[`let.js format 1`] = `
+====================================options=====================================
+parsers: ["acorn", "espree", "meriyah", "babel"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+foo.let;
+let.foo;
+new let();
+({ let: "foo" });
+(let, "foo");
+void let;
+var let = "foo";
+
+=====================================output=====================================
+foo.let;
+let.foo;
+new let();
+({ let: "foo" });
+(let, "foo");
+void let;
+var let = "foo";
+
+================================================================================
+`;
+
+exports[`yield.js format 1`] = `
+====================================options=====================================
+parsers: ["acorn", "espree", "meriyah", "babel"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+foo.yield;
+yield.foo;
+new yield();
+({ yield: "foo" });
+(yield, "foo");
+void yield;
+var yield = "foo";
+
+=====================================output=====================================
+foo.yield;
+yield.foo;
+new yield();
+({ yield: "foo" });
+(yield, "foo");
+void yield;
+var yield = "foo";
+
+================================================================================
+`;

--- a/tests/format/js/reserved-word/interfaces.js
+++ b/tests/format/js/reserved-word/interfaces.js
@@ -4,4 +4,4 @@ new interface();
 ({ interface: "foo" });
 (interface, "foo");
 void interface;
-const interface = "foo";
+var interface = "foo";

--- a/tests/format/js/reserved-word/let.js
+++ b/tests/format/js/reserved-word/let.js
@@ -1,0 +1,7 @@
+foo.let;
+let.foo;
+new let();
+({ let: "foo" });
+(let, "foo");
+void let;
+var let = "foo";

--- a/tests/format/js/reserved-word/yield.js
+++ b/tests/format/js/reserved-word/yield.js
@@ -1,0 +1,7 @@
+foo.yield;
+yield.foo;
+new yield();
+({ yield: "foo" });
+(yield, "foo");
+void yield;
+var yield = "foo";


### PR DESCRIPTION
closes: #10603

## Description

<!-- Please provide a brief summary of your changes -->

Just added missing test cases for the reserved words `yield` and `let`.

These words are mentioned in https://github.com/prettier/prettier/issues/10603#issuecomment-845466073.
These words would be contextual keywords that can be used as identifiers in certain contexts.

Adding missing test cases are required in https://github.com/prettier/prettier/issues/10603#issuecomment-845468319.

### Note
In https://github.com/o-m12a/prettier/commit/1980a53bfefe841a608c762eb40ad4ee5d04ed01, I also unified to use `var` in test snippets.

This was done because, using `const` or `let` instead of `var` like the following in `let.js`
```.ts
const let = "foo"; // using `const` instead of `var`
let let = "foo"; // using `let` instead of `var`
```
causes the TypeScript error `'let' is not allowed to be used as a name in 'let' or 'const' declarations. ts(2480)`.

I'd like to avoid this compile error by using `var`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨