### PR TITLE
Simplify `TSModuleDeclaration` print

### DIFF
--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -281,7 +281,7 @@ function printTypescript(path, options, print) {
     case "TSModuleDeclaration":
       return [
         printDeclareToken(path),
-        node.kind !== "global" ? `${node.kind} ` : "",
+        node.kind === "global" ? "" : `${node.kind} `,
         print("id"),
         node.body ? [" ", group(print("body"))] : options.semi ? ";" : "",
       ];


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

The AST changed in typescript-estree v6, and Babel v8 now uses the same AST shape. The body check logic is outdated.

Related issues:

- https://github.com/typescript-eslint/typescript-eslint/issues/4966
- https://github.com/typescript-eslint/typescript-eslint/issues/6440

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
