### PR TITLE
fix(markdown): fix strong emphasis

### DIFF
--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -160,7 +160,8 @@ function genericPrint(path, options, print) {
       } else {
         const hasPrevOrNextWord = prevOrNextWord(path); // `1*2*3` is considered emphasis but `1_2_3` is not
         const inStrongAndHasPrevOrNextWord = // `1***2***3` is considered strong emphasis but `1**_2_**3` is not
-          path.parent?.type === "strong" && prevOrNextWord(path.ancestors);
+          path.parent?.type === "strong" &&
+          path.callParent((parent) => prevOrNextWord(parent));
         style =
           hasPrevOrNextWord ||
           inStrongAndHasPrevOrNextWord ||


### PR DESCRIPTION
## Description

This is a supplementary fix for #17143, where the original PR could not determine whether the contents on the left and right sides were both words.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
