### PR TITLE
Fix JSDoc comments broken by ASI semicolon (#18307)

### DIFF
--- a/changelog_unreleased/javascript/18307.md
+++ b/changelog_unreleased/javascript/18307.md
@@ -1,0 +1,18 @@
+#### Fix JSDoc comments broken by ASI semicolon with `semi: false` (#18307 by @jagadish-555)
+
+When `semi: false` is configured, Prettier inserts a semicolon for ASI protection. Previously, this was inserted after attached comments, separating JSDoc `@type` comments from their target expressions. This fix ensures the semicolon is printed before the comments.
+
+<!-- prettier-ignore -->
+```js
+// Input
+/** @type {string} */
+(foo);
+
+// Prettier stable
+/** @type {string} */
+;(foo);
+
+// Prettier main
+;/** @type {string} */
+(foo);
+```

--- a/src/language-js/comments/will-print-own-comments.js
+++ b/src/language-js/comments/will-print-own-comments.js
@@ -1,3 +1,4 @@
+import { shouldPrintLeadingSemicolon } from "../semicolon/semicolon.js";
 import {
   createTypeCheckFunction,
   hasNodeIgnoreComment,
@@ -17,16 +18,15 @@ const isClassOrInterface = createTypeCheckFunction([
   "DeclareClass",
   "DeclareInterface",
   "InterfaceDeclaration",
+  "InterfaceTypeAnnotation",
   "TSInterfaceDeclaration",
-  // Can't have `id` or `typeParameters`
-  // "InterfaceTypeAnnotation",
 ]);
 
 /**
  * @param {AstPath} path
  * @returns {boolean}
  */
-function willPrintOwnComments(path) {
+function willPrintOwnComments(path, options) {
   const { key, parent } = path;
   if (
     (key === "types" && isUnionType(parent)) ||
@@ -53,6 +53,10 @@ function willPrintOwnComments(path) {
   }
 
   if (isJsxElement(node)) {
+    return true;
+  }
+
+  if (shouldPrintLeadingSemicolon(path, options)) {
     return true;
   }
 

--- a/src/language-js/print/index.js
+++ b/src/language-js/print/index.js
@@ -1,4 +1,5 @@
 import { group, indent, inheritLabel, line } from "../../document/index.js";
+import { printComments } from "../../main/comments/print.js";
 import isNonEmptyArray from "../../utilities/is-non-empty-array.js";
 import { locEnd, locStart } from "../loc.js";
 import needsParentheses from "../parentheses/needs-parentheses.js";
@@ -88,14 +89,23 @@ function print(path, options, print, args) {
     return doc;
   }
 
-  return inheritLabel(doc, (doc) => [
-    needsSemi ? ";" : "",
-    needsParens ? "(" : "",
-    needsParens && isClassExpression && hasDecorators
-      ? [indent([line, decoratorsDoc, doc]), line]
-      : [decoratorsDoc, doc],
-    needsParens ? ")" : "",
-  ]);
+  return inheritLabel(doc, (doc) => {
+    let parts = [decoratorsDoc, doc];
+
+    if (needsParens && isClassExpression && hasDecorators) {
+      parts = [indent([line, parts]), line];
+    }
+
+    if (needsParens) {
+      parts = ["(", parts, ")"];
+    }
+
+    if (needsSemi) {
+      parts = [";", printComments(path, parts, options)];
+    }
+
+    return parts;
+  });
 }
 
 export default print;

--- a/tests/format/js/no-semi/__snapshots__/format.test.js.snap
+++ b/tests/format/js/no-semi/__snapshots__/format.test.js.snap
@@ -514,12 +514,12 @@ x;
 
 =====================================output=====================================
 let error = new Error(response.statusText)
-// comment
-;[].response = response
+;// comment
+[].response = response
 
 x
 
-/* comment */ ;[].response = response
+;/* comment */ [].response = response
 
 x
 


### PR DESCRIPTION
## Description

When semi: false is configured, Prettier inserts a semicolon for ASI protection on lines starting with (, [, etc. Previously, this semicolon was inserted after attached comments, which separated JSDoc @type comments from their target expressions and broke type checking.

This fix updates the printer to manually handle comment printing for nodes requiring ASI protection, ensuring the semicolon is printed before the comments.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
