### PR TITLE
Add plaintext support in code block

### DIFF
--- a/tests/format/markdown/code/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/code/__snapshots__/format.test.js.snap
@@ -1296,6 +1296,52 @@ hello world
 ================================================================================
 `;
 
+exports[`text.md - {"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+printWidth: 80
+proseWrap: "always"
+                                                                                | printWidth
+=====================================input======================================
+\`\`\`text
+This is some example prose that will exceed the length of 40 characters in order to test the wrapping formatting feature.
+\`\`\`
+
+\`\`\`txt
+This is some example prose that will exceed the length of 40 characters in order to test the wrapping formatting feature.
+\`\`\`
+
+\`\`\`plaintext
+This is some example prose that will exceed the length of 40 characters in order to test the wrapping formatting feature.
+\`\`\`
+
+\`\`\`
+This is some example prose that will exceed the length of 40 characters in order to test the wrapping formatting feature.
+\`\`\`
+
+=====================================output=====================================
+\`\`\`text
+This is some example prose that will exceed the length of 40 characters in order
+to test the wrapping formatting feature.
+\`\`\`
+
+\`\`\`txt
+This is some example prose that will exceed the length of 40 characters in order
+to test the wrapping formatting feature.
+\`\`\`
+
+\`\`\`plaintext
+This is some example prose that will exceed the length of 40 characters in order
+to test the wrapping formatting feature.
+\`\`\`
+
+\`\`\`
+This is some example prose that will exceed the length of 40 characters in order to test the wrapping formatting feature.
+\`\`\`
+
+================================================================================
+`;
+
 exports[`ts-trailing-comma.md - {"proseWrap":"always"} format 1`] = `
 ====================================options=====================================
 parsers: ["markdown"]

--- a/tests/format/markdown/code/text.md
+++ b/tests/format/markdown/code/text.md
@@ -1,0 +1,15 @@
+```text
+This is some example prose that will exceed the length of 40 characters in order to test the wrapping formatting feature.
+```
+
+```txt
+This is some example prose that will exceed the length of 40 characters in order to test the wrapping formatting feature.
+```
+
+```plaintext
+This is some example prose that will exceed the length of 40 characters in order to test the wrapping formatting feature.
+```
+
+```
+This is some example prose that will exceed the length of 40 characters in order to test the wrapping formatting feature.
+```


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

fix: #18000 

<img width="1114" height="272" alt="CleanShot 2025-10-13 at 10 27 21@2x" src="https://github.com/user-attachments/assets/3d11dee9-1911-4524-acae-0e88bae80732" />


## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
