### PR TITLE
Clean up graphql visitor keys

### DIFF
--- a/tests/unit/__snapshots__/visitor-keys.js.snap
+++ b/tests/unit/__snapshots__/visitor-keys.js.snap
@@ -1260,21 +1260,9 @@ exports[`visitor keys graphql 1`] = `
     "name",
     "value",
   ],
-  "ArgumentCoordinate": [
-    "argumentName",
-    "fieldName",
-    "name",
-  ],
   "BooleanValue": [],
   "Directive": [
     "arguments",
-    "name",
-  ],
-  "DirectiveArgumentCoordinate": [
-    "argumentName",
-    "name",
-  ],
-  "DirectiveCoordinate": [
     "name",
   ],
   "DirectiveDefinition": [
@@ -1373,10 +1361,6 @@ exports[`visitor keys graphql 1`] = `
   "ListValue": [
     "values",
   ],
-  "MemberCoordinate": [
-    "memberName",
-    "name",
-  ],
   "Name": [],
   "NamedType": [
     "name",
@@ -1437,9 +1421,6 @@ exports[`visitor keys graphql 1`] = `
     "selections",
   ],
   "StringValue": [],
-  "TypeCoordinate": [
-    "name",
-  ],
   "UnionTypeDefinition": [
     "description",
     "directives",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

~Blocked by https://github.com/prettier/prettier/pull/18214~

~Ref https://github.com/prettier/prettier/issues/18212~

Closes #18212

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
