### PR TITLE
Fix incorrect line break for CallExpression with block comment

### DIFF
--- a/src/language-js/print/call-arguments.js
+++ b/src/language-js/print/call-arguments.js
@@ -50,7 +50,17 @@ function printCallArguments(path, options, print) {
 
   const args = getCallArguments(node);
   if (args.length === 0) {
-    return ["(", printDanglingComments(path, options), ")"];
+    if (!hasComment(node, CommentCheckFlags.Dangling)) {
+      return ["(", ")"];
+    }
+    const hasLineComment = hasComment(node, CommentCheckFlags.Line);
+    const printed = printDanglingComments(path, options, {
+      indent: hasLineComment,
+    });
+    if (hasLineComment) {
+      return group(["(", printed, softline, ")"]);
+    }
+    return group(["(", indent([line, printed]), line, ")"]);
   }
 
   const lastArgIndex = args.length - 1;

--- a/tests/format/js/call/no-argument/__snapshots__/format.test.js.snap
+++ b/tests/format/js/call/no-argument/__snapshots__/format.test.js.snap
@@ -14,12 +14,12 @@ it(/* comment */)
 new it(/* comment */)
 
 =====================================output=====================================
-require(/* comment */);
-new require(/* comment */);
-define(/* comment */);
-new define(/* comment */);
-it(/* comment */);
-new it(/* comment */);
+require( /* comment */ );
+new require( /* comment */ );
+define( /* comment */ );
+new define( /* comment */ );
+it( /* comment */ );
+new it( /* comment */ );
 
 ================================================================================
 `;


### PR DESCRIPTION
Fixes #18403. Adds proper spacing around dangling block comments in empty CallExpression arguments, matching the behavior of arrays and objects.