### PR TITLE
Fix typescript config test on Node.js v22

### DIFF
--- a/tests/integration/__tests__/config-file-typescript.js
+++ b/tests/integration/__tests__/config-file-typescript.js
@@ -16,18 +16,13 @@ const TAB_WIDTH_3_OUTPUT = outdent`
   }
 `;
 
-// Node.js>=22 supports ts files, 22 requires experimental flag, 23 doesn't
+// Node.js>=22 supports ts files
 if (NODE_JS_MAJOR_VERSION >= 22) {
-  const nodeOptions = NODE_JS_MAJOR_VERSION === 22 ? NODE_TS_SUPPORT_FLAGS : [];
-
   test("Should support typescript config files", async () => {
     const output = await runCli(
       "cli/config/ts/auto-discovery/",
       ["--stdin-filepath", "foo.js"],
-      {
-        input: code,
-        nodeOptions,
-      },
+      { input: code },
     ).stdout;
 
     expect(output).toBe(TAB_WIDTH_3_OUTPUT);
@@ -46,28 +41,12 @@ if (NODE_JS_MAJOR_VERSION >= 22) {
         const output = await runCli(
           "cli/config/ts/config-file-names/",
           ["--stdin-filepath", "foo.js", "--config", configFileName],
-          {
-            input: code,
-            nodeOptions,
-          },
+          { input: code },
         ).stdout;
 
         expect(getOutputTabWidth(output)).toBe(expectedTabWidth);
       });
     }
-  });
-}
-
-if (NODE_JS_MAJOR_VERSION === 22) {
-  test("Should throw errors when flags are missing", () => {
-    runCli("cli/config/ts/auto-discovery/", ["--stdin-filepath", "foo.js"], {
-      input: code,
-    }).test({
-      status: "non-zero",
-      stdout: "",
-      write: [],
-      stderr: expect.stringMatching(/Unknown file extension ".ts" for/u),
-    });
   });
 }
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

Node.js v22.18.0 

[Type stripping is enabled by default](https://nodejs.org/zh-cn/blog/release/v22.18.0#type-stripping-is-enabled-by-default)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
