### PR TITLE
Avoid unnecessary `getUnescapedAttributeValue()` call

### DIFF
--- a/src/language-html/embed/angular-attributes.js
+++ b/src/language-html/embed/angular-attributes.js
@@ -68,22 +68,23 @@ function printAngularAttribute(path, options) {
     return printNgDirective;
   }
 
-  const value = getUnescapedAttributeValue(node);
-
   /**
    *     i18n="longDescription"
    *     i18n-attr="longDescription"
    */
   if (/^i18n(?:-.+)?$/u.test(attributeName)) {
-    return () =>
-      printExpand(
+    return () => {
+      const value = getUnescapedAttributeValue(node);
+      return printExpand(
         fill(getTextValueParts(node, value.trim())),
         !value.includes("@@"),
       );
+    };
   }
 
-  if (angularInterpolationRegex.test(value)) {
-    return (textToDoc) => printAngularInterpolation(value, textToDoc);
+  if (angularInterpolationRegex.test(node.value)) {
+    return (textToDoc) =>
+      printAngularInterpolation(getUnescapedAttributeValue(node), textToDoc);
   }
 }
 

--- a/src/language-html/embed/vue-attributes.js
+++ b/src/language-html/embed/vue-attributes.js
@@ -30,11 +30,13 @@ function printVueAttribute(path, options) {
     return printVueScriptGenericAttributeValue;
   }
 
-  const value = getUnescapedAttributeValue(node);
   const parseWithTs = isVueSfcWithTypescriptScript(path, options);
 
   if (isVueSlotAttribute(node) || isVueSfcBindingsAttribute(node, options)) {
-    return (textToDoc) => printVueBindings(value, textToDoc, { parseWithTs });
+    return (textToDoc) =>
+      printVueBindings(getUnescapedAttributeValue(node), textToDoc, {
+        parseWithTs,
+      });
   }
 
   /**
@@ -45,7 +47,9 @@ function printVueAttribute(path, options) {
    */
   if (attributeName.startsWith("@") || attributeName.startsWith("v-on:")) {
     return (textToDoc) =>
-      printVueVOnDirective(value, textToDoc, { parseWithTs });
+      printVueVOnDirective(getUnescapedAttributeValue(node), textToDoc, {
+        parseWithTs,
+      });
   }
 
   /**
@@ -59,14 +63,19 @@ function printVueAttribute(path, options) {
     attributeName.startsWith("v-bind:")
   ) {
     return (textToDoc) =>
-      printVueVBindDirective(value, textToDoc, { parseWithTs });
+      printVueVBindDirective(getUnescapedAttributeValue(node), textToDoc, {
+        parseWithTs,
+      });
   }
 
   /**
    *     v-if="jsExpression"
    */
   if (attributeName.startsWith("v-")) {
-    return (textToDoc) => printExpression(value, textToDoc, { parseWithTs });
+    return (textToDoc) =>
+      printExpression(getUnescapedAttributeValue(node), textToDoc, {
+        parseWithTs,
+      });
   }
 }
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
