### PR TITLE
Fix config file names order

### DIFF
--- a/src/config/prettier-config/config-searcher.js
+++ b/src/config/prettier-config/config-searcher.js
@@ -8,26 +8,33 @@ import {
 @import {SearcherOptions} from 'search-closest'
 */
 
+// Align with docs, docs/configuration.md
 const CONFIG_FILE_NAMES = [
   "package.json",
   "package.yaml",
+
   ".prettierrc",
+
   ".prettierrc.json",
-  ".prettierrc.yaml",
   ".prettierrc.yml",
+  ".prettierrc.yaml",
   ".prettierrc.json5",
+
   ".prettierrc.js",
-  ".prettierrc.ts",
-  ".prettierrc.mjs",
-  ".prettierrc.mts",
-  ".prettierrc.cjs",
-  ".prettierrc.cts",
   "prettier.config.js",
+  ".prettierrc.ts",
   "prettier.config.ts",
+
+  ".prettierrc.mjs",
   "prettier.config.mjs",
+  ".prettierrc.mts",
   "prettier.config.mts",
+
+  ".prettierrc.cjs",
   "prettier.config.cjs",
+  ".prettierrc.cts",
   "prettier.config.cts",
+
   ".prettierrc.toml",
 ];
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

The list is not in the correct order, per https://prettier.io/docs/configuration
I don't think that user should use multiple configuration files, so it should not break anything, I'm not going to add changelog for this change.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
