### PR TITLE
Simplify oxc parser parsing

### DIFF
--- a/src/language-js/parse/utils/get-source-type.js
+++ b/src/language-js/parse/utils/get-source-type.js
@@ -1,9 +1,10 @@
 /** @returns {"module" | "script" | undefined} */
 function getSourceType(options) {
   let { filepath } = options;
-  if (!filepath) {
+  if (typeof filepath !== "string") {
     return;
   }
+
   filepath = filepath.toLowerCase();
 
   if (filepath.endsWith(".cjs") || filepath.endsWith(".cts")) {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

- Remove `rawTransferSupported` cache https://github.com/prettier/prettier/pull/17472#discussion_r2108833255
- Use `sourceType: undefined` instead of `tryCombinationsAsync` https://github.com/prettier/prettier/pull/17472#discussion_r2108836532

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
