### PR TITLE
Enable decorators tests on `flow` and `typescript` parser

### DIFF
--- a/tests/config/run-format-test.js
+++ b/tests/config/run-format-test.js
@@ -78,10 +78,16 @@ const meriyahDisabledTests = new Set([
     "js/regex/regexp-modifiers.js",
   ].map((file) => path.join(__dirname, "../format", file)),
 ]);
-const babelTsDisabledTest = new Set(
+const babelTsDisabledTests = new Set(
   ["conformance/types/moduleDeclaration/kind-detection.ts"].map((file) =>
     path.join(__dirname, "../format/typescript", file),
   ),
+);
+const flowDisabledTests = new Set(
+  [
+    // Parsing to different ASTs
+    "js/decorators/member-expression.js",
+  ].map((file) => path.join(__dirname, "../format", file)),
 );
 
 const isUnstable = (filename, options) => {
@@ -288,7 +294,9 @@ function runFormatTest(fixtures, parsers, options) {
           (currentParser === "espree" && espreeDisabledTests.has(filename)) ||
           (currentParser === "meriyah" && meriyahDisabledTests.has(filename)) ||
           (currentParser === "acorn" && acornDisabledTests.has(filename)) ||
-          (currentParser === "babel-ts" && babelTsDisabledTest.has(filename))
+          (currentParser === "babel-ts" &&
+            babelTsDisabledTests.has(filename)) ||
+          (currentParser === "flow" && flowDisabledTests.has(filename))
         ) {
           continue;
         }

--- a/tests/format/js/decorators/__snapshots__/format.test.js.snap
+++ b/tests/format/js/decorators/__snapshots__/format.test.js.snap
@@ -22,7 +22,7 @@ Cause: Unexpected character '@'"
 
 exports[`classes.js format 1`] = `
 ====================================options=====================================
-parsers: ["babel"]
+parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -93,7 +93,7 @@ Cause: Unexpected character '@'"
 
 exports[`comments.js format 1`] = `
 ====================================options=====================================
-parsers: ["babel"]
+parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -198,7 +198,7 @@ Cause: Unexpected character '@'"
 
 exports[`member-expression.js format 1`] = `
 ====================================options=====================================
-parsers: ["babel"]
+parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -366,7 +366,7 @@ Cause: Unexpected character '@'"
 
 exports[`methods.js format 1`] = `
 ====================================options=====================================
-parsers: ["babel"]
+parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -422,7 +422,7 @@ Cause: Unexpected character '@'"
 
 exports[`mixed.js format 1`] = `
 ====================================options=====================================
-parsers: ["babel"]
+parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -472,7 +472,7 @@ Cause: Unexpected character '@'"
 
 exports[`mobx.js format 1`] = `
 ====================================options=====================================
-parsers: ["babel"]
+parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -586,7 +586,7 @@ Cause: Unexpected character '@'"
 
 exports[`multiline.js format 1`] = `
 ====================================options=====================================
-parsers: ["babel"]
+parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -647,7 +647,7 @@ Cause: Unexpected character '@'"
 
 exports[`multiple.js format 1`] = `
 ====================================options=====================================
-parsers: ["babel"]
+parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -718,7 +718,7 @@ Cause: Unexpected character '@'"
 
 exports[`parens.js format 1`] = `
 ====================================options=====================================
-parsers: ["babel"]
+parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -758,7 +758,7 @@ Cause: Unexpected character '@'"
 
 exports[`redux.js format 1`] = `
 ====================================options=====================================
-parsers: ["babel"]
+parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/js/decorators/format.test.js
+++ b/tests/format/js/decorators/format.test.js
@@ -1,3 +1,3 @@
-runFormatTest(import.meta, ["babel"], {
-  errors: { acorn: true, espree: true },
+runFormatTest(import.meta, ["babel", "flow", "typescript"], {
+  errors: { acorn: true, espree: true, flow: ["classes.js"] },
 });


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
