### PR TITLE
fix: remove `get-stdin`

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "find-cache-directory": "6.0.0",
     "flow-parser": "0.278.0",
     "get-east-asian-width": "1.3.0",
-    "get-stdin": "9.0.0",
     "graphql": "16.11.0",
     "hermes-parser": "0.31.0",
     "html-element-attributes": "3.5.0",

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import * as streamConsumers from "node:stream/consumers"
+import * as streamConsumers from "node:stream/consumers";
 import * as prettier from "../index.js";
 import { expandPatterns } from "./expand-patterns.js";
 import findCacheFile from "./find-cache-file.js";
@@ -148,9 +148,9 @@ async function format(context, input, opt) {
             : diff(ast, past);
         throw new DebugError(
           "ast(input) !== ast(prettier(input))\n" +
-          astDiff +
-          "\n" +
-          diff(input, pp),
+            astDiff +
+            "\n" +
+            diff(input, pp),
         );
       }
       /* c8 ignore end */
@@ -179,7 +179,7 @@ async function format(context, input, opt) {
     const [result] = bench.table();
     context.logger.debug(
       "'--debug-benchmark' measurements for formatWithCursor: " +
-      JSON.stringify(result, undefined, 2),
+        JSON.stringify(result, undefined, 2),
     );
   } else if (performanceTestFlag?.debugRepeat) {
     const repeat = performanceTestFlag.debugRepeat;
@@ -197,7 +197,8 @@ async function format(context, input, opt) {
       ms: averageMs,
     };
     context.logger.debug(
-      `'${performanceTestFlag.name
+      `'${
+        performanceTestFlag.name
       }' measurements for formatWithCursor: ${JSON.stringify(
         results,
         null,

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import getStdin from "get-stdin";
+import * as streamConsumers from "node:stream/consumers"
 import * as prettier from "../index.js";
 import { expandPatterns } from "./expand-patterns.js";
 import findCacheFile from "./find-cache-file.js";
@@ -148,9 +148,9 @@ async function format(context, input, opt) {
             : diff(ast, past);
         throw new DebugError(
           "ast(input) !== ast(prettier(input))\n" +
-            astDiff +
-            "\n" +
-            diff(input, pp),
+          astDiff +
+          "\n" +
+          diff(input, pp),
         );
       }
       /* c8 ignore end */
@@ -179,7 +179,7 @@ async function format(context, input, opt) {
     const [result] = bench.table();
     context.logger.debug(
       "'--debug-benchmark' measurements for formatWithCursor: " +
-        JSON.stringify(result, undefined, 2),
+      JSON.stringify(result, undefined, 2),
     );
   } else if (performanceTestFlag?.debugRepeat) {
     const repeat = performanceTestFlag.debugRepeat;
@@ -197,8 +197,7 @@ async function format(context, input, opt) {
       ms: averageMs,
     };
     context.logger.debug(
-      `'${
-        performanceTestFlag.name
+      `'${performanceTestFlag.name
       }' measurements for formatWithCursor: ${JSON.stringify(
         results,
         null,
@@ -226,7 +225,7 @@ async function formatStdin(context) {
   const { filepath } = context.argv;
 
   try {
-    const input = await getStdin();
+    const input = await streamConsumers.text(process.stdin);
     // TODO[@fisker]: Exit if no input.
     // `prettier --config-precedence cli-override`
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4944,13 +4944,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-stdin@npm:9.0.0":
-  version: 9.0.0
-  resolution: "get-stdin@npm:9.0.0"
-  checksum: 10/5972bc34d05932b45512c8e2d67b040f1c1ca8afb95c56cbc480985f2d761b7e37fe90dc8abd22527f062cc5639a6930ff346e9952ae4c11a2d4275869459594
-  languageName: node
-  linkType: hard
-
 "get-stream@npm:^6.0.0":
   version: 6.0.1
   resolution: "get-stream@npm:6.0.1"
@@ -7502,7 +7495,6 @@ __metadata:
     find-cache-directory: "npm:6.0.0"
     flow-parser: "npm:0.278.0"
     get-east-asian-width: "npm:1.3.0"
-    get-stdin: "npm:9.0.0"
     globals: "npm:16.3.0"
     graphql: "npm:16.11.0"
     hermes-parser: "npm:0.31.0"


### PR DESCRIPTION
## Description

Removes `get-stdin` in favor of Node.js native `stream/consumers` module.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
