### PR TITLE
Remove outdated `typeArguments` check

### DIFF
--- a/src/language-js/print/assignment.js
+++ b/src/language-js/print/assignment.js
@@ -419,7 +419,7 @@ function isObjectPropertyWithShortKey(node, keyDoc, options) {
 }
 
 function isCallExpressionWithComplexTypeArguments(node, print) {
-  const typeArgs = getTypeArgumentsFromCallExpression(node);
+  const typeArgs = node.typeArguments?.params;
   if (isNonEmptyArray(typeArgs)) {
     if (typeArgs.length > 1) {
       return true;
@@ -435,18 +435,11 @@ function isCallExpressionWithComplexTypeArguments(node, print) {
         return true;
       }
     }
-    const typeArgsKeyName = node.typeParameters
-      ? "typeParameters"
-      : "typeArguments";
-    if (willBreak(print(typeArgsKeyName))) {
+    if (willBreak(print("typeArguments"))) {
       return true;
     }
   }
   return false;
-}
-
-function getTypeArgumentsFromCallExpression(node) {
-  return (node.typeParameters ?? node.typeArguments)?.params;
 }
 
 function isGeneric(node) {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

`typeParameters` is no longer possible.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
