### PR TITLE
Fix typo in v3.6.0 release notes for markdown

### DIFF
--- a/website/blog/2025-06-23-3.6.0.md
+++ b/website/blog/2025-06-23-3.6.0.md
@@ -771,7 +771,7 @@ Correctly parsed as CSS.
 
 #### Fix strong emphasis ([#17143](https://github.com/prettier/prettier/pull/17143) by [@fiji-flo](https://github.com/fiji-flo)) {#change-17143}
 
-Most markdown implementations don't support `1**_2_**3` so prefer `1***2**3`.
+Most markdown implementations don't support `1**_2_**3` so prefer `1***2***3`.
 
 <!-- prettier-ignore -->
 ```md


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

Unbalanced `*` in the example text

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
