### PR TITLE
Preserve empty line before endComment

### DIFF
--- a/src/language-yaml/printer-yaml.js
+++ b/src/language-yaml/printer-yaml.js
@@ -218,7 +218,18 @@ function printNode(path, options, print) {
       return [
         join(hardline, path.map(print, "children")),
         separator,
-        join(hardline, path.map(print, "endComments")),
+        join(
+          hardline,
+          path.map(
+            ({ node }) => [
+              isPreviousLineEmpty(options.originalText, locStart(node))
+                ? hardline
+                : "",
+              print(),
+            ],
+            "endComments",
+          ),
+        ),
       ];
     }
     case "directive":

--- a/tests/format/yaml/comment/__snapshots__/format.test.js.snap
+++ b/tests/format/yaml/comment/__snapshots__/format.test.js.snap
@@ -90,6 +90,10 @@ A:
  #A
    #A
 
+foo: bar
+
+# End Comment - Don't remove previous empty line
+
 =====================================output=====================================
 parent:
   one: 1
@@ -104,6 +108,10 @@ A:
   B:
   #A
   #A
+
+foo: bar
+
+# End Comment - Don't remove previous empty line
 
 ================================================================================
 `;

--- a/tests/format/yaml/comment/end-comment.yml
+++ b/tests/format/yaml/comment/end-comment.yml
@@ -11,3 +11,7 @@ A:
   B:
  #A
    #A
+
+foo: bar
+
+# End Comment - Don't remove previous empty line


### PR DESCRIPTION
## Description

Fix: #10922 

Aligns the documentBody endComments processing with the general logic by adding isPreviousLineEmpty
checks to preserve original empty line formatting.

```js
// General logic
if (shouldPrintEndComments(node)) {
    parts.push(
      alignWithSpaces(node.type === "sequenceItem" ? 2 : 0, [
        hardline,
        join(
          hardline,
          path.map(
            ({ node }) => [
              isPreviousLineEmpty(options.originalText, locStart(node))
                ? hardline
                : "",
              print(),
            ],
            "endComments",
          ),
        ),
      ]),
    );
  }
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
