### PR TITLE
docs: use correct tense in v3.7 blog post

### DIFF
--- a/website/blog/2025-11-27-3.7.0.md
+++ b/website/blog/2025-11-27-3.7.0.md
@@ -151,7 +151,7 @@ interface ExtendsLongOneWithGenerics extends Bar<
 
 ##### Inconsistent opening brace print logic of class and interface body
 
-In Prettier v2.3, to improve visual separation between class head and body, [we started to print the opening `{` of the class's body on a new line when the class has multiple heritages](https://prettier.io/blog/2021/05/09/2.3.0.html#improve-visual-separation-between-header-and-body-in-classes-with-multiline-headers-10085-by-sosukesuzuki).
+In Prettier v2.3, to improve visual separation between class head and body, [we started to print the opening `{` of the class body on a new line when the class has multiple heritages](https://prettier.io/blog/2021/05/09/2.3.0.html#improve-visual-separation-between-header-and-body-in-classes-with-multiline-headers-10085-by-sosukesuzuki).
 
 <!-- prettier-ignore -->
 ```tsx
@@ -1896,11 +1896,11 @@ export const print = (path, options, print) => {
 
 For a node with `prettier-ignore` comment, Prettier prints the text of the node directly. However, this may cause problems, for example, if the node needs to be parenthesized or needs to print a leading semicolon to prevent ASI issue in `--no-semi` mode.
 
-Since Prettier 3.7, plugins can add the `printPrettierIgnored()` function to the printer to customize the `prettier-ignore`d node print process. This function uses the extract same signature as [`plugin.printer.print()`](https://prettier.io/docs/plugins#print)
+Since Prettier 3.7, plugins can add a `printPrettierIgnored()` function to the printer to customize the `prettier-ignore`d node print process. This function uses the extract same signature as [`plugin.printer.print()`](https://prettier.io/docs/plugins#print)
 
 #### Allow plugin to provide an `estree` printer ([#18072](https://github.com/prettier/prettier/pull/18072) by [@fisker](https://github.com/fisker)) {#change-18072}
 
-Previously, if a plugin wanted to make a plugin with the `estree` printer that outputs different code based on the built-in one, the plugin needed to provide both `parsers` and `printers`. Prettier 3.7 allows a plugin to create a plugin that only provides the `estree` printer.
+Previously, if a plugin wanted to make a plugin with an `estree` printer that outputs different code based on the built-in one, the plugin needed to provide both `parsers` and `printers`. Prettier 3.7 allows a plugin to create a plugin that only provides an `estree` printer.
 
 ### CLI
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

I noticed this while reading over the post 😅 

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] ~I’ve added tests to confirm my change works.~
- [x] ~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).~
- [x] ~(If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).