### PR TITLE
Run Node.js v14 test on `macos-15-intel` instead of `macos-13`

### DIFF
--- a/.github/workflows/prod-test.yml
+++ b/.github/workflows/prod-test.yml
@@ -75,7 +75,7 @@ jobs:
           - os: "ubuntu-latest"
             node: "16"
           # Tests on Intel Mac x Node.js 14 ( https://github.com/prettier/prettier/issues/16248 )
-          - os: "macos-13"
+          - os: "macos-15-intel"
             node: "14"
         # setup-node does not support Node.js 14 x M1 Mac
         exclude:


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

`macos-13` will be removed on December 4th, 2025

https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/#what-you-need-to-do

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
