### PR TITLE
Fix website doesn't show error in `doc` and `comment` panel

### DIFF
--- a/website/static/worker.mjs
+++ b/website/static/worker.mjs
@@ -175,18 +175,22 @@ async function handleFormatMessage(message) {
         await prettier.__debug.printToDoc(message.code, options),
         { plugins },
       );
-    } catch {
-      response.debug.doc = "";
+    } catch (e) {
+      response.debug.doc = String(e);
     }
   }
 
   if (!isDocExplorer && message.debug.comments) {
-    response.debug.comments = (
-      await formatCode(JSON.stringify(formatResult.comments || []), {
-        parser: "json",
-        plugins,
-      })
-    ).formatted;
+    try {
+      response.debug.comments = (
+        await formatCode(JSON.stringify(formatResult.comments), {
+          parser: "json",
+          plugins,
+        })
+      ).formatted;
+    } catch (e) {
+      response.debug.comments = String(e);
+    }
   }
 
   if (!isDocExplorer && message.debug.reformat) {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->
Fix: #18756 

<table>
<tr>
 <td>
<img width="2582" height="1820" alt="CleanShot 2026-01-27 at 14 20 00@2x" src="https://github.com/user-attachments/assets/21705079-ad99-4cd7-b713-66a6198addf3" />

 <td>
<img width="2994" height="1818" alt="CleanShot 2026-01-27 at 14 20 08@2x" src="https://github.com/user-attachments/assets/e785a0ce-c66a-4fcd-9d15-1bf6dd01e393" />

</table>

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
