### PR TITLE
Resolve ESLint warning log `[@stylistic/eslint-plugin]: You are using deprecated value(boolean) for "allowTemplateLiterals" in "quotes", please use "always"/"never" instead.`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -331,7 +331,7 @@ export default [
         "double",
         {
           avoidEscape: true,
-          allowTemplateLiterals: true,
+          allowTemplateLiterals: "always",
         },
       ],
       "jest/valid-expect": [


### PR DESCRIPTION
## Description
Running `yarn lint`, following warning log is shown.
> [@stylistic/eslint-plugin]: You are using deprecated value(boolean) for "allowTemplateLiterals" in "quotes", please use "always"/"never" instead.

This PR resolve the warning.

`@stylistic/quotes` now also supports `"allowTemplateLiterals" : "allowEscape"`. I think it is preferred over `"always"` but `"allowEscape"` yields many error reports in current code base. Feel free to ask me switching the option to `"allowEscape"`. Then I'll resolve violations.

https://github.com/eslint-stylistic/eslint-stylistic/blob/0a725921e595688d4d958508ca5fdd0d06c71609/packages/eslint-plugin/rules/quotes/README.md#options

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] ~I’ve added tests to confirm my change works.~
- [ ] ~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).~
- [ ] ~(If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
