### PR TITLE
Revert "Use `prettier.prettier-vscode` instead of the legacy one (#18374)

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
-    "prettier.prettier-vscode",
+    "esbenp.prettier-vscode",
     "editorconfig.editorconfig",
     "dbaeumer.vscode-eslint",
     "streetsidesoftware.code-spell-checker",

--- a/.vscode/settings.example.json
+++ b/.vscode/settings.example.json
@@ -1,6 +1,6 @@
 {
   "[javascript][typescript][javascriptreact][typescriptreact][json][jsonc][json5][markdown][yaml][css][html][vue]": {
-    "editor.defaultFormatter": "prettier.prettier-vscode",
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
   },
   "[javascript][typescript][javascriptreact][typescriptreact]": {


### PR DESCRIPTION


## Description

<!-- Please provide a brief summary of your changes -->

This reverts commit 030e43ebf2ce73563846e3269a34e8d3be8bb008  (#18374)

Unfortunately, it switched back to the old namespace.

https://github.com/prettier/prettier-vscode/pull/3899
https://github.com/prettier/prettier-vscode/issues/3872#issuecomment-3662898646

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
