### PR TITLE
Add prettier-plugin-hugo-post to plugins list

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -56,6 +56,7 @@ Strings provided to `plugins` are ultimately passed to [`import()` expression](h
 - [`prettier-plugin-gherkin`](https://github.com/mapado/prettier-plugin-gherkin) by [**@mapado**](https://github.com/mapado)
 - [`prettier-plugin-glsl`](https://github.com/NaridaL/glsl-language-toolkit/tree/main/packages/prettier-plugin-glsl) by [**@NaridaL**](https://github.com/NaridaL)
 - [`prettier-plugin-go-template`](https://github.com/NiklasPor/prettier-plugin-go-template) by [**@NiklasPor**](https://github.com/NiklasPor)
+- [`prettier-plugin-hugo-post`](https://github.com/metcalfc/prettier-plugin-hugo-post) by [**@metcalfc**](https://github.com/metcalfc)
 - [`prettier-plugin-java`](https://github.com/jhipster/prettier-java) by [**@JHipster**](https://github.com/jhipster)
 - [`prettier-plugin-jinja-template`](https://github.com/davidodenwald/prettier-plugin-jinja-template) by [**@davidodenwald**](https://github.com/davidodenwald)
 - [`prettier-plugin-jsonata`](https://github.com/Stedi/prettier-plugin-jsonata) by [**@Stedi**](https://github.com/Stedi)


### PR DESCRIPTION
Add prettier-plugin-hugo-post for Hugo content files

This plugin formats Hugo's .md content files that mix front matter (YAML/TOML/JSON), markdown, and Hugo templates in a single file. Works great alongside prettier-plugin-go-template for complete Hugo project formatting.

## Description

Added a link in the docs for a new plugin

## Checklist

- [x] I’ve added tests to confirm my change works. Tested the URL
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
