### PR TITLE
Add note about EditorConfig search stopping at project root

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -225,6 +225,12 @@ If you’d like a JSON schema to validate your configuration, one is available h
 
 If a [`.editorconfig` file](https://editorconfig.org/) is in your project, Prettier will parse it and convert its properties to the corresponding Prettier configuration. This configuration will be overridden by `.prettierrc`, etc.
 
+:::note
+
+Unlike the EditorConfig spec, the search for `.editorconfig` file will stop on the project root and won't proceed further.
+
+:::
+
 Here’s an annotated description of how different properties map to Prettier’s behavior:
 
 ```ini

--- a/website/versioned_docs/version-stable/configuration.md
+++ b/website/versioned_docs/version-stable/configuration.md
@@ -225,6 +225,12 @@ If you’d like a JSON schema to validate your configuration, one is available h
 
 If a [`.editorconfig` file](https://editorconfig.org/) is in your project, Prettier will parse it and convert its properties to the corresponding Prettier configuration. This configuration will be overridden by `.prettierrc`, etc.
 
+:::note
+
+Unlike the EditorConfig spec, the search for `.editorconfig` file will stop on the project root and won't proceed further.
+
+:::
+
 Here’s an annotated description of how different properties map to Prettier’s behavior:
 
 ```ini


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

Add a note to document editorconfig behaviour that can be unexpected for someone working with .editorconfig files before.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
