### PR TITLE
website: Change Twitter to X

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -201,8 +201,8 @@ const config = {
                 href: "http://stackoverflow.com/questions/tagged/prettier",
               },
               {
-                label: "@PrettierCode on Twitter",
-                href: "https://twitter.com/PrettierCode",
+                label: "@PrettierCode on X",
+                href: "https://x.com/PrettierCode",
               },
             ],
           },


### PR DESCRIPTION
## Description

This pull request includes a minor update to the `website/docusaurus.config.js` file. The change reflects the rebranding of Twitter to X by updating the label and URL for the social media link in the configuration.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
