### PR TITLE
Fix typo in template literals test message

### DIFF
--- a/tests/format/js/strings/template-literals.js
+++ b/tests/format/js/strings/template-literals.js
@@ -67,7 +67,7 @@ which already had a linebreak so can be broken up
 `;
 
 // https://github.com/prettier/prettier/issues/16114
-message = `this is a long messsage a simple interpolation without a linebreak ${foo} <- like this`;
+message = `this is a long message a simple interpolation without a linebreak ${foo} <- like this`;
 
 message = `whereas this messsage has a linebreak in the interpolation ${
   foo} <- like this`;


### PR DESCRIPTION


**Description:**  
Corrects a minor typo ("messsage" → "message") in the template literals test file for improved clarity and accuracy.
