### PR TITLE
Fix typo in CHANGELOG of 3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### API: Fix performance regression in doc printer ([#18342](https://github.com/prettier/prettier/pull/18342) by [@fisker](https://github.com/fisker))
 
-Prettier 3.7.1 can be very slow when formatting big files, the regression has been fixed.
+Prettier 3.7.0 can be very slow when formatting big files, the regression has been fixed.
 
 # 3.7.0
 


### PR DESCRIPTION
Corrected the version number for the performance regression fix.

## Description

Fix typo in CHANGELOG of 3.7.1

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
