### PR TITLE
docs: mention code block formatting support in markdown

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ Prettier is an opinionated code formatter with support for:
 - [JSON](https://json.org/)
 - [GraphQL](https://graphql.org/)
 - [Markdown](https://commonmark.org/), including [GFM](https://github.github.com/gfm/) and [MDX v1](https://mdxjs.com/)
+  - Prettier formats code blocks within Markdown based on their language identifier
 - [YAML](https://yaml.org/)
 
 It removes all original styling[\*](#footnotes) and ensures that all outputted code conforms to a consistent style. (See this [blog post](https://jlongster.com/A-Prettier-Formatter))


### PR DESCRIPTION
### What
Small docs enhancement: clarify that Prettier formats code blocks within Markdown based on their language identifier.

### Why
Improves discoverability of embedded-language formatting in fenced code blocks.

### Notes
- Docs-only change
- Diff: 1 line
- Ref: prettier/prettier#4768