### PR TITLE
Disable `module <identifier>` test on `babel-ts` parser

### DIFF
--- a/tests/config/run-format-test.js
+++ b/tests/config/run-format-test.js
@@ -79,6 +79,7 @@ const meriyahDisabledTests = new Set(
 const babelTsDisabledTests = new Set(
   [
     "conformance/types/moduleDeclaration/kind-detection.ts",
+    // https://github.com/babel/babel/pull/17659
     "conformance/internalModules/importDeclarations/circularImportAlias.ts",
     "conformance/internalModules/importDeclarations/exportImportAlias.ts",
     "conformance/internalModules/importDeclarations/importAliasIdentifiers.ts",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

Babel is removing support for `module <identifier>` https://github.com/babel/babel/pull/17659

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
