### PR TITLE
Fix indentation for starred block comments in JSX

### DIFF
--- a/changelog_unreleased/javascript/tbd-jsx-starred-block-comments.md
+++ b/changelog_unreleased/javascript/tbd-jsx-starred-block-comments.md
@@ -1,0 +1,28 @@
+#### Fix starred block comments in JSX expressions (TBD by @wchargin)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+<div>
+  {/*
+     * starred
+      * comment
+       */}
+</div>;
+
+// Prettier stable
+<div>
+  {/*
+   * starred
+   * comment
+   */}
+</div>;
+
+// Prettier main
+<div>
+  {/*
+    * starred
+    * comment
+    */}
+</div>;
+```

--- a/src/language-js/print/comment.js
+++ b/src/language-js/print/comment.js
@@ -17,7 +17,10 @@ function printComment(commentPath, options) {
 
   if (isBlockComment(comment)) {
     if (isIndentableBlockComment(comment)) {
-      return printIndentableBlockComment(comment);
+      const inJsxEmptyExpression =
+        commentPath.parent?.type === "JSXEmptyExpression";
+      const leadingWhitespace = inJsxEmptyExpression ? "  " : " ";
+      return printIndentableBlockComment(comment, leadingWhitespace);
     }
 
     return ["/*", replaceEndOfLine(comment.value), "*/"];
@@ -27,7 +30,7 @@ function printComment(commentPath, options) {
   throw new Error("Not a comment: " + JSON.stringify(comment));
 }
 
-function printIndentableBlockComment(comment) {
+function printIndentableBlockComment(comment, leadingWhitespace) {
   const lines = comment.value.split("\n");
 
   return [
@@ -37,7 +40,8 @@ function printIndentableBlockComment(comment) {
       lines.map((line, index) =>
         index === 0
           ? line.trimEnd()
-          : " " + (index < lines.length - 1 ? line.trim() : line.trimStart()),
+          : leadingWhitespace +
+            (index < lines.length - 1 ? line.trim() : line.trimStart()),
       ),
     ),
     "*/",

--- a/tests/format/js/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/js/comments/__snapshots__/format.test.js.snap
@@ -3835,7 +3835,7 @@ onClick={() => {}}>
 
 ;<div>
   {/* comment
-   */}
+    */}
 </div>
 
 ;<div>
@@ -3891,14 +3891,14 @@ onClick={() => {}}>
 
 ;<div>
   {/**
-   * JSDoc-y comment in JSX. I wonder what will happen to it?
-   */}
+    * JSDoc-y comment in JSX. I wonder what will happen to it?
+    */}
 </div>
 
 ;<div>
   {/**
-   * Another JSDoc comment in JSX.
-   */}
+    * Another JSDoc comment in JSX.
+    */}
 </div>
 
 ;<div
@@ -4075,7 +4075,7 @@ onClick={() => {}}>
 
 <div>
   {/* comment
-   */}
+    */}
 </div>;
 
 <div>
@@ -4131,14 +4131,14 @@ onClick={() => {}}>
 
 <div>
   {/**
-   * JSDoc-y comment in JSX. I wonder what will happen to it?
-   */}
+    * JSDoc-y comment in JSX. I wonder what will happen to it?
+    */}
 </div>;
 
 <div>
   {/**
-   * Another JSDoc comment in JSX.
-   */}
+    * Another JSDoc comment in JSX.
+    */}
 </div>;
 
 <div

--- a/tests/format/jsx/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/jsx/comments/__snapshots__/format.test.js.snap
@@ -280,6 +280,59 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`indentable.js - {"bracketSameLine":true} format 1`] = `
+====================================options=====================================
+bracketSameLine: true
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<div>
+  {/*
+     * an indentable comment
+      * on several lines
+       */}
+</div>;
+
+<div>
+  {/* an indentable comment
+    * with compact start
+    * and end */}
+</div>;
+
+<div>
+  {999 /* another indentable comment
+    * with something on
+    * the first line
+    */}
+</div>;
+
+=====================================output=====================================
+<div>
+  {/*
+    * an indentable comment
+    * on several lines
+    */}
+</div>;
+
+<div>
+  {/* an indentable comment
+    * with compact start
+    * and end */}
+</div>;
+
+<div>
+  {
+    999 /* another indentable comment
+     * with something on
+     * the first line
+     */
+  }
+</div>;
+
+================================================================================
+`;
+
 exports[`jsx-tag-comment-after-prop.js - {"bracketSameLine":true} format 1`] = `
 ====================================options=====================================
 bracketSameLine: true

--- a/tests/format/jsx/comments/indentable.js
+++ b/tests/format/jsx/comments/indentable.js
@@ -1,0 +1,19 @@
+<div>
+  {/*
+     * an indentable comment
+      * on several lines
+       */}
+</div>;
+
+<div>
+  {/* an indentable comment
+    * with compact start
+    * and end */}
+</div>;
+
+<div>
+  {999 /* another indentable comment
+    * with something on
+    * the first line
+    */}
+</div>;


### PR DESCRIPTION
This patch improves Prettier's handling for multi-line block comments where each line starts with an asterisk, when those comments appear in a JSX expression, like this:

```jsx
<div>
  {/*
    * starred
    * comment
    */}
</div>;
```

Prettier already has nice special handling for this in the non-JSX context: the asterisks are made to line up by adding an extra space at the start of each non-initial line. In a JSX expression node, though, we need two spaces, because the prefix is `{/*` and not just `/*`.

This builds on #2470, which left this test case for future work: https://github.com/prettier/prettier/pull/2470#issuecomment-334964986

Fixes #17487.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] **(N/A)** (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
