### PR TITLE
Allow const without initializer in `babel-ts` parser

### DIFF
--- a/changelog_unreleased/typescript/17650.md
+++ b/changelog_unreleased/typescript/17650.md
@@ -1,0 +1,16 @@
+#### Allow const without initializer (#17650 by @fisker)
+
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+export const version: string;
+
+// Prettier stable (--parser=babel-ts)
+SyntaxError: Unexpected token (1:21)
+> 1 | export const version: string;
+    |                     ^
+
+// Prettier main
+export const version: string;
+```

--- a/changelog_unreleased/typescript/17650.md
+++ b/changelog_unreleased/typescript/17650.md
@@ -1,6 +1,5 @@
 #### Allow const without initializer (#17650 by @fisker)
 
-
 <!-- prettier-ignore -->
 ```jsx
 // Input

--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -223,10 +223,11 @@ const babelParserOptionsCombinations = [appendPlugins(["jsx"])];
 const babel = createBabelParser({
   optionsCombinations: babelParserOptionsCombinations,
 });
+const typescriptPluginWithDtsOptions = ["typescript", { dts: true }];
 const babelTs = createBabelParser({
   optionsCombinations: [
-    appendPlugins(["jsx", ["typescript", { dts: true }]]),
-    appendPlugins([["typescript", { dts: true }]]),
+    appendPlugins(["jsx", typescriptPluginWithDtsOptions]),
+    appendPlugins([typescriptPluginWithDtsOptions]),
   ],
 });
 const babelExpression = createBabelParser({

--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -223,11 +223,11 @@ const babelParserOptionsCombinations = [appendPlugins(["jsx"])];
 const babel = createBabelParser({
   optionsCombinations: babelParserOptionsCombinations,
 });
-const typescriptPluginWithDtsOptions = ["typescript", { dts: true }];
+const typescriptPluginWithDtsOption = ["typescript", { dts: true }];
 const babelTs = createBabelParser({
   optionsCombinations: [
-    appendPlugins(["jsx", typescriptPluginWithDtsOptions]),
-    appendPlugins([typescriptPluginWithDtsOptions]),
+    appendPlugins(["jsx", typescriptPluginWithDtsOption]),
+    appendPlugins([typescriptPluginWithDtsOption]),
   ],
 });
 const babelExpression = createBabelParser({

--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -225,8 +225,8 @@ const babel = createBabelParser({
 });
 const babelTs = createBabelParser({
   optionsCombinations: [
-    appendPlugins(["jsx", "typescript"]),
-    appendPlugins(["typescript"]),
+    appendPlugins(["jsx", ["typescript", { dts: true }]]),
+    appendPlugins([["typescript", { dts: true }]]),
   ],
 });
 const babelExpression = createBabelParser({

--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -217,17 +217,26 @@ const allowedReasonCodes = new Set([
   ```
   */
   "ImportAttributesUseAssert",
+
+  /*
+  Allow const without initializer in `.d.ts` files
+  https://github.com/prettier/prettier/issues/17649
+
+  ```
+  export const version: string;
+  ```
+  */
+  "DeclarationMissingInitializer",
 ]);
 
 const babelParserOptionsCombinations = [appendPlugins(["jsx"])];
 const babel = createBabelParser({
   optionsCombinations: babelParserOptionsCombinations,
 });
-const typescriptPluginWithDtsOption = ["typescript", { dts: true }];
 const babelTs = createBabelParser({
   optionsCombinations: [
-    appendPlugins(["jsx", typescriptPluginWithDtsOption]),
-    appendPlugins([typescriptPluginWithDtsOption]),
+    appendPlugins(["jsx", "typescript"]),
+    appendPlugins(["typescript"]),
   ],
 });
 const babelExpression = createBabelParser({

--- a/tests/format/misc/errors/js/variable-declarator/__snapshots__/format.test.js.snap
+++ b/tests/format/misc/errors/js/variable-declarator/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`invalid-const.js [acorn] format 1`] = `
 "Unexpected token (1:10)
@@ -6,14 +6,6 @@ exports[`invalid-const.js [acorn] format 1`] = `
     |          ^
   2 |
 Cause: Unexpected token (1:9)"
-`;
-
-exports[`invalid-const.js [babel] format 1`] = `
-"Missing initializer in const declaration. (1:10)
-> 1 | const foo;
-    |          ^
-  2 |
-Cause: Missing initializer in const declaration. (1:9)"
 `;
 
 exports[`invalid-const.js [espree] format 1`] = `

--- a/tests/format/misc/errors/js/variable-declarator/format.test.js
+++ b/tests/format/misc/errors/js/variable-declarator/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ["babel", "acorn", "espree", "meriyah"]);
+runFormatTest(import.meta, ["acorn", "espree", "meriyah"]);

--- a/tests/format/misc/errors/typescript/modifiers/__snapshots__/format.test.js.snap
+++ b/tests/format/misc/errors/typescript/modifiers/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`snippet: #0 [babel-ts] format 1`] = `
 "'abstract' modifier cannot appear on a type member. (2:3)
@@ -1069,10 +1069,10 @@ Cause: 'async' modifier cannot be used here."
 `;
 
 exports[`snippet: #60 [babel-ts] format 1`] = `
-"Missing initializer in const declaration. (1:16)
+"Missing semicolon. (1:16)
 > 1 | const interface Foo {}
     |                ^
-Cause: Missing initializer in const declaration. (1:15)"
+Cause: Missing semicolon. (1:15)"
 `;
 
 exports[`snippet: #60 [typescript] format 1`] = `
@@ -1533,10 +1533,10 @@ Cause: 'async' modifier cannot be used here."
 `;
 
 exports[`snippet: #92 [babel-ts] format 1`] = `
-"Missing initializer in const declaration. (1:13)
+"Missing semicolon. (1:13)
 > 1 | const module Foo {}
     |             ^
-Cause: Missing initializer in const declaration. (1:12)"
+Cause: Missing semicolon. (1:12)"
 `;
 
 exports[`snippet: #92 [typescript] format 1`] = `
@@ -1547,10 +1547,10 @@ Cause: ',' expected."
 `;
 
 exports[`snippet: #93 [babel-ts] format 1`] = `
-"Missing initializer in const declaration. (1:16)
+"Missing semicolon. (1:16)
 > 1 | const namespace Foo {}
     |                ^
-Cause: Missing initializer in const declaration. (1:15)"
+Cause: Missing semicolon. (1:15)"
 `;
 
 exports[`snippet: #93 [typescript] format 1`] = `

--- a/tests/format/typescript/d-ts-files/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/d-ts-files/__snapshots__/format.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`const-without-initializer.d.ts [oxc-ts] format 1`] = `
-"Missing initializer in const declaration (1:14)
-> 1 | export const version: string;
-    |              ^^^^^^^^^^^^^^^
+"Missing initializer in const declaration (1:17)
+> 1 | export const    version: string;
+    |                 ^^^^^^^^^^^^^^^
   2 |"
 `;
 
@@ -13,10 +13,37 @@ parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
-export const version: string;
+export const    version: string;
 
 =====================================output=====================================
 export const version: string;
+
+================================================================================
+`;
+
+exports[`const-without-initializer-in-namespace.d.ts [oxc-ts] format 1`] = `
+"Missing initializer in const declaration (2:12)
+  1 | export namespace builders {
+> 2 |   const    breakParent: string;
+    |            ^^^^^^^^^^^^^^^^^^^
+  3 | }
+  4 |"
+`;
+
+exports[`const-without-initializer-in-namespace.d.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export namespace builders {
+  const    breakParent: string;
+}
+
+=====================================output=====================================
+export namespace builders {
+  const breakParent: string;
+}
 
 ================================================================================
 `;

--- a/tests/format/typescript/d-ts-files/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/d-ts-files/__snapshots__/format.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`const-without-initializer.d.ts [oxc-ts] format 1`] = `
+"Missing initializer in const declaration (1:14)
+> 1 | export const version: string;
+    |              ^^^^^^^^^^^^^^^
+  2 |"
+`;
+
+exports[`const-without-initializer.d.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export const version: string;
+
+=====================================output=====================================
+export const version: string;
+
+================================================================================
+`;

--- a/tests/format/typescript/d-ts-files/const-without-initializer-in-namespace.d.ts
+++ b/tests/format/typescript/d-ts-files/const-without-initializer-in-namespace.d.ts
@@ -1,0 +1,3 @@
+export namespace builders {
+  const    breakParent: string;
+}

--- a/tests/format/typescript/d-ts-files/const-without-initializer.d.ts
+++ b/tests/format/typescript/d-ts-files/const-without-initializer.d.ts
@@ -1,0 +1,1 @@
+export const version: string;

--- a/tests/format/typescript/d-ts-files/const-without-initializer.d.ts
+++ b/tests/format/typescript/d-ts-files/const-without-initializer.d.ts
@@ -1,1 +1,1 @@
-export const version: string;
+export const    version: string;

--- a/tests/format/typescript/d-ts-files/format.test.js
+++ b/tests/format/typescript/d-ts-files/format.test.js
@@ -1,3 +1,8 @@
 runFormatTest(import.meta, ["typescript"], {
-  errors: { "oxc-ts": ["const-without-initializer.d.ts"] },
+  errors: {
+    "oxc-ts": [
+      "const-without-initializer.d.ts",
+      "const-without-initializer-in-namespace.d.ts",
+    ],
+  },
 });

--- a/tests/format/typescript/d-ts-files/format.test.js
+++ b/tests/format/typescript/d-ts-files/format.test.js
@@ -1,0 +1,3 @@
+runFormatTest(import.meta, ["typescript"], {
+  errors: { "oxc-ts": ["const-without-initializer.d.ts"] },
+});


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

Part of #17649

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
