### PR TITLE
Revert "Support type cast comments for `espree` parser (#17587)"

### DIFF
--- a/changelog_unreleased/javascript/17491.md
+++ b/changelog_unreleased/javascript/17491.md
@@ -1,4 +1,4 @@
-#### Support type cast comments for `acorn`, `espree`, and `meriyah` parser (#17491, #17566 by @ArnaudBarre, #17587, #17600 by #fisker)
+#### Support type cast comments for `acorn` and `meriyah` parser (#17491, #17566 by @ArnaudBarre, #17600 by #fisker)
 
 This was previously only supported by the Babel parser.
 
@@ -7,9 +7,9 @@ This was previously only supported by the Babel parser.
 // Input
 /** @type {MyType} */ (x).foo;
 
-// Prettier stable (--parser=acorn|espree|meriyah)
+// Prettier stable (--parser=acorn|meriyah)
 /** @type {MyType} */ x.foo;
 
-// Prettier main
+// Prettier main (--parser=acorn)
 /** @type {MyType} */ (x).foo;
 ```

--- a/changelog_unreleased/javascript/17491.md
+++ b/changelog_unreleased/javascript/17491.md
@@ -10,6 +10,6 @@ This was previously only supported by the Babel parser.
 // Prettier stable (--parser=acorn|meriyah)
 /** @type {MyType} */ x.foo;
 
-// Prettier main (--parser=acorn)
+// Prettier main
 /** @type {MyType} */ (x).foo;
 ```

--- a/src/language-js/parse/espree.js
+++ b/src/language-js/parse/espree.js
@@ -1,4 +1,3 @@
-import { defaultOptions as acornDefaultOptions } from "acorn";
 import { parse as espreeParse } from "espree";
 import createError from "../../common/parser-create-error.js";
 import tryCombinations from "../../utils/try-combinations.js";
@@ -57,18 +56,4 @@ function parse(text, options) {
   return postprocess(ast, { parser: "espree", text });
 }
 
-// Workaround for https://github.com/eslint/js/issues/661
-const overrideAcornDefaultOptions =
-  (function_) =>
-  (...arguments_) => {
-    const preserveParensOriginalValue = acornDefaultOptions.preserveParens;
-    acornDefaultOptions.preserveParens = true;
-
-    try {
-      return function_(...arguments_);
-    } finally {
-      acornDefaultOptions.preserveParens = preserveParensOriginalValue;
-    }
-  };
-
-export const espree = createParser(overrideAcornDefaultOptions(parse));
+export const espree = createParser(parse);

--- a/tests/config/run-format-test.js
+++ b/tests/config/run-format-test.js
@@ -64,7 +64,7 @@ const commentClosureTypecaseTests = new Set(
   ].map((directory) => path.join(__dirname, "../format/js", directory)),
 );
 
-const espreeDisabledTests = new Set();
+const espreeDisabledTests = commentClosureTypecaseTests;
 const acornDisabledTests = new Set();
 const meriyahDisabledTests = new Set(
   [


### PR DESCRIPTION
This reverts commit 3b0f335.


## Description

<!-- Please provide a brief summary of your changes -->

They refuse to add support https://github.com/eslint/js/issues/661

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
