### PR TITLE
Remove `Experimental{Rest,Spread}Property` from visitorKeys

### DIFF
--- a/src/language-js/traverse/visitor-keys.evaluate.js
+++ b/src/language-js/traverse/visitor-keys.evaluate.js
@@ -57,6 +57,10 @@ const excludeNodeTypes = [
   "RecordExpression",
   // Babel, Won't exist since we use `createImportExpressions` when parsing with babel
   "Import",
+
+  // https://github.com/typescript-eslint/typescript-eslint/blob/d2d7ace4e52bedf07482fd879d8e31a52b38fc26/packages/visitor-keys/tests/visitor-keys.test.ts#L14-L18
+  "ExperimentalRestProperty",
+  "ExperimentalSpreadProperty",
 ];
 
 let visitorKeys = unionVisitorKeys(

--- a/tests/unit/__snapshots__/visitor-keys.js.snap
+++ b/tests/unit/__snapshots__/visitor-keys.js.snap
@@ -308,12 +308,6 @@ exports[`visitor keys estree 1`] = `
     "members",
   ],
   "ExistsTypeAnnotation": [],
-  "ExperimentalRestProperty": [
-    "argument",
-  ],
-  "ExperimentalSpreadProperty": [
-    "argument",
-  ],
   "ExportAllDeclaration": [
     "attributes",
     "exported",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
