### PR TITLE
Improve postprocess perf for type cast comments

### DIFF
--- a/src/language-js/parse/acorn.js
+++ b/src/language-js/parse/acorn.js
@@ -80,7 +80,7 @@ function parse(text, options) {
     throw createParseError(error);
   }
 
-  return postprocess(ast, { text });
+  return postprocess(ast, { text, supportTypeCastComments: true });
 }
 
 export const acorn = createParser(parse);

--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -163,7 +163,7 @@ function createParse({ isExpression = false, optionsCombinations }) {
       ast = wrapBabelExpression(ast, { text, rootMarker: options.rootMarker });
     }
 
-    return postprocess(ast, { text });
+    return postprocess(ast, { text, supportTypeCastComments: true });
   };
 }
 

--- a/src/language-js/parse/oxc.js
+++ b/src/language-js/parse/oxc.js
@@ -71,7 +71,11 @@ async function parseJs(text, options) {
   // @ts-expect-error -- expected
   ast.comments = comments;
 
-  return postprocess(ast, { text, parser: "oxc" });
+  return postprocess(ast, {
+    text,
+    parser: "oxc",
+    supportTypeCastComments: true,
+  });
 }
 
 async function parseTs(text, options) {

--- a/src/language-js/parse/postprocess/index.js
+++ b/src/language-js/parse/postprocess/index.js
@@ -46,7 +46,7 @@ function postprocess(ast, options) {
   // Other parsers parse it as comment, babel treat it as comment too
   // https://github.com/babel/babel/issues/15116
   const program = ast.type === "File" ? ast.program : ast;
-  if (ast.type === "File" && program.interpreter) {
+  if (program.interpreter) {
     comments.unshift(program.interpreter);
     delete program.interpreter;
   }

--- a/src/language-js/parse/postprocess/index.js
+++ b/src/language-js/parse/postprocess/index.js
@@ -45,9 +45,10 @@ function postprocess(ast, options) {
   // `InterpreterDirective` from babel parser and flow parser
   // Other parsers parse it as comment, babel treat it as comment too
   // https://github.com/babel/babel/issues/15116
-  if (ast.type === "File" && ast.program.interpreter) {
-    comments.unshift(ast.program.interpreter);
-    delete ast.program.interpreter;
+  const program = ast.type === "File" ? ast.program : ast;
+  if (ast.type === "File" && program.interpreter) {
+    comments.unshift(program.interpreter);
+    delete program.interpreter;
   }
 
   if (parser === "oxc" && options.oxcAstType === "ts" && ast.hashbang) {

--- a/src/language-js/utils/is-type-cast-comment.js
+++ b/src/language-js/utils/is-type-cast-comment.js
@@ -4,19 +4,26 @@ import isBlockComment from "./is-block-comment.js";
  * @import {Comment} from "../types/estree.js"
  */
 
+const cache = new WeakMap();
+
 /**
  * @param {Comment} comment
  * @returns {boolean}
  */
 function isTypeCastComment(comment) {
-  return (
-    isBlockComment(comment) &&
-    comment.value[0] === "*" &&
-    // TypeScript expects the type to be enclosed in curly brackets, however
-    // Closure Compiler accepts types in parens and even without any delimiters at all.
-    // That's why we just search for "@type" and "@satisfies".
-    /@(?:type|satisfies)\b/u.test(comment.value)
-  );
+  if (!cache.has(comment)) {
+    cache.set(
+      comment,
+      isBlockComment(comment) &&
+        comment.value[0] === "*" &&
+        // TypeScript expects the type to be enclosed in curly brackets, however
+        // Closure Compiler accepts types in parens and even without any delimiters at all.
+        // That's why we just search for "@type" and "@satisfies".
+        /@(?:type|satisfies)\b/u.test(comment.value),
+    );
+  }
+
+  return cache.get(comment);
 }
 
 export default isTypeCastComment;


### PR DESCRIPTION
Fixes #17552

With this the timing for parsing+postprocess of the typescript compiler in node_modules went from 750ms to 250ms, which is close enough to the timing of skipping this step that you get noise depending on which one runs first