### PR TITLE
Fix inline comments moved outside parentheses in abstract methods

### DIFF
--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -639,6 +639,7 @@ function handleCommentInEmptyParens({ comment, enclosingNode, options }) {
   // i.e. a function without any argument.
   if (
     ((isRealFunctionLikeNode(enclosingNode) &&
+      enclosingNode.type !== "TSAbstractMethodDefinition" &&
       getFunctionParameters(enclosingNode).length === 0) ||
       (isCallLikeExpression(enclosingNode) &&
         getCallArguments(enclosingNode).length === 0)) &&
@@ -1227,6 +1228,7 @@ const isRealFunctionLikeNode = createTypeCheckFunction([
   "TSConstructorType",
   "TSFunctionType",
   "TSDeclareMethod",
+  "TSAbstractMethodDefinition",
 ]);
 
 const handleComments = {

--- a/tests/format/typescript/comments/18478/input.ts
+++ b/tests/format/typescript/comments/18478/input.ts
@@ -1,0 +1,12 @@
+abstract class Foo {
+  abstract abstractMethod(
+    param1: number,
+    // param2: number,
+  ): void;
+
+  method(
+    param1: number,
+    // param2: number,
+  ): void {}
+}
+

--- a/tests/format/typescript/comments/18478/output.ts
+++ b/tests/format/typescript/comments/18478/output.ts
@@ -1,0 +1,12 @@
+abstract class Foo {
+  abstract abstractMethod(
+    param1: number,
+    // param2: number,
+  ): void;
+
+  method(
+    param1: number,
+    // param2: number,
+  ): void {}
+}
+


### PR DESCRIPTION
Fixes #18478

Comments in abstract method parameter lists were being incorrectly
positioned outside the closing parenthesis. This fix ensures comments
in abstract method parameters are kept inside the parentheses, matching
the behavior of regular methods.