### PR TITLE
Allow const without initializer in `oxc-ts` parser

### DIFF
--- a/src/language-js/parse/oxc.js
+++ b/src/language-js/parse/oxc.js
@@ -84,36 +84,31 @@ async function parseJs(text, options) {
 }
 
 async function parseTs(text, options) {
-  let filepath = options?.filepath;
+  const filepath = options?.filepath;
   const sourceType = getSourceType(filepath);
   /** @type {ParserOptions} */
   const parseOptions = { sourceType, astType: "ts" };
   const isKnownJsx =
     typeof filepath === "string" && /\.(?:jsx|tsx)$/iu.test(filepath);
+  const isDtsFile =
+    typeof filepath === "string" && filepath.toLowerCase().endsWith(".d.ts");
 
   /** @type {ParserOptions[]} */
-  let parseOptionsCombinations = [];
-  if (isKnownJsx) {
-    parseOptionsCombinations = [{ ...parseOptions, lang: "tsx" }];
-  } else {
+  let filepathCombinations = ["prettier.tsx"];
+  if (isDtsFile) {
+    filepathCombinations = ["prettier.d.ts"];
+  } else if (!isKnownJsx) {
     const shouldEnableJsx = jsxRegexp.test(text);
-    parseOptionsCombinations = [shouldEnableJsx, !shouldEnableJsx].map(
-      (shouldEnableJsx) => ({
-        ...parseOptions,
-        lang: shouldEnableJsx ? "tsx" : "ts",
-      }),
+    filepathCombinations = [shouldEnableJsx, !shouldEnableJsx].map(
+      (shouldEnableJsx) => (shouldEnableJsx ? "prettier.tsx" : "prettier.ts"),
     );
-  }
-
-  if (typeof filepath !== "string") {
-    filepath = "prettier.tsx";
   }
 
   let result;
   try {
     result = await tryCombinationsAsync(
-      parseOptionsCombinations.map(
-        (parseOptions) => () => parseWithOptions(filepath, text, parseOptions),
+      filepathCombinations.map(
+        (filepath) => () => parseWithOptions(filepath, text, parseOptions),
       ),
     );
   } catch ({

--- a/tests/format/typescript/d-ts-files/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/d-ts-files/__snapshots__/format.test.js.snap
@@ -1,12 +1,5 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`const-without-initializer.d.ts [oxc-ts] format 1`] = `
-"Missing initializer in const declaration (1:17)
-> 1 | export const    version: string;
-    |                 ^^^^^^^^^^^^^^^
-  2 |"
-`;
-
 exports[`const-without-initializer.d.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -19,15 +12,6 @@ export const    version: string;
 export const version: string;
 
 ================================================================================
-`;
-
-exports[`const-without-initializer-in-namespace.d.ts [oxc-ts] format 1`] = `
-"Missing initializer in const declaration (2:12)
-  1 | export namespace builders {
-> 2 |   const    breakParent: string;
-    |            ^^^^^^^^^^^^^^^^^^^
-  3 | }
-  4 |"
 `;
 
 exports[`const-without-initializer-in-namespace.d.ts format 1`] = `

--- a/tests/format/typescript/d-ts-files/format.test.js
+++ b/tests/format/typescript/d-ts-files/format.test.js
@@ -1,8 +1,1 @@
-runFormatTest(import.meta, ["typescript"], {
-  errors: {
-    "oxc-ts": [
-      "const-without-initializer.d.ts",
-      "const-without-initializer-in-namespace.d.ts",
-    ],
-  },
-});
+runFormatTest(import.meta, ["typescript"]);


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
