### PR TITLE
Forbid use 2nd and 3rd parameter in `AstPath` callbacks

### DIFF
--- a/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
@@ -960,6 +960,7 @@ test("no-useless-ast-path-callback-parameter", {
     "path.call(({first},) => first)",
     "path.call((...a) => a)",
     "path.call(notFunctionExpression)",
+    "path.callParent(({isFirst}, index) => index)",
   ],
   invalid: [
     ...["call", "callParent", "each", "map"].map((method) => ({
@@ -980,7 +981,7 @@ test("no-useless-ast-path-callback-parameter", {
     {
       code: "path.each((childPath,index, foo) => {})",
       output: null,
-      errors: 1,
+      errors: 3,
     },
     {
       code: "fooPath.call((childPath) => childPath)",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
