### PR TITLE
Remove unused `shouldBreak` check in `printTernaryOld`

### DIFF
--- a/src/language-js/print/ternary-old.js
+++ b/src/language-js/print/ternary-old.js
@@ -1,6 +1,5 @@
 import {
   align,
-  breakParent,
   dedent,
   group,
   ifBreak,
@@ -8,16 +7,12 @@ import {
   line,
   softline,
 } from "../../document/index.js";
-import hasNewlineInRange from "../../utils/has-newline-in-range.js";
-import { locEnd, locStart } from "../loc.js";
 import {
-  hasComment,
   isBinaryCastExpression,
   isCallExpression,
   isJsxElement,
   isMemberExpression,
 } from "../utils/index.js";
-import isBlockComment from "../utils/is-block-comment.js";
 
 /**
  * @import {Doc} from "../../document/index.js"
@@ -323,31 +318,8 @@ function printTernaryOld(path, options, print) {
     );
   }
 
-  // We want a whole chain of ConditionalExpressions to all
-  // break if any of them break. That means we should only group around the
-  // outer-most ConditionalExpression.
-  const shouldBreak = [
-    consequentNodePropertyName,
-    alternateNodePropertyName,
-    ...testNodePropertyNames,
-  ].some((property) =>
-    hasComment(
-      node[property],
-      (comment) =>
-        isBlockComment(comment) &&
-        hasNewlineInRange(
-          options.originalText,
-          locStart(comment),
-          locEnd(comment),
-        ),
-    ),
-  );
   const maybeGroup = (doc) =>
-    parent === firstNonConditionalParent
-      ? group(doc, { shouldBreak })
-      : shouldBreak
-        ? [doc, breakParent]
-        : doc;
+    parent === firstNonConditionalParent ? group(doc) : doc;
 
   // Break the closing paren to keep the chain right after it:
   // (a


### PR DESCRIPTION
## Description

While debugging `oxc_formatter`, I noticed this condition seems unnecessary.
(Since it's certain to break when comments are printed?)

If you have any concerns, feel free to close it.
(And if you do, I'd appreciate it if you could let us know why.)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
