### PR TITLE
Fix "Bundler Friendly" test

### DIFF
--- a/scripts/tools/bundle-test/index.js
+++ b/scripts/tools/bundle-test/index.js
@@ -30,7 +30,12 @@ const TEMPORARY_DIRECTORY = url.fileURLToPath(
 );
 
 for (const packageConfig of packageConfigs) {
-  const { distDirectory, files } = packageConfig;
+  const { packageName, distDirectory, files } = packageConfig;
+
+  if (packageName === "@prettier/plugin-oxc") {
+    continue;
+  }
+
   /* `require` in `parser-typescript.js`, #12338 */
   for (const file of files) {
     if (file.platform !== "universal") {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

`@prettier/plugin-oxc` is currently not runnable with webpack.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
