### PR TITLE
ci: fix a typo `embeded` → `embedded`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Lint docs code block
         run: yarn prettier "{docs,website/versioned_docs/version-stable}/**/*.md" --check
         env:
-          # Make Prettier throws on embeded format
+          # Make Prettier throws on embedded format
           PRETTIER_DEBUG: true
 
       - name: Lint workflow files


### PR DESCRIPTION
## Description

CI:
- Correct 'embeded' to 'embedded' in [lint.yml](https://github.com/prettier/prettier/blob/main/.github/workflows/lint.yml) comment

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
