### PR TITLE
Fix misplacement of comments from after an arrow to before it

### DIFF
--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -95,6 +95,7 @@ function handleEndOfLineComment(context) {
     handleSwitchDefaultCaseComments,
     handleLastUnionElementInExpression,
     handleLastBinaryOperatorOperand,
+    handleCommentAfterArrowExpression,
   ].some((fn) => fn(context));
 }
 
@@ -1075,6 +1076,39 @@ function handleLastBinaryOperatorOperand({
       return true;
     }
   }
+  return false;
+}
+
+/**
+ * Handle a comment after an arrow, like:
+ *   ```ts
+ *   const test = (): any => /* first line
+ *   second line
+ *   *\/
+ *   null;
+ *   ```
+ *
+ * @param {CommentContext} context
+ * @returns {boolean}
+ */
+function handleCommentAfterArrowExpression({
+  comment,
+  enclosingNode,
+  followingNode,
+  precedingNode,
+}) {
+  if (!(enclosingNode && followingNode && precedingNode)) {
+    return false;
+  }
+
+  if (
+    precedingNode.type === "TSTypeAnnotation" &&
+    enclosingNode.type === "ArrowFunctionExpression"
+  ) {
+    addLeadingComment(followingNode, comment);
+    return true;
+  }
+
   return false;
 }
 

--- a/tests/format/typescript/arrow/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/arrow/__snapshots__/format.test.js.snap
@@ -99,7 +99,7 @@ foo4 =
 
 exports[`16067.ts format 1`] = `
 ====================================options=====================================
-parsers: ["typescript"]
+parsers: ["typescript", "babel-ts"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -237,7 +237,7 @@ app.get("/", (req, res): void => {
 
 exports[`arrow_regression.ts format 1`] = `
 ====================================options=====================================
-parsers: ["typescript"]
+parsers: ["typescript", "babel-ts"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -294,6 +294,12 @@ const fn2 = () => {
 // foo
 ;
 
+const fn3 = (): any => /*
+A comment after an arrow with a type definition, and before a line break.
+Formatting should keep it after the arrow.
+*/
+null;
+
 =====================================output=====================================
 const fn1 = () => {
   return
@@ -304,13 +310,19 @@ const fn2 = () => {
 }
 
 // foo
+const fn3 = (): any =>
+  /*
+A comment after an arrow with a type definition, and before a line break.
+Formatting should keep it after the arrow.
+*/
+  null
 
 ================================================================================
 `;
 
 exports[`comments.ts format 1`] = `
 ====================================options=====================================
-parsers: ["typescript"]
+parsers: ["typescript", "babel-ts"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -325,6 +337,12 @@ const fn2 = () => {
 // foo
 ;
 
+const fn3 = (): any => /*
+A comment after an arrow with a type definition, and before a line break.
+Formatting should keep it after the arrow.
+*/
+null;
+
 =====================================output=====================================
 const fn1 = () => {
   return;
@@ -335,6 +353,12 @@ const fn2 = () => {
 };
 
 // foo
+const fn3 = (): any =>
+  /*
+A comment after an arrow with a type definition, and before a line break.
+Formatting should keep it after the arrow.
+*/
+  null;
 
 ================================================================================
 `;
@@ -390,7 +414,7 @@ const getIconEngagementTypeFrom2 =
 
 exports[`issue-6107-curry.ts format 1`] = `
 ====================================options=====================================
-parsers: ["typescript"]
+parsers: ["typescript", "babel-ts"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/typescript/arrow/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/arrow/__snapshots__/format.test.js.snap
@@ -300,6 +300,9 @@ Formatting should keep it after the arrow.
 */
 null;
 
+const fn4 = (): any => /* A single line ver of \`fn3\` */
+null;
+
 =====================================output=====================================
 const fn1 = () => {
   return
@@ -316,6 +319,8 @@ A comment after an arrow with a type definition, and before a line break.
 Formatting should keep it after the arrow.
 */
   null
+
+const fn4 = (): any => /* A single line ver of \`fn3\` */ null
 
 ================================================================================
 `;
@@ -343,6 +348,9 @@ Formatting should keep it after the arrow.
 */
 null;
 
+const fn4 = (): any => /* A single line ver of \`fn3\` */
+null;
+
 =====================================output=====================================
 const fn1 = () => {
   return;
@@ -359,6 +367,8 @@ A comment after an arrow with a type definition, and before a line break.
 Formatting should keep it after the arrow.
 */
   null;
+
+const fn4 = (): any => /* A single line ver of \`fn3\` */ null;
 
 ================================================================================
 `;

--- a/tests/format/typescript/arrow/comments.ts
+++ b/tests/format/typescript/arrow/comments.ts
@@ -8,3 +8,9 @@ const fn2 = () => {
 
 // foo
 ;
+
+const fn3 = (): any => /*
+A comment after an arrow with a type definition, and before a line break.
+Formatting should keep it after the arrow.
+*/
+null;

--- a/tests/format/typescript/arrow/comments.ts
+++ b/tests/format/typescript/arrow/comments.ts
@@ -14,3 +14,6 @@ A comment after an arrow with a type definition, and before a line break.
 Formatting should keep it after the arrow.
 */
 null;
+
+const fn4 = (): any => /* A single line ver of `fn3` */
+null;

--- a/tests/format/typescript/arrow/format.test.js
+++ b/tests/format/typescript/arrow/format.test.js
@@ -1,2 +1,2 @@
-runFormatTest(import.meta, ["typescript"]);
+runFormatTest(import.meta, ["typescript", "babel-ts"]);
 runFormatTest(import.meta, ["typescript"], { semi: false });


### PR DESCRIPTION
closes: #11100

## Description

Just applied a correction suggested in https://github.com/prettier/prettier/issues/11100#issuecomment-1059689408 (thanks, @t-mangoe).

### Note

I also wrote detailed conditions to reproduce this issue in https://github.com/prettier/prettier/issues/11100#issuecomment-2846775428.

<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨