### PR TITLE
Disable `experimentalRawTransfer` for oxc parser

### DIFF
--- a/packages/plugin-oxc/package.json
+++ b/packages/plugin-oxc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prettier/plugin-oxc",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Prettier Oxc plugin.",
   "type": "module",
   "exports": {

--- a/src/language-js/parse/oxc.js
+++ b/src/language-js/parse/oxc.js
@@ -44,7 +44,6 @@ async function parseWithOptions(filepath, text, options) {
   const result = await oxcParser.parseAsync(filepath, text, {
     preserveParens: true,
     showSemanticErrors: false,
-    experimentalRawTransfer: oxcParser.rawTransferSupported(),
     ...options,
   });
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

It fails tests on my machine, let's try this later. Besides, it seems `experimentalRawTransfer:true` is not faster when I test for parsing a small file.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
