### PR TITLE
fix(markdown): prevent extra blank line before nested list

### DIFF
--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -473,6 +473,10 @@ function printListItem(path, options, print, listPrefix) {
         const alignment = " ".repeat(
           clamp(options.tabWidth - listPrefix.length, 0, 3), // 4+ will cause indented code block
         );
+
+        if(node.type === "list"){
+          return print();
+        }
         return [alignment, align(alignment, print())];
       },
     }),


### PR DESCRIPTION
This PR fixes an issue where Prettier added an unnecessary blank line before a nested list.

### Input:
- item
  - sub-item

### Output (before):
- item

  - sub-item

### Output (after fix):
- item
  - sub-item

Updated `printListItem` to skip alignment spacing when node is a list.

