### PR TITLE
Resolve Node.js deprecation DEP0178

### DIFF
--- a/scripts/format-test-lint.js
+++ b/scripts/format-test-lint.js
@@ -34,7 +34,7 @@ async function* checkDirectory(directory) {
 
   for (const dirent of files) {
     if (dirent.isDirectory() && dirent.name !== SNAPSHOTS_DIRECTORY_NAME) {
-      yield* checkDirectory(path.join(dirent.path, dirent.name));
+      yield* checkDirectory(path.join(dirent.parentPath, dirent.name));
     }
   }
 }


### PR DESCRIPTION
## Description
Fixes #17630

https://nodejs.org/docs/latest-v22.x/api/fs.html#direntparentpath
The document says dirent.path is an alias for dirent.parentPath. This replacement should be safe.

<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] ~I’ve added tests to confirm my change works.~
- [ ] ~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).~
- [ ] ~(If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
