### PR TITLE
refactor(markdown): improve getMinNotPresentContinuousCount

### DIFF
--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -182,7 +182,7 @@ function genericPrint(path, options, print) {
           ? node.value
           : node.value.replaceAll("\n", " ");
       const backtickCount = getMinNotPresentContinuousCount(code, "`");
-      const backtickString = "`".repeat(backtickCount || 1);
+      const backtickString = "`".repeat(backtickCount);
       const padding =
         code.startsWith("`") ||
         code.endsWith("`") ||

--- a/src/utils/get-min-not-present-continuous-count.js
+++ b/src/utils/get-min-not-present-continuous-count.js
@@ -1,9 +1,13 @@
 import escapeStringRegexp from "escape-string-regexp";
 
 /**
+ * Calculates the minimum `n` (>= 1) where `searchString.repeat(n)` is not present in `text`.
  * @param {string} text
  * @param {string} searchString
- * @returns {number}
+ * @example getMinNotPresentContinuousCount("```", "`") // 1
+ * @example getMinNotPresentContinuousCount("``` `", "`") // 2 (1 is occupied)
+ * @example getMinNotPresentContinuousCount("``` ` ``", "`") // 4 (1-3 are occupied)
+ * @returns {number} 1 if not exists, see the above example otherwise
  */
 function getMinNotPresentContinuousCount(text, searchString) {
   const matches = text.match(
@@ -11,7 +15,7 @@ function getMinNotPresentContinuousCount(text, searchString) {
   );
 
   if (matches === null) {
-    return 0;
+    return 1;
   }
 
   const countPresent = new Map();


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

Related to #18119 

`getMinNotPresentContinuousCount` is used only for determining the number of `` ` `` for an inline code.
It should return 1 if `searchString` (i.e. ``"`"``) does not exist because `` ` `` can be used as the opening and closing symbol for the inline code there. It will remove the unnecessary `|| 1`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
