### PR TITLE
Forbid required type after optional type in tuple

### DIFF
--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -204,7 +204,6 @@ const allowedReasonCodes = new Set([
   "ModuleAttributesWithDuplicateKeys",
   "InvalidEscapeSequenceTemplate",
   "NonAbstractClassHasAbstractMethod",
-  "OptionalTypeBeforeRequired",
   "PatternIsOptional",
   "DeclareClassFieldHasInitializer",
 

--- a/tests/format/misc/errors/typescript/tuple/__snapshots__/format.test.js.snap
+++ b/tests/format/misc/errors/typescript/tuple/__snapshots__/format.test.js.snap
@@ -7,10 +7,23 @@ exports[`snippet: #0 [babel-ts] format 1`] = `
 Cause: Tuple members must be labeled with a simple identifier. (1:10)"
 `;
 
+exports[`snippet: #0 [babel-ts] format 2`] = `
+"A required element cannot follow an optional element. (1:18)
+> 1 | type T = [x?: A, y: B];
+    |                  ^
+Cause: A required element cannot follow an optional element. (1:17)"
+`;
+
 exports[`snippet: #0 [oxc-ts] format 1`] = `
 "Expected \`,\` or \`]\` but found \`:\` (1:14)
 > 1 | type T = [x.y: A];
     |              ^"
+`;
+
+exports[`snippet: #0 [oxc-ts] format 2`] = `
+"A required element cannot follow an optional element. (1:18)
+> 1 | type T = [x?: A, y: B];
+    |                  ^^^^"
 `;
 
 exports[`snippet: #0 [typescript] format 1`] = `

--- a/tests/format/misc/errors/typescript/tuple/format.test.js
+++ b/tests/format/misc/errors/typescript/tuple/format.test.js
@@ -10,3 +10,18 @@ runFormatTest(
   },
   ["typescript", "babel-ts", "oxc-ts"],
 );
+
+runFormatTest(
+  {
+    importMeta: import.meta,
+    snippets: [
+      // A required element cannot follow an optional element.
+      "type T = [x?: A, y: B];",
+    ],
+  },
+  [
+    // "typescript",
+    "babel-ts",
+    "oxc-ts",
+  ],
+);


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
