### PR TITLE
Fix exitCode when parser can not infer

### DIFF
--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -44,10 +44,8 @@ function handleError(context, filename, error, printedFilename, ignoreUnknown) {
     if (ignoreUnknown) {
       return;
     }
-    if (!context.argv.check && !context.argv.listDifferent) {
-      process.exitCode = 2;
-    }
     context.logger.error(error.message);
+    process.exitCode = 2;
     return;
   }
 

--- a/tests/integration/__tests__/infer-parser.js
+++ b/tests/integration/__tests__/infer-parser.js
@@ -88,14 +88,14 @@ describe("unknown path and no parser", () => {
 describe("--check with unknown path and no parser", () => {
   describe("specific file", () => {
     runCli("cli/infer-parser/", ["--check", "FOO"]).test({
-      status: 0,
+      status: 2,
       write: [],
     });
   });
 
   describe("multiple files", () => {
     runCli("cli/infer-parser/", ["--check", "*"]).test({
-      status: 1,
+      status: 2,
       write: [],
     });
   });
@@ -104,7 +104,7 @@ describe("--check with unknown path and no parser", () => {
 describe("--list-different with unknown path and no parser", () => {
   describe("specific file", () => {
     runCli("cli/infer-parser/", ["--list-different", "FOO"]).test({
-      status: 0,
+      status: 2,
       stdout: "",
       write: [],
     });
@@ -112,7 +112,7 @@ describe("--list-different with unknown path and no parser", () => {
 
   describe("multiple files", () => {
     runCli("cli/infer-parser/", ["--list-different", "*"]).test({
-      status: 1,
+      status: 2,
       stdout: "foo.js",
       write: [],
     });
@@ -138,14 +138,14 @@ describe("--write with unknown path and no parser", () => {
 describe("--write and --check with unknown path and no parser", () => {
   describe("specific file", () => {
     runCli("cli/infer-parser/", ["--check", "--write", "FOO"]).test({
-      status: 0,
+      status: 2,
       write: [],
     });
   });
 
   describe("multiple files", () => {
     runCli("cli/infer-parser/", ["--check", "--write", "*"]).test({
-      status: 0,
+      status: 2,
     });
   });
 });
@@ -153,7 +153,7 @@ describe("--write and --check with unknown path and no parser", () => {
 describe("--write and --list-different with unknown path and no parser", () => {
   describe("specific file", () => {
     runCli("cli/infer-parser/", ["--list-different", "--write", "FOO"]).test({
-      status: 0,
+      status: 2,
       stdout: "",
       write: [],
     });
@@ -161,7 +161,7 @@ describe("--write and --list-different with unknown path and no parser", () => {
 
   describe("multiple files", () => {
     runCli("cli/infer-parser/", ["--list-different", "--write", "*"]).test({
-      status: 0,
+      status: 2,
     });
   });
 });

--- a/tests/integration/__tests__/patterns-dirs.js
+++ b/tests/integration/__tests__/patterns-dirs.js
@@ -45,7 +45,7 @@ testPatterns("1b - special characters in dir name", ["dir1", "!dir"], {
 });
 testPatterns("1c", ["dir1", "empty"], { status: 1 });
 
-testPatterns("2", ["dir1", "dir2/**/*"], { status: 1 });
+testPatterns("2", ["dir1", "dir2/**/*"], { status: 2 });
 
 testPatterns("3", ["nonexistent-dir", "dir2/**/*"], { status: 2 });
 
@@ -122,7 +122,7 @@ describe("plugins `*`", () => {
     uppercaseRocksPlugin,
   ]).test({
     write: [],
-    status: 1,
+    status: 2,
   });
 });
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
