### PR TITLE
(docs) Replaced every incorrect usages of `bun exec` with `bunx`, `pnpm exec` with `pnpm`, and `yarn exec` with `yarn`

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,7 +11,7 @@ prettier [options] [file/dir/glob ...]
 
 :::note
 
-To run your locally installed version of Prettier, prefix the command with `npx`, `yarn exec`, `pnpm exec`, or `bun exec`, i.e. `npx prettier --help`, `yarn exec prettier --help`, `pnpm exec prettier --help`, or `bun exec prettier --help`.
+To run your locally installed version of Prettier, prefix the command with `npx`, `yarn exec`, `pnpm exec`, or `bun`, i.e. `npx prettier --help`, `yarn exec prettier --help`, `pnpm exec prettier --help`, or `bun prettier --help`.
 
 :::
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,7 +11,7 @@ prettier [options] [file/dir/glob ...]
 
 :::note
 
-To run your locally installed version of Prettier, prefix the command with `npx`, `yarn exec`, `pnpm exec`, or `bunx`, i.e. `npx prettier --help`, `yarn exec prettier --help`, `pnpm exec prettier --help`, or `bunx prettier --help`.
+To run your locally installed version of Prettier, prefix the command with `npx`, `yarn`, `pnpm`, or `bunx`, i.e. `npx prettier --help`, `yarn prettier --help`, `pnpm prettier --help`, or `bunx prettier --help`.
 
 :::
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,7 +11,7 @@ prettier [options] [file/dir/glob ...]
 
 :::note
 
-To run your locally installed version of Prettier, prefix the command with `npx`, `yarn exec`, `pnpm exec`, or `bun`, i.e. `npx prettier --help`, `yarn exec prettier --help`, `pnpm exec prettier --help`, or `bun prettier --help`.
+To run your locally installed version of Prettier, prefix the command with `npx`, `yarn exec`, `pnpm exec`, or `bunx`, i.e. `npx prettier --help`, `yarn exec prettier --help`, `pnpm exec prettier --help`, or `bunx prettier --help`.
 
 :::
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -121,12 +121,16 @@ What is `pnpm exec` doing at the start? `pnpm exec prettier` runs the locally in
 <TabItem value="bun">
 
 ```bash
-bun prettier . --write
+bunx prettier . --write
 ```
 
 :::info
 
-What is `bun` doing at the start? `bun prettier` runs the locally installed version of Prettier. We’ll leave off the `bun` part for brevity throughout the rest of this file!
+What is `bunx` doing at the start? `bunx prettier` runs the locally installed version of Prettier. We’ll leave off the `bunx` part for brevity throughout the rest of this file!
+
+:::warning
+
+If you forget to install Prettier first, `npx` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
 
 :::
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -95,12 +95,12 @@ If you forget to install Prettier first, `npx` will temporarily download the lat
 <TabItem value="yarn">
 
 ```bash
-yarn exec prettier . --write
+yarn prettier . --write
 ```
 
 :::info
 
-What is `yarn exec` doing at the start? `yarn exec prettier` runs the locally installed version of Prettier. We’ll leave off the `yarn exec` part for brevity throughout the rest of this file!
+What is `yarn` doing at the start? `yarn prettier` runs the locally installed version of Prettier. We’ll leave off the `yarn` part for brevity throughout the rest of this file!
 
 :::
 
@@ -108,12 +108,12 @@ What is `yarn exec` doing at the start? `yarn exec prettier` runs the locally in
 <TabItem value="pnpm">
 
 ```bash
-pnpm exec prettier . --write
+pnpm prettier . --write
 ```
 
 :::info
 
-What is `pnpm exec` doing at the start? `pnpm exec prettier` runs the locally installed version of Prettier. We’ll leave off the `pnpm exec` part for brevity throughout the rest of this file!
+What is `pnpm` doing at the start? `pnpm prettier` runs the locally installed version of Prettier. We’ll leave off the `pnpm` part for brevity throughout the rest of this file!
 
 :::
 
@@ -204,8 +204,8 @@ If you use Yarn 2, see https://typicode.github.io/husky/#/?id=yarn-2
 
 ```bash
 pnpm add --save-dev husky lint-staged
-pnpm exec husky init
-node --eval "fs.writeFileSync('.husky/pre-commit','pnpm exec lint-staged\n')"
+pnpm husky init
+node --eval "fs.writeFileSync('.husky/pre-commit','pnpm lint-staged\n')"
 ```
 
 </TabItem>

--- a/docs/install.md
+++ b/docs/install.md
@@ -121,12 +121,12 @@ What is `pnpm exec` doing at the start? `pnpm exec prettier` runs the locally in
 <TabItem value="bun">
 
 ```bash
-bun exec prettier . --write
+bun prettier . --write
 ```
 
 :::info
 
-What is `bun exec` doing at the start? `bun exec prettier` runs the locally installed version of Prettier. We’ll leave off the `bun exec` part for brevity throughout the rest of this file!
+What is `bun` doing at the start? `bun prettier` runs the locally installed version of Prettier. We’ll leave off the `bun` part for brevity throughout the rest of this file!
 
 :::
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -130,7 +130,7 @@ What is `bunx` doing at the start? `bunx prettier` runs the locally installed ve
 
 :::warning
 
-If you forget to install Prettier first, `npx` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
+If you forget to install Prettier first, `bunx` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
 
 :::
 

--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -125,7 +125,7 @@ node --eval "fs.writeFileSync('.husky/pre-commit', 'git-format-staged -f \'prett
 <TabItem value="pnpm">
 
 ```bash
-pnpm exec husky init
+pnpm husky init
 pnpm add --save-dev git-format-staged
 node --eval "fs.writeFileSync('.husky/pre-commit', 'git-format-staged -f \'prettier --ignore-unknown --stdin --stdin-filepath \"{}\"\' .\n')"
 ```

--- a/website/versioned_docs/version-stable/cli.md
+++ b/website/versioned_docs/version-stable/cli.md
@@ -11,7 +11,7 @@ prettier [options] [file/dir/glob ...]
 
 :::note
 
-To run your locally installed version of Prettier, prefix the command with `npx`, `yarn exec`, `pnpm exec`, or `bun exec`, i.e. `npx prettier --help`, `yarn exec prettier --help`, `pnpm exec prettier --help`, or `bun exec prettier --help`.
+To run your locally installed version of Prettier, prefix the command with `npx`, `yarn exec`, `pnpm exec`, or `bun`, i.e. `npx prettier --help`, `yarn exec prettier --help`, `pnpm exec prettier --help`, or `bun prettier --help`.
 
 :::
 

--- a/website/versioned_docs/version-stable/cli.md
+++ b/website/versioned_docs/version-stable/cli.md
@@ -11,7 +11,7 @@ prettier [options] [file/dir/glob ...]
 
 :::note
 
-To run your locally installed version of Prettier, prefix the command with `npx`, `yarn exec`, `pnpm exec`, or `bunx`, i.e. `npx prettier --help`, `yarn exec prettier --help`, `pnpm exec prettier --help`, or `bunx prettier --help`.
+To run your locally installed version of Prettier, prefix the command with `npx`, `yarn`, `pnpm`, or `bunx`, i.e. `npx prettier --help`, `yarn prettier --help`, `pnpm prettier --help`, or `bunx prettier --help`.
 
 :::
 

--- a/website/versioned_docs/version-stable/cli.md
+++ b/website/versioned_docs/version-stable/cli.md
@@ -11,7 +11,7 @@ prettier [options] [file/dir/glob ...]
 
 :::note
 
-To run your locally installed version of Prettier, prefix the command with `npx`, `yarn exec`, `pnpm exec`, or `bun`, i.e. `npx prettier --help`, `yarn exec prettier --help`, `pnpm exec prettier --help`, or `bun prettier --help`.
+To run your locally installed version of Prettier, prefix the command with `npx`, `yarn exec`, `pnpm exec`, or `bunx`, i.e. `npx prettier --help`, `yarn exec prettier --help`, `pnpm exec prettier --help`, or `bunx prettier --help`.
 
 :::
 

--- a/website/versioned_docs/version-stable/install.md
+++ b/website/versioned_docs/version-stable/install.md
@@ -95,12 +95,12 @@ If you forget to install Prettier first, `npx` will temporarily download the lat
 <TabItem value="yarn">
 
 ```bash
-yarn exec prettier . --write
+yarn prettier . --write
 ```
 
 :::info
 
-What is `yarn exec` doing at the start? `yarn exec prettier` runs the locally installed version of Prettier. We’ll leave off the `yarn exec` part for brevity throughout the rest of this file!
+What is `yarn` doing at the start? `yarn prettier` runs the locally installed version of Prettier. We’ll leave off the `yarn` part for brevity throughout the rest of this file!
 
 :::
 
@@ -108,12 +108,12 @@ What is `yarn exec` doing at the start? `yarn exec prettier` runs the locally in
 <TabItem value="pnpm">
 
 ```bash
-pnpm exec prettier . --write
+pnpm prettier . --write
 ```
 
 :::info
 
-What is `pnpm exec` doing at the start? `pnpm exec prettier` runs the locally installed version of Prettier. We’ll leave off the `pnpm exec` part for brevity throughout the rest of this file!
+What is `pnpm` doing at the start? `pnpm prettier` runs the locally installed version of Prettier. We’ll leave off the `pnpm` part for brevity throughout the rest of this file!
 
 :::
 
@@ -206,8 +206,8 @@ If you use Yarn 2, see https://typicode.github.io/husky/#/?id=yarn-2
 
 ```bash
 pnpm add --save-dev husky lint-staged
-pnpm exec husky init
-node --eval "fs.writeFileSync('.husky/pre-commit','pnpm exec lint-staged\n')"
+pnpm husky init
+node --eval "fs.writeFileSync('.husky/pre-commit','pnpm lint-staged\n')"
 ```
 
 </TabItem>

--- a/website/versioned_docs/version-stable/install.md
+++ b/website/versioned_docs/version-stable/install.md
@@ -121,12 +121,18 @@ What is `pnpm exec` doing at the start? `pnpm exec prettier` runs the locally in
 <TabItem value="bun">
 
 ```bash
-bun prettier . --write
+bunx prettier . --write
 ```
 
 :::info
 
-What is `bun` doing at the start? `bun prettier` runs the locally installed version of Prettier. We’ll leave off the `bun` part for brevity throughout the rest of this file!
+What is `bunx` doing at the start? `bunx prettier` runs the locally installed version of Prettier. We’ll leave off the `bunx` part for brevity throughout the rest of this file!
+
+:::
+
+:::warning
+
+If you forget to install Prettier first, `bunx` will temporarily download the latest version. That’s not a good idea when using Prettier, because we change how code is formatted in each release! It’s important to have a locked down version of Prettier in your `package.json`. And it’s faster, too.
 
 :::
 

--- a/website/versioned_docs/version-stable/install.md
+++ b/website/versioned_docs/version-stable/install.md
@@ -121,12 +121,12 @@ What is `pnpm exec` doing at the start? `pnpm exec prettier` runs the locally in
 <TabItem value="bun">
 
 ```bash
-bun exec prettier . --write
+bun prettier . --write
 ```
 
 :::info
 
-What is `bun exec` doing at the start? `bun exec prettier` runs the locally installed version of Prettier. We’ll leave off the `bun exec` part for brevity throughout the rest of this file!
+What is `bun` doing at the start? `bun prettier` runs the locally installed version of Prettier. We’ll leave off the `bun` part for brevity throughout the rest of this file!
 
 :::
 

--- a/website/versioned_docs/version-stable/precommit.md
+++ b/website/versioned_docs/version-stable/precommit.md
@@ -125,7 +125,7 @@ node --eval "fs.writeFileSync('.husky/pre-commit', 'git-format-staged -f \'prett
 <TabItem value="pnpm">
 
 ```bash
-pnpm exec husky init
+pnpm husky init
 pnpm add --save-dev git-format-staged
 node --eval "fs.writeFileSync('.husky/pre-commit', 'git-format-staged -f \'prettier --ignore-unknown --stdin --stdin-filepath \"{}\"\' .\n')"
 ```


### PR DESCRIPTION
## Description

- The command `bun exec` is incorrect. It should be used either with the `bun` prefix or the `bunx` prefix. Here are a few example usages:
  ```bash
  ❌ bun exec prettier . --write
  ✅ bun prettier . --write
  ✅ bunx . --write
  ```
- Additionally, I have added a warning for the usage of the `bunx` command in reference to https://github.com/prettier/prettier/pull/17191#issuecomment-2685135942.
-  This PR also replaces all the usages of `pnpm exec` with `pnpm` and `yarn exec` with `yarn` as per https://github.com/prettier/prettier/pull/17191#issuecomment-2704465697. The interoperability can also be noted from the [documentation for pnpm exec](https://pnpm.io/cli/exec) and the [documentation for yarn exec](https://yarnpkg.com/cli/exec).

## Checklist

- [x] ~I’ve added tests to confirm my change works.~
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] ~(If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
