### PR TITLE
fix: remove `.component.html` suffix from angular formatter

### DIFF
--- a/src/language-html/languages.evaluate.js
+++ b/src/language-html/languages.evaluate.js
@@ -6,7 +6,7 @@ const languages = [
     name: "Angular",
     parsers: ["angular"],
     vscodeLanguageIds: ["html"],
-    extensions: [".component.html"],
+    extensions: [".html"],
     filenames: [],
   })),
   createLanguage(linguistLanguages.HTML, () => ({


### PR DESCRIPTION

## Description

The .component.html naming convention aligns with the previous style guide; however, the updated guide removes the .component suffix from filenames.


## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
