### PR TITLE
Add types for Espree back

### DIFF
--- a/types/espree/index.d.ts
+++ b/types/espree/index.d.ts
@@ -1,0 +1,17 @@
+declare module "espree" {
+  // https://github.com/eslint/espree#options
+  export interface Options {
+    range?: boolean;
+    loc?: boolean;
+    comment?: boolean;
+    tokens?: boolean;
+    ecmaVersion?: "latest";
+    sourceType?: "script" | "module" | "commonjs";
+    ecmaFeatures?: {
+      jsx?: boolean;
+      impliedStrict?: boolean;
+    };
+  }
+  // https://github.com/eslint/espree#parse
+  export function parse(code: string, options?: Options): any;
+}


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

Removed in https://github.com/prettier/prettier/pull/18333

Since ESLint started add types, I thought they also added for espree, but forgot to test.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
