### PR TITLE
Fix minor typos in rationale documentation

### DIFF
--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -207,7 +207,7 @@ console.log('Running a background task')
 })()
 ```
 
-If you feed this into Prettier, it will not alter the behavior of this code, instead, it will reformat it in a way that shows how this code will actually behave when run.
+If you feed this into Prettier, it will not alter the behavior of this code; instead, it will reformat it in a way that shows how this code will actually behave when run.
 
 ```js
 console.log("Running a background task")(async () => {


### PR DESCRIPTION
## Description

Corrected the typo of "when ran" to "when run". To elaborate a little, we could instead say "when it is run", and then it becomes a bit clearer that we actually need the past participle form of "to run".

Also corrected a comma splice.

Lemme know if I should do anything else with this PR, I'm new here 😊 (And yes I know that's another comma splice, I just hold documentation to a higher standard 😄)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
