### PR TITLE
Centralize "class like" children related logic

### DIFF
--- a/src/language-js/print/class.js
+++ b/src/language-js/print/class.js
@@ -14,6 +14,7 @@ import {
 } from "../../main/comments/print.js";
 import createGroupIdMapper from "../../utilities/create-group-id-mapper.js";
 import isNonEmptyArray from "../../utilities/is-non-empty-array.js";
+import { isNonEmptyClassBody } from "../utilities/class-members.js";
 import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
 import { createTypeCheckFunction } from "../utilities/create-type-check-function.js";
 import { isMemberExpression } from "../utilities/node-types.js";
@@ -141,16 +142,6 @@ function printClass(path, options, print) {
   parts.push(print("body"));
 
   return parts;
-}
-
-function isNonEmptyClassBody(node) {
-  return node.type === "ObjectTypeAnnotation"
-    ? ["properties", "indexers", "callProperties", "internalSlots"].some(
-        (property) => isNonEmptyArray(node[property]),
-      )
-    : node.type === "RecordDeclarationBody"
-      ? isNonEmptyArray(node.elements)
-      : isNonEmptyArray(node.body);
 }
 
 function hasMultipleHeritage(node) {

--- a/src/language-js/utilities/class-members.js
+++ b/src/language-js/utilities/class-members.js
@@ -1,0 +1,86 @@
+import isNonEmptyArray from "../../utilities/is-non-empty-array.js";
+import { locStart } from "../loc.js";
+
+/**
+@import AstPath from "../../common/ast-path.js";
+@import {Node, NodeMap} from "../types/estree.js";
+*/
+
+const flowObjectTypeAnnotationChildrenProperties = [
+  "properties",
+  "indexers",
+  "callProperties",
+  "internalSlots",
+];
+
+function iterateClassMembersPath(path, iteratee) {
+  const { node } = path;
+  if (node.type === "ClassBody" || node.type === "TSInterfaceBody") {
+    path.each(iteratee, "body");
+    return;
+  }
+
+  if (node.type === "TSTypeLiteral") {
+    path.each(iteratee, "members");
+    return;
+  }
+
+  if (node.type === "RecordDeclarationBody") {
+    path.each(iteratee, "elements");
+    return;
+  }
+
+  if (node.type === "ObjectTypeAnnotation") {
+    // Unfortunately, things grouped together in the ast can be
+    // interleaved in the source code. So we need to reorder them before
+    // printing them.
+    const children = flowObjectTypeAnnotationChildrenProperties
+      .flatMap((field) =>
+        path.map(
+          ({ node, index }) => ({
+            node,
+            loc: locStart(node),
+            selector: [field, index],
+          }),
+          field,
+        ),
+      )
+      .sort((a, b) => a.loc - b.loc);
+
+    for (const [index, { node, selector }] of children.entries()) {
+      path.call(
+        () =>
+          iteratee({
+            node,
+            next: children[index + 1]?.node,
+            isLast: index === children.length - 1,
+          }),
+        ...selector,
+      );
+    }
+  }
+}
+
+/**
+@param {
+  | NodeMap["ClassBody"]
+  | NodeMap["TSInterfaceBody"]
+  | NodeMap["RecordDeclarationBody"]
+  | NodeMap["ObjectTypeAnnotation"]
+} node
+@returns {boolean}
+*/
+function isNonEmptyClassBody(node) {
+  if (node.type === "ObjectTypeAnnotation") {
+    return flowObjectTypeAnnotationChildrenProperties.some((property) =>
+      isNonEmptyArray(node[property]),
+    );
+  }
+
+  const members =
+    node.type === "RecordDeclarationBody" ? node.elements : node.body;
+
+  return isNonEmptyArray(members);
+}
+
+export { isNonEmptyClassBody, iterateClassMembersPath };


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

Like we did in `call-arguments.js` and `function-parameters.js`, these nodes have different children.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
