### PR TITLE
Corrected Angular version.

### DIFF
--- a/website/blog/2025-06-23-3.6.0.md
+++ b/website/blog/2025-06-23-3.6.0.md
@@ -595,7 +595,7 @@ TypeError: Vn(...).startsWith is not a function
 
 #### Support `TemplateLiteral` introduced in Angular 19.2 ([#17238](https://github.com/prettier/prettier/pull/17238) by [@fisker](https://github.com/fisker)) {#change-17238}
 
-Angular 29.2 added [support for `TemplateLiteral`](https://blog.angular.dev/angular-19-2-is-now-available-673ec70aea12#ed7b).
+Angular 19.2 added [support for `TemplateLiteral`](https://blog.angular.dev/angular-19-2-is-now-available-673ec70aea12#ed7b).
 
 <!-- prettier-ignore -->
 ```html


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

Fixed a typo in the 3.6 blog post where "Angular 29.2" was used instead of "Angular 19.2".

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
