### PR TITLE
Fix: Consistent formatting for NewExpression with type cast (#18406)

### DIFF
--- a/src/language-js/print/cast-expression.js
+++ b/src/language-js/print/cast-expression.js
@@ -26,7 +26,8 @@ function printBinaryCastExpression(path, options, print) {
   ];
 
   if (
-    (key === "callee" && isCallExpression(parent)) ||
+    (key === "callee" &&
+      (isCallExpression(parent) || parent.type === "NewExpression")) ||
     (key === "object" && isMemberExpression(parent))
   ) {
     return group([indent([softline, ...parts]), softline]);

--- a/tests/format/typescript/cast/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/cast/__snapshots__/format.test.js.snap
@@ -310,6 +310,27 @@ function x() {
 ================================================================================
 `;
 
+exports[`gh-18406.ts format 1`] = `
+====================================options=====================================
+parsers: ["babel-ts", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+new (require("./webpack/plugins/next-trace-entrypoints-plugin")
+  .TraceEntryPointsPlugin as P)({
+  rootDir: dir,
+});
+=====================================output=====================================
+new (
+  require("./webpack/plugins/next-trace-entrypoints-plugin")
+    .TraceEntryPointsPlugin as P
+)({
+  rootDir: dir,
+});
+
+================================================================================
+`;
+
 exports[`hug-args.ts format 1`] = `
 ====================================options=====================================
 parsers: ["babel-ts", "typescript"]

--- a/tests/format/typescript/cast/gh-18406.ts
+++ b/tests/format/typescript/cast/gh-18406.ts
@@ -1,0 +1,4 @@
+new (require("./webpack/plugins/next-trace-entrypoints-plugin")
+  .TraceEntryPointsPlugin as P)({
+  rootDir: dir,
+});


### PR DESCRIPTION
Fixes #18406

## Summary
Previously, `NewExpression` with a type cast was formatted inconsistently compared to `CallExpression`, causing it to break onto multiple lines unnecessarily.

This PR adds a check for `NewExpression` in `cast-expression.js` (specifically checking `parent.type === "NewExpression"`) to align the formatting logic with `CallExpression`.

## Changes
- Modified `printBinaryCastExpression` in `src/language-js/print/cast-expression.js`.
- Added a regression test case in `tests/format/typescript/cast/gh-18406.ts`.

## Test Plan
Ran `yarn jest tests/format/typescript/cast` and verified that the snapshot was updated to show the correct formatting.