### PR TITLE
Fix HTML format that tag name is an object prototype property

### DIFF
--- a/changelog_unreleased/html/17501.md
+++ b/changelog_unreleased/html/17501.md
@@ -1,4 +1,4 @@
-#### Fix formatting when tag name is an object prototype property (#XXXX by @user)
+#### Fix formatting when tag name is an object prototype property (#17501 by @fisker)
 
 <!-- prettier-ignore -->
 ```html

--- a/changelog_unreleased/html/17501.md
+++ b/changelog_unreleased/html/17501.md
@@ -1,0 +1,15 @@
+#### Fix formatting when tag name is an object prototype property (#XXXX by @user)
+
+<!-- prettier-ignore -->
+```html
+<!-- Input -->
+<constructor>
+	text
+</constructor>
+
+<!-- Prettier stable -->
+TypeError: Vn(...).startsWith is not a function
+
+<!-- Prettier main -->
+<constructor> text </constructor>
+```

--- a/src/language-html/utils/index.js
+++ b/src/language-html/utils/index.js
@@ -498,24 +498,28 @@ function getNodeCssStyleDisplay(node, options) {
     case "ignore":
       return "block";
     default:
-      return (
-        (node.type === "element" &&
-          (!node.namespace ||
-            isInSvgForeignObject ||
-            isUnknownNamespace(node)) &&
-          CSS_DISPLAY_TAGS[node.name]) ||
-        CSS_DISPLAY_DEFAULT
-      );
+      if (
+        node.type === "element" &&
+        (!node.namespace || isInSvgForeignObject || isUnknownNamespace(node)) &&
+        Object.hasOwn(CSS_DISPLAY_TAGS, node.name)
+      ) {
+        return CSS_DISPLAY_TAGS[node.name];
+      }
   }
+
+  return CSS_DISPLAY_DEFAULT;
 }
 
 function getNodeCssStyleWhiteSpace(node) {
-  return (
-    (node.type === "element" &&
-      (!node.namespace || isUnknownNamespace(node)) &&
-      CSS_WHITE_SPACE_TAGS[node.name]) ||
-    CSS_WHITE_SPACE_DEFAULT
-  );
+  if (
+    node.type === "element" &&
+    (!node.namespace || isUnknownNamespace(node)) &&
+    Object.hasOwn(CSS_WHITE_SPACE_TAGS, node.name)
+  ) {
+    return CSS_WHITE_SPACE_TAGS[node.name];
+  }
+
+  return CSS_WHITE_SPACE_DEFAULT;
 }
 
 function getMinIndentation(text) {

--- a/tests/format/html/tags/object-prototype-properties/__snapshots__/format.test.js.snap
+++ b/tests/format/html/tags/object-prototype-properties/__snapshots__/format.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`object-prototype-properties.html format 1`] = `
+====================================options=====================================
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<constructor>constructor</constructor>
+<hasOwnProperty>hasOwnProperty</hasOwnProperty>
+<isPrototypeOf>isPrototypeOf</isPrototypeOf>
+<propertyIsEnumerable>propertyIsEnumerable</propertyIsEnumerable>
+<toLocaleString>toLocaleString</toLocaleString>
+<toString>toString</toString>
+<valueOf>valueOf</valueOf>
+<!-- <__defineGetter__>__defineGetter__</__defineGetter__> -->
+<!-- <__defineSetter__>__defineSetter__</__defineSetter__> -->
+<!-- <__lookupGetter__>__lookupGetter__</__lookupGetter__> -->
+<!-- <__lookupSetter__>__lookupSetter__</__lookupSetter__> -->
+<!-- <__proto__>__proto__</__proto__> -->
+
+=====================================output=====================================
+<constructor>constructor</constructor>
+<hasOwnProperty>hasOwnProperty</hasOwnProperty>
+<isPrototypeOf>isPrototypeOf</isPrototypeOf>
+<propertyIsEnumerable>propertyIsEnumerable</propertyIsEnumerable>
+<toLocaleString>toLocaleString</toLocaleString>
+<toString>toString</toString>
+<valueOf>valueOf</valueOf>
+<!-- <__defineGetter__>__defineGetter__</__defineGetter__> -->
+<!-- <__defineSetter__>__defineSetter__</__defineSetter__> -->
+<!-- <__lookupGetter__>__lookupGetter__</__lookupGetter__> -->
+<!-- <__lookupSetter__>__lookupSetter__</__lookupSetter__> -->
+<!-- <__proto__>__proto__</__proto__> -->
+
+================================================================================
+`;

--- a/tests/format/html/tags/object-prototype-properties/format.test.js
+++ b/tests/format/html/tags/object-prototype-properties/format.test.js
@@ -1,0 +1,1 @@
+runFormatTest(import.meta, ["html"]);

--- a/tests/format/html/tags/object-prototype-properties/object-prototype-properties.html
+++ b/tests/format/html/tags/object-prototype-properties/object-prototype-properties.html
@@ -1,0 +1,12 @@
+<constructor>constructor</constructor>
+<hasOwnProperty>hasOwnProperty</hasOwnProperty>
+<isPrototypeOf>isPrototypeOf</isPrototypeOf>
+<propertyIsEnumerable>propertyIsEnumerable</propertyIsEnumerable>
+<toLocaleString>toLocaleString</toLocaleString>
+<toString>toString</toString>
+<valueOf>valueOf</valueOf>
+<!-- <__defineGetter__>__defineGetter__</__defineGetter__> -->
+<!-- <__defineSetter__>__defineSetter__</__defineSetter__> -->
+<!-- <__lookupGetter__>__lookupGetter__</__lookupGetter__> -->
+<!-- <__lookupSetter__>__lookupSetter__</__lookupSetter__> -->
+<!-- <__proto__>__proto__</__proto__> -->


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

Fixes #15511

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
