### PR TITLE
Move `BreakStatement` `ContinueStatement` location override to `locEnd`

### DIFF
--- a/src/language-js/loc.js
+++ b/src/language-js/loc.js
@@ -30,11 +30,6 @@ function locEnd(node) {
           (node.type === "BreakStatement" ? "break".length : "continue".length);
   }
 
-  if (node.type === "VariableDeclaration") {
-    const lastDeclaration = node.declarations.at(-1);
-    return locEnd(lastDeclaration);
-  }
-
   const end = node.range?.[1] ?? node.end;
 
   /* c8 ignore next 3 */

--- a/src/language-js/parse/postprocess/index.js
+++ b/src/language-js/parse/postprocess/index.js
@@ -135,6 +135,15 @@ function postprocess(ast, options) {
           }
           break;
 
+        // fix unexpected locEnd caused by --no-semi style
+        case "VariableDeclaration": {
+          const lastDeclaration = node.declarations.at(-1);
+          if (lastDeclaration?.init && text[locEnd(lastDeclaration)] !== ";") {
+            node.range = [locStart(node), locEnd(lastDeclaration)];
+          }
+          break;
+        }
+
         // remove redundant TypeScript nodes
         case "TSParenthesizedType":
           return node.typeAnnotation;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
