### PR TITLE
Decrease CI `timeout-minutes` to 15mins

### DIFF
--- a/.github/workflows/dev-package-test.yml
+++ b/.github/workflows/dev-package-test.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   test:
     if: github.event_name != 'schedule' || github.repository == 'prettier/prettier'
-    timeout-minutes: 60
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test:
-    timeout-minutes: 60
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/prod-test.yml
+++ b/.github/workflows/prod-test.yml
@@ -46,7 +46,7 @@ jobs:
         run: yarn test:dist-lint
 
   test:
-    timeout-minutes: 90
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

This job hangs for 90 mins https://github.com/prettier/prettier/actions/runs/15631246601/job/44035926724#step:9:1376

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
