### PR TITLE
Cleanup `TaggedTemplateExpression` print

### DIFF
--- a/src/language-js/print/estree.js
+++ b/src/language-js/print/estree.js
@@ -68,7 +68,7 @@ import { printObject } from "./object.js";
 import { printProperty } from "./property.js";
 import { printStatementSequence } from "./statement.js";
 import {
-  printTaggedTemplateLiteral,
+  printTaggedTemplateExpression,
   printTemplateLiteral,
 } from "./template-literal.js";
 import { printTernary } from "./ternary.js";
@@ -631,7 +631,7 @@ function printEstree(path, options, print, args) {
     case "TemplateLiteral":
       return printTemplateLiteral(path, options, print);
     case "TaggedTemplateExpression":
-      return printTaggedTemplateLiteral(path, options, print);
+      return printTaggedTemplateExpression(path, options, print);
     case "PrivateIdentifier":
       return ["#", node.name];
     case "PrivateName":

--- a/src/language-js/print/template-literal.js
+++ b/src/language-js/print/template-literal.js
@@ -128,7 +128,7 @@ function printTemplateLiteral(path, options, print) {
   return parts;
 }
 
-function printTaggedTemplateLiteral(path, options, print) {
+function printTaggedTemplateExpression(path, options, print) {
   const quasiDoc = print("quasi");
   const { node } = path;
 
@@ -142,7 +142,7 @@ function printTaggedTemplateLiteral(path, options, print) {
     if (
       hasNewlineInRange(
         options.originalText,
-        locEnd(node.typeArguments ?? node.typeParameters ?? node.tag),
+        locEnd(node.typeArguments ?? node.tag),
         locStart(quasiLeadingComment),
       )
     ) {
@@ -311,7 +311,7 @@ function isJestEachTemplateLiteral({ node, parent }) {
 
 export {
   escapeTemplateCharacters,
-  printTaggedTemplateLiteral,
+  printTaggedTemplateExpression,
   printTemplateExpressions,
   printTemplateLiteral,
   uncookTemplateElementValue,


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

`node.typeParameters` does not exist.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
