### PR TITLE
[docs/rationale.md] delete outdated part

### DIFF
--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -138,15 +138,6 @@ class OrderLine {
 }
 ```
 
-One final thing: TC39 has [not yet decided if decorators come before or after `export`](https://github.com/tc39/proposal-decorators/issues/69). In the meantime, Prettier supports both:
-
-<!-- prettier-ignore -->
-```js
-@decorator export class Foo {}
-
-export @decorator class Foo {}
-```
-
 ### Template literals
 
 Template literals can contain interpolations. Deciding whether it's appropriate to insert a linebreak within an interpolation unfortunately depends on the semantic content of the template - for example, introducing a linebreak in the middle of a natural-language sentence is usually undesirable. Since Prettier doesn't have enough information to make this decision itself, it uses a heuristic similar to that used for objects: it will only split an interpolation expression across multiple lines if there was already a linebreak within that interpolation.


### PR DESCRIPTION
## Description

Fix #17573

TC39 has since decided decorators are valid either before or after `export`, so the clarification is not needed anymore.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
