### PR TITLE
Fix ICSS detection for nested exports

### DIFF
--- a/changelog_unreleased/css/17929.md
+++ b/changelog_unreleased/css/17929.md
@@ -1,0 +1,27 @@
+#### Fix ICSS detection for nested exports (#17929 by @kovsu)
+
+<!-- prettier-ignore -->
+```css
+/* Input */
+:export {
+  nest: {
+    myColor: blue;
+  }
+  myColor: red;
+}
+/* Prettier stable */
+:export {
+  nest: {
+    mycolor: blue;
+  }
+  myColor: red;
+}
+
+/* Prettier main */
+:export {
+  nest: {
+    myColor: blue;
+  }
+  myColor: red;
+}
+```

--- a/changelog_unreleased/css/17929.md
+++ b/changelog_unreleased/css/17929.md
@@ -1,4 +1,4 @@
-#### Fix ICSS detection for nested exports (#17929 by @kovsu)
+#### Fix selector been lowercased incorrectly inside css modules (#17929 by @kovsu)
 
 <!-- prettier-ignore -->
 ```css

--- a/changelog_unreleased/css/17929.md
+++ b/changelog_unreleased/css/17929.md
@@ -9,6 +9,7 @@
   }
   myColor: red;
 }
+
 /* Prettier stable */
 :export {
   nest: {

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -35,7 +35,7 @@ import {
   hasComposesNode,
   hasParensAroundNode,
   insideAtRuleNode,
-  insideICSSRuleNode,
+  insideIcssRuleNode,
   insideValueFunctionNode,
   isDetachedRulesetCallNode,
   isDetachedRulesetDeclarationNode,
@@ -126,7 +126,7 @@ function genericPrint(path, options, print) {
         node.raws.before.replaceAll(/[\s;]/gu, ""),
         // Less variable
         (parentNode.type === "css-atrule" && parentNode.variable) ||
-        insideICSSRuleNode(path)
+        insideIcssRuleNode(path)
           ? node.prop
           : maybeToLowerCase(node.prop),
         trimmedBetween.startsWith("//") ? " " : "",

--- a/src/language-css/utils/index.js
+++ b/src/language-css/utils/index.js
@@ -67,15 +67,17 @@ function insideValueFunctionNode(path, functionName) {
 }
 
 function insideICSSRuleNode(path) {
-  const ruleAncestorNode = path.findAncestor(
-    (node) => node.type === "css-rule",
-  );
-  const selector = ruleAncestorNode?.raws?.selector;
+  return path.hasAncestor((node) => {
+    if (node.type !== "css-rule") {
+      return false;
+    }
 
-  return (
-    selector &&
-    (selector.startsWith(":import") || selector.startsWith(":export"))
-  );
+    const selector = node.raws?.selector;
+    return (
+      selector &&
+      (selector.startsWith(":import") || selector.startsWith(":export"))
+    );
+  });
 }
 
 function insideAtRuleNode(path, atRuleNameOrAtRuleNames) {

--- a/src/language-css/utils/index.js
+++ b/src/language-css/utils/index.js
@@ -66,6 +66,7 @@ function insideValueFunctionNode(path, functionName) {
   return funcAncestorNode?.value?.toLowerCase() === functionName;
 }
 
+// https://github.com/css-modules/icss
 function insideIcssRuleNode(path) {
   return path.hasAncestor((node) => {
     if (node.type !== "css-rule") {

--- a/src/language-css/utils/index.js
+++ b/src/language-css/utils/index.js
@@ -66,7 +66,7 @@ function insideValueFunctionNode(path, functionName) {
   return funcAncestorNode?.value?.toLowerCase() === functionName;
 }
 
-function insideICSSRuleNode(path) {
+function insideIcssRuleNode(path) {
   return path.hasAncestor((node) => {
     if (node.type !== "css-rule") {
       return false;
@@ -388,7 +388,7 @@ export {
   hasEmptyRawBefore,
   hasParensAroundNode,
   insideAtRuleNode,
-  insideICSSRuleNode,
+  insideIcssRuleNode,
   insideURLFunctionInImportAtRuleNode,
   insideValueFunctionNode,
   isAdditionNode,

--- a/tests/format/css/modules/__snapshots__/format.test.js.snap
+++ b/tests/format/css/modules/__snapshots__/format.test.js.snap
@@ -62,6 +62,13 @@ printWidth: 80
   }
 }
 
+:export {
+  nest: {
+    myColor: blue;
+  }
+  myColor: red;
+}
+
 =====================================output=====================================
 @value colors: './colors.css';
 @value first, second, third from colors;
@@ -117,6 +124,13 @@ printWidth: 80
   to {
     transform: rotate(360deg);
   }
+}
+
+:export {
+  nest: {
+    myColor: blue;
+  }
+  myColor: red;
 }
 
 ================================================================================

--- a/tests/format/css/modules/modules.css
+++ b/tests/format/css/modules/modules.css
@@ -53,3 +53,10 @@
     transform: rotate(360deg);
   }
 }
+
+:export {
+  nest: {
+    myColor: blue;
+  }
+  myColor: red;
+}


### PR DESCRIPTION
## Description

Fix: #10057 

- treat css rules as ICSS whenever any ancestor selector starts with :import or :export

### Before

`path.findAncestor((node) => node.type === "css-rule")` only returns the *closest* css-rule ancestor.
For nested blocks like `nest { myColor: ... }`, the closest selector is `nest`, so `selector.startsWith(":export")` is `false` and `insideICSSRuleNode` returns `false`.
The printer then calls `maybeToLowerCase` on `myColor`, which forces it to lowercase.

### After

`path.hasAncestor((node) => { ... })` walks upward through every ancestor.
Whenever it encounters a css-rule, it checks whether the selector starts with `:import/:export`, and if any level matches it returns `true`.
For declarations inside `nest`, it skips the `nest` rule, finds the outer `:export`, and returns `true`, so `maybeToLowerCase` is skipped and camelCase like `myColor` is preserved.


## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
