### PR TITLE
docs: mention fenced code block formatting support in markdown

### DIFF
--- a/website/data/languages.yml
+++ b/website/data/languages.yml
@@ -30,6 +30,7 @@
     - "[CommonMark](https://commonmark.org/)"
     - "[GitHub-Flavored Markdown](https://github.github.com/gfm/)"
     - "[MDX v1](https://mdxjs.com/)"
+    - Fenced code blocks are formatted in any supported language
 - name: GraphQL
   nameLink: https://graphql.org
   image: /images/languages/tools_gql.svg


### PR DESCRIPTION
## Summary
Adds a note to the website landing page mentioning that Prettier can format fenced code blocks within markdown files in any supported language.

## Context
Prettier's ability to format code blocks in markdown (JavaScript, TypeScript, CSS, JSON, etc.) is a useful but not-widely-known feature. This adds visibility to the feature on the website.

## Changes
Added "Fenced code blocks are formatted in any supported language" to the Markdown variants in `website/data/languages.yml`.

Fixes #4768

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=101010297