### PR TITLE
Remove `since` from `SupportLanguage` and `ChoiceSupportOption.options` types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -667,7 +667,6 @@ export function clearConfigCache(): Promise<void>;
 
 export interface SupportLanguage {
   name: string;
-  since?: string | undefined;
   parsers: BuiltInParserName[] | string[];
   group?: string | undefined;
   tmScope?: string | undefined;
@@ -772,7 +771,6 @@ export interface ChoiceSupportOption<Value = any>
   default?: Value | Array<{ value: Value }> | undefined;
   description: string;
   choices: Array<{
-    since?: string | undefined;
     value: Value;
     description: string;
   }>;

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -659,12 +659,15 @@ function needsParens(path, options) {
         return true;
       }
 
-      /* Matches the following case in Flow:
-         ```
-         const a = (x: any): x is (number => string) => true;
-         ```
-         This case is not necessary in TS since `number => string` is not a valid
-         arrow type there.
+      /*
+      Matches the following case in Flow:
+
+      ```
+      const a = (x: any): x is (number => string) => true;
+      ```
+
+      This case is not necessary in TS since `number => string` is not a valid
+      arrow type there.
       */
       if (
         path.match(

--- a/tests/dts/unit/cases/plugins.ts
+++ b/tests/dts/unit/cases/plugins.ts
@@ -109,13 +109,12 @@ const plugin: prettier.Plugin<PluginAST> = {
     },
     testChoiceComplexOption: {
       type: "choice",
-      default: [{ since: "1.0.7", value: "banana" }, { value: "apple" }],
+      default: [{ value: "banana" }, { value: "apple" }],
       choices: [
         { value: "apple", description: "A fruit." },
-        { value: "orange", since: "1.0.6", description: "A different fruit." },
+        { value: "orange", description: "A different fruit." },
         {
           value: "banana",
-          since: "1.0.5",
           description: "Added in 1.0.5, made default in 1.0.7.",
         },
       ],

--- a/tests/dts/unit/run.js
+++ b/tests/dts/unit/run.js
@@ -22,6 +22,7 @@ describe("Unit tests for dts files", () => {
       noEmit: true,
       strict: true,
       esModuleInterop: true,
+      skipLibCheck: true,
     };
 
     const program = ts.createProgram(testCaseFiles, compilerOptions);


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

They have been removed in #13699

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
