### PR TITLE
Keep less mixin lookups tight

### DIFF
--- a/src/language-css/print/comma-separated-value-group.js
+++ b/src/language-css/print/comma-separated-value-group.js
@@ -212,6 +212,31 @@ function printCommaSeparatedValueGroup(path, options, print) {
       continue;
     }
 
+    /*
+      .mixin() [@result]
+             ^^^
+    */
+    if (
+      iNode.type === "value-func" &&
+      iNode.value.startsWith(".") &&
+      iNextNode?.type === "value-word" &&
+      iNextNode.value === "["
+    ) {
+      continue;
+    }
+
+    /*
+      .mixin()[ @result]
+              ^^^
+    */
+    if (
+      iNode.type === "value-word" &&
+      iNode.value === "[" &&
+      iNextNode?.type === "value-atword"
+    ) {
+      continue;
+    }
+
     // Ignore escape `\`
     if (
       iNode.type !== "value-string" &&

--- a/tests/format/less/mixin/__snapshots__/format.test.js.snap
+++ b/tests/format/less/mixin/__snapshots__/format.test.js.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`mixin.less format 1`] = `
+====================================options=====================================
+parsers: ["less"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+.average(@x, @y) {
+  @result: ((@x + @y) / 2);
+}
+
+div {
+  // call a mixin and look up its "@result" value
+  padding: .average(16px, 50px)[@result];
+}
+
+@config: {
+  option1: true;
+  option2: false;
+}
+
+.mixin() when (@config[option1] = true) {
+  selected: value;
+}
+
+=====================================output=====================================
+.average(@x, @y) {
+  @result: ((@x + @y) / 2);
+}
+
+div {
+  // call a mixin and look up its "@result" value
+  padding: .average(16px, 50px)[@result];
+}
+
+@config: {
+  option1: true;
+  option2: false;
+};
+
+.mixin() when (@config[option1] = true) {
+  selected: value;
+}
+
+================================================================================
+`;

--- a/tests/format/less/mixin/format.test.js
+++ b/tests/format/less/mixin/format.test.js
@@ -1,0 +1,1 @@
+runFormatTest(import.meta, ["less"]);

--- a/tests/format/less/mixin/mixin.less
+++ b/tests/format/less/mixin/mixin.less
@@ -1,0 +1,17 @@
+.average(@x, @y) {
+  @result: ((@x + @y) / 2);
+}
+
+div {
+  // call a mixin and look up its "@result" value
+  padding: .average(16px, 50px)[@result];
+}
+
+@config: {
+  option1: true;
+  option2: false;
+}
+
+.mixin() when (@config[option1] = true) {
+  selected: value;
+}


### PR DESCRIPTION
## Description

Fix: #8767

<img  height="300" alt="CleanShot 2025-09-26 at 11 03 48@2x" src="https://github.com/user-attachments/assets/4e763b47-8854-4d04-9645-9324ba0cccdb" />


## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
