### PR TITLE
Fix object check in `isTypeModuleObjectExpression`

### DIFF
--- a/src/language-js/print/call-arguments.js
+++ b/src/language-js/print/call-arguments.js
@@ -378,16 +378,24 @@ function isNonEmptyBlockStatement(node) {
   );
 }
 
-// { type: "module" }
+// `{ type: "module" }` and `{"type": "module"}`
 function isTypeModuleObjectExpression(node) {
+  if (!(node.type === "ObjectExpression" && node.properties.length === 1)) {
+    return false;
+  }
+
+  const [property] = node.properties;
+
+  if (!isObjectProperty(property)) {
+    return;
+  }
+
   return (
-    node.type === "ObjectExpression" &&
-    node.properties.length === 1 &&
-    isObjectProperty(node.properties[0]) &&
-    node.properties[0].key.type === "Identifier" &&
-    node.properties[0].key.name === "type" &&
-    isStringLiteral(node.properties[0].value) &&
-    node.properties[0].value.value === "module"
+    !property.computed &&
+    ((property.key.type === "Identifier" && property.key.name === "type") ||
+      (isStringLiteral(property.key) && property.key.value === "type")) &&
+    isStringLiteral(property.value) &&
+    property.value.value === "module"
   );
 }
 

--- a/tests/format/js/module-blocks/__snapshots__/format.test.js.snap
+++ b/tests/format/js/module-blocks/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`comments.js [acorn] format 1`] = `
 "Unexpected token (1:32)
@@ -291,94 +291,6 @@ let moduleBlock = module {
 
 foo(module {
   export let foo = "foo";
-});
-
-================================================================================
-`;
-
-exports[`worker.js [acorn] format 1`] = `
-"Unexpected token (1:32)
-> 1 | let worker = new Worker(module {
-    |                                ^
-  2 |   onmessage = function({data}) {
-  3 |     let mod = import(data);
-  4 |     postMessage(mod.fn());
-Cause: Unexpected token (1:31)"
-`;
-
-exports[`worker.js [espree] format 1`] = `
-"Unexpected token { (1:32)
-> 1 | let worker = new Worker(module {
-    |                                ^
-  2 |   onmessage = function({data}) {
-  3 |     let mod = import(data);
-  4 |     postMessage(mod.fn());
-Cause: Unexpected token {"
-`;
-
-exports[`worker.js [meriyah] format 1`] = `
-"Expected ')' (1:32)
-> 1 | let worker = new Worker(module {
-    |                                ^
-  2 |   onmessage = function({data}) {
-  3 |     let mod = import(data);
-  4 |     postMessage(mod.fn());
-Cause: [1:31-1:32]: Expected ')'"
-`;
-
-exports[`worker.js [oxc] format 1`] = `
-"Expected \`,\` but found \`{\` (1:32)
-> 1 | let worker = new Worker(module {
-    |                                ^
-  2 |   onmessage = function({data}) {
-  3 |     let mod = import(data);
-  4 |     postMessage(mod.fn());"
-`;
-
-exports[`worker.js format 1`] = `
-====================================options=====================================
-parsers: ["babel"]
-printWidth: 80
-                                                                                | printWidth
-=====================================input======================================
-let worker = new Worker(module {
-  onmessage = function({data}) {
-    let mod = import(data);
-    postMessage(mod.fn());
-  }
-}, {type: "module"});
-
-let worker = new Worker(module {
-  onmessage = function({data}) {
-    let mod = import(data);
-    postMessage(mod.fn());
-  }
-}, {type: "module", foo: "bar" });
-
-worker.postMessage(module { export function fn() { return "hello!" } });
-
-=====================================output=====================================
-let worker = new Worker(module {
-  onmessage = function ({ data }) {
-    let mod = import(data);
-    postMessage(mod.fn());
-  };
-}, { type: "module" });
-
-let worker = new Worker(
-  module {
-    onmessage = function ({ data }) {
-      let mod = import(data);
-      postMessage(mod.fn());
-    };
-  },
-  { type: "module", foo: "bar" },
-);
-
-worker.postMessage(module {
-  export function fn() {
-    return "hello!";
-  }
 });
 
 ================================================================================

--- a/tests/format/js/module-blocks/format.test.js
+++ b/tests/format/js/module-blocks/format.test.js
@@ -1,9 +1,9 @@
-runFormatTest(import.meta, ["babel"], {
-  errors: {
-    acorn: ["module-blocks.js", "range.js", "comments.js", "worker.js"],
-    espree: ["module-blocks.js", "range.js", "comments.js", "worker.js"],
-    meriyah: ["module-blocks.js", "range.js", "comments.js", "worker.js"],
-    oxc: ["module-blocks.js", "range.js", "comments.js", "worker.js"],
-    "oxc-ts": ["module-blocks.js", "range.js", "comments.js", "worker.js"],
-  },
-});
+const errors = {
+  acorn: ["module-blocks.js", "range.js", "comments.js"],
+  espree: ["module-blocks.js", "range.js", "comments.js"],
+  meriyah: ["module-blocks.js", "range.js", "comments.js"],
+  oxc: ["module-blocks.js", "range.js", "comments.js"],
+  "oxc-ts": ["module-blocks.js", "range.js", "comments.js"],
+};
+
+runFormatTest(import.meta, ["babel"], { errors });

--- a/tests/format/js/module-blocks/quote-props/__snapshots__/format.test.js.snap
+++ b/tests/format/js/module-blocks/quote-props/__snapshots__/format.test.js.snap
@@ -1,0 +1,103 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`worker.js [acorn] format 1`] = `
+"Unexpected token (1:28)
+> 1 | worker = new Worker(module {
+    |                            ^
+  2 |   onmessage = function({data}) {
+  3 |     let mod = import(data);
+  4 |     postMessage(mod.fn());
+Cause: Unexpected token (1:27)"
+`;
+
+exports[`worker.js [espree] format 1`] = `
+"Unexpected token { (1:28)
+> 1 | worker = new Worker(module {
+    |                            ^
+  2 |   onmessage = function({data}) {
+  3 |     let mod = import(data);
+  4 |     postMessage(mod.fn());
+Cause: Unexpected token {"
+`;
+
+exports[`worker.js [meriyah] format 1`] = `
+"Expected ')' (1:28)
+> 1 | worker = new Worker(module {
+    |                            ^
+  2 |   onmessage = function({data}) {
+  3 |     let mod = import(data);
+  4 |     postMessage(mod.fn());
+Cause: [1:27-1:28]: Expected ')'"
+`;
+
+exports[`worker.js [oxc] format 1`] = `
+"Expected \`,\` but found \`{\` (1:28)
+> 1 | worker = new Worker(module {
+    |                            ^
+  2 |   onmessage = function({data}) {
+  3 |     let mod = import(data);
+  4 |     postMessage(mod.fn());"
+`;
+
+exports[`worker.js format 1`] = `
+====================================options=====================================
+parsers: ["babel"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+worker = new Worker(module {
+  onmessage = function({data}) {
+    let mod = import(data);
+    postMessage(mod.fn());
+  }
+}, {type: "module"});
+
+worker = new Worker(module {
+  onmessage = function({data}) {
+    let mod = import(data);
+    postMessage(mod.fn());
+  }
+}, {'type': "module"});
+
+worker = new Worker(module {
+  onmessage = function({data}) {
+    let mod = import(data);
+    postMessage(mod.fn());
+  }
+}, {type: "module", foo: "bar" });
+
+worker.postMessage(module { export function fn() { return "hello!" } });
+
+=====================================output=====================================
+worker = new Worker(module {
+  onmessage = function ({ data }) {
+    let mod = import(data);
+    postMessage(mod.fn());
+  };
+}, { type: "module" });
+
+worker = new Worker(module {
+  onmessage = function ({ data }) {
+    let mod = import(data);
+    postMessage(mod.fn());
+  };
+}, { type: "module" });
+
+worker = new Worker(
+  module {
+    onmessage = function ({ data }) {
+      let mod = import(data);
+      postMessage(mod.fn());
+    };
+  },
+  { type: "module", foo: "bar" },
+);
+
+worker.postMessage(module {
+  export function fn() {
+    return "hello!";
+  }
+});
+
+================================================================================
+`;

--- a/tests/format/js/module-blocks/quote-props/format.test.js
+++ b/tests/format/js/module-blocks/quote-props/format.test.js
@@ -1,0 +1,9 @@
+runFormatTest(import.meta, ["babel"], {
+  errors: {
+    acorn: ["worker.js"],
+    espree: ["worker.js"],
+    meriyah: ["worker.js"],
+    oxc: ["worker.js"],
+    "oxc-ts": ["worker.js"],
+  },
+});

--- a/tests/format/js/module-blocks/quote-props/worker.js
+++ b/tests/format/js/module-blocks/quote-props/worker.js
@@ -1,11 +1,18 @@
-let worker = new Worker(module {
+worker = new Worker(module {
   onmessage = function({data}) {
     let mod = import(data);
     postMessage(mod.fn());
   }
 }, {type: "module"});
 
-let worker = new Worker(module {
+worker = new Worker(module {
+  onmessage = function({data}) {
+    let mod = import(data);
+    postMessage(mod.fn());
+  }
+}, {'type': "module"});
+
+worker = new Worker(module {
   onmessage = function({data}) {
     let mod = import(data);
     postMessage(mod.fn());


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

Fixes #10909

Since this only effect module expression, and it's an experimental syntax, so I'm not going to add changelog for it.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
