### PR TITLE
Improve `isIndentableBlockComment`

### DIFF
--- a/src/language-js/parse/postprocess/index.js
+++ b/src/language-js/parse/postprocess/index.js
@@ -64,8 +64,6 @@ function postprocess(ast, options) {
       if (
         followingComment &&
         locEnd(comment) === locStart(followingComment) &&
-        isBlockComment(comment) &&
-        isBlockComment(followingComment) &&
         isIndentableBlockComment(comment) &&
         isIndentableBlockComment(followingComment)
       ) {

--- a/src/language-js/parse/postprocess/index.js
+++ b/src/language-js/parse/postprocess/index.js
@@ -56,7 +56,7 @@ function postprocess(ast, options) {
     delete ast.hashbang;
   }
 
-  if (comments.length > 0) {
+  if (comments.length > 1) {
     let followingComment;
     for (let i = comments.length - 1; i >= 0; i--) {
       const comment = comments[i];

--- a/src/language-js/print/comment.js
+++ b/src/language-js/print/comment.js
@@ -15,11 +15,11 @@ function printComment(commentPath, options) {
       .trimEnd();
   }
 
-  if (isBlockComment(comment)) {
-    if (isIndentableBlockComment(comment)) {
-      return printIndentableBlockComment(comment);
-    }
+  if (isIndentableBlockComment(comment)) {
+    return printIndentableBlockComment(comment);
+  }
 
+  if (isBlockComment(comment)) {
     return ["/*", replaceEndOfLine(comment.value), "*/"];
   }
 

--- a/src/language-js/utils/is-indentable-block-comment.js
+++ b/src/language-js/utils/is-indentable-block-comment.js
@@ -1,10 +1,26 @@
-function isIndentableBlockComment(comment) {
+import isBlockComment from "./is-block-comment.js";
+
+function isIndentableBlockCommentInternal(comment) {
+  if (!isBlockComment(comment)) {
+    return;
+  }
+
   // If the comment has multiple lines and every line starts with a star
   // we can fix the indentation of each line. The stars in the `/*` and
   // `*/` delimiters are not included in the comment value, so add them
   // back first.
   const lines = `*${comment.value}*`.split("\n");
   return lines.length > 1 && lines.every((line) => line.trimStart()[0] === "*");
+}
+
+const cache = new WeakMap();
+
+function isIndentableBlockComment(comment) {
+  if (!cache.has(comment)) {
+    cache.set(comment, isIndentableBlockCommentInternal(comment));
+  }
+
+  return cache.get(comment);
 }
 
 export default isIndentableBlockComment;

--- a/src/language-js/utils/is-indentable-block-comment.js
+++ b/src/language-js/utils/is-indentable-block-comment.js
@@ -1,6 +1,15 @@
 import isBlockComment from "./is-block-comment.js";
 
 function isIndentableBlockCommentInternal(comment) {
+  /*
+  In postprocess.js
+  this only called when two comments are next to each other,
+  since it's not possible for line comments.
+
+  In printComment
+  It's the line comment is checked first, it can't be a line comment either.
+  */
+  /* c8 ignore next 3 */
   if (!isBlockComment(comment)) {
     return false;
   }

--- a/src/language-js/utils/is-indentable-block-comment.js
+++ b/src/language-js/utils/is-indentable-block-comment.js
@@ -2,7 +2,7 @@ import isBlockComment from "./is-block-comment.js";
 
 function isIndentableBlockCommentInternal(comment) {
   if (!isBlockComment(comment)) {
-    return;
+    return false;
   }
 
   // If the comment has multiple lines and every line starts with a star

--- a/src/language-js/utils/is-indentable-block-comment.js
+++ b/src/language-js/utils/is-indentable-block-comment.js
@@ -4,10 +4,10 @@ function isIndentableBlockCommentInternal(comment) {
   /*
   In postprocess.js
   this only called when two comments are next to each other,
-  since it's not possible for line comments.
+  it's not possible for line comments.
 
   In printComment
-  It's the line comment is checked first, it can't be a line comment either.
+  The line comments are checked first, it can't be a line comment either.
   */
   /* c8 ignore next 3 */
   if (!isBlockComment(comment)) {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

Similar to change for `isTypeCastComment` in #17566, add a cache for it, since the comment value can be big.

Note: this cache may not hit in production, since printer and parser are bundled separately. But will make https://github.com/prettier/prettier/pull/17567 faster.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
