### PR TITLE
Skip uploading coverage work in fork repo

### DIFF
--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Upload Coverage
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
-        if: ${{ matrix.ENABLE_CODE_COVERAGE }}
+        if: ${{ matrix.ENABLE_CODE_COVERAGE && github.repository == 'prettier/prettier' }}
         with:
           fail_ci_if_error: true
           disable_search: true


### PR DESCRIPTION
## Description

I keep receiving this notification whenever I update my forked repository. it only should be working in the `prettier/prettier` repo instead of in my fork

<img width="1404" height="126" alt="image" src="https://github.com/user-attachments/assets/fde37e5f-6a81-43e2-96bf-3f172ba0ee12" />


<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
