### PR TITLE
Fix colors detect for logger

### DIFF
--- a/src/cli/logger.js
+++ b/src/cli/logger.js
@@ -1,6 +1,22 @@
 import mockable from "./mockable.js";
 import { picocolors } from "./prettier-internal.js";
 
+const { argv, env } = process;
+// https://github.com/alexeyraspopov/picocolors/blob/0e7c4af2de299dd7bc5916f2bddd151fa2f66740/picocolors.js#L2
+// Not working on Windows, but this is how `picocolors` works for stdout, let's keep it this way for now
+const isStderrColorSupported =
+  !(Boolean(env.NO_COLOR) || argv.includes("--no-color")) &&
+  (Boolean(env.FORCE_COLOR) ||
+    argv.includes("--color") ||
+    process.platform === "win32" ||
+    (process.stderr.isTTY && env.TERM !== "dumb") ||
+    Boolean(env.CI));
+// To test this feature,
+// run `echo foo | node bin/prettier --unknown-flag --log-level=debug 2>error.log`
+// open error.log check if `[warn]` or `[debug]` is colored
+// https://github.com/prettier/prettier/issues/13097
+const picocolorsStderr = picocolors.createColors(isStderrColorSupported);
+
 const emptyLogResult = { clear() {} };
 function createLogger(logLevel = "log") {
   return {
@@ -17,7 +33,8 @@ function createLogger(logLevel = "log") {
     }
 
     const stream = process[loggerName === "log" ? "stdout" : "stderr"];
-    const prefix = color ? `[${picocolors[color](loggerName)}] ` : "";
+    const colors = loggerName === "log" ? picocolors : picocolorsStderr;
+    const prefix = color ? `[${colors[color](loggerName)}] ` : "";
 
     return (message, options) => {
       options = {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

When I work on https://github.com/prettier/prettier/pull/17226, I noticed this, I thought it doesn't matter, but apparently it breaks #13097

I try to add test for it, but it's hard to do, I'm going to give up. Added comment how to test instead.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
