### PR TITLE
docs: add monaco-prettier integration

### DIFF
--- a/docs/related-projects.md
+++ b/docs/related-projects.md
@@ -31,3 +31,4 @@ title: Related Projects
 - [spotless](https://github.com/diffplug/spotless) lets you run prettier from [gradle](https://github.com/diffplug/spotless/tree/main/plugin-gradle#prettier) or [maven](https://github.com/diffplug/spotless/tree/main/plugin-maven#prettier).
 - [csharpier](https://github.com/belav/csharpier) is a port of Prettier for C#
 - [reviewdog-action-prettier](https://github.com/EPMatt/reviewdog-action-prettier) runs Prettier in GitHub Actions CI/CD workflows
+- [monaco-prettier](https://github.com/remcohaszing/monaco-prettier) integrates Prettier into [Monaco editor](https://microsoft.github.io/monaco-editor/)


### PR DESCRIPTION
## Description

[Monaco editor](https://microsoft.github.io/monaco-editor/) is the editor which powers VSCode. It can be used as a library to create a code editor on websites as well. This adds [`monaco-prettier`](https://github.com/remcohaszing/monaco-prettier) to the list of misc integrations.

Since Monaco editor is a text editor library, not a program, I’m not sure whether this fits best in _Related Projects_ or _Editor Integration_.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
