### PR TITLE
Replace `adjustClause` with `printClause`

### DIFF
--- a/src/language-js/print/clause.js
+++ b/src/language-js/print/clause.js
@@ -1,0 +1,38 @@
+import { indent, line } from "../../document/index.js";
+import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
+
+function printClause(path, print, property = "body") {
+  return path.call(({ node }) => {
+    const doc = print();
+
+    if (node.type === "EmptyStatement") {
+      return hasComment(node, CommentCheckFlags.Leading) ? [" ", doc] : doc;
+    }
+
+    if (
+      node.type === "BlockStatement" ||
+      (node.type === "IfStatement" &&
+        path.parent.type === "IfStatement" &&
+        path.key === "alternate")
+    ) {
+      return [" ", doc];
+    }
+
+    return indent([line, doc]);
+  }, property);
+}
+
+const printIfStatementConsequent = (path, print) =>
+  printClause(path, print, "consequent");
+const printIfStatementAlternate = (path, print) =>
+  printClause(path, print, "alternate");
+
+export {
+  printClause as printDoWhileStatementBody,
+  printClause as printForInStatementBody,
+  printClause as printForOfStatementBody,
+  printClause as printForStatementBody,
+  printIfStatementAlternate,
+  printIfStatementConsequent,
+  printClause as printWhileStatementBody,
+};

--- a/src/language-js/print/do-while-statement.js
+++ b/src/language-js/print/do-while-statement.js
@@ -1,12 +1,10 @@
 import { group, hardline } from "../../document/index.js";
-import {
-  printClause,
-  printDoWhileStatementCondition,
-} from "./miscellaneous.js";
+import { printDoWhileStatementBody } from "./clause.js";
+import { printDoWhileStatementCondition } from "./miscellaneous.js";
 
 function printDoWhileStatement(path, options, print) {
   return [
-    group(["do", printClause(path, print)]),
+    group(["do", printDoWhileStatementBody(path, print)]),
     path.node.body.type === "BlockStatement" ? " " : hardline,
     "while (",
     printDoWhileStatementCondition(path, options, print),

--- a/src/language-js/print/estree.js
+++ b/src/language-js/print/estree.js
@@ -32,6 +32,7 @@ import {
   printClassMethod,
   printClassProperty,
 } from "./class.js";
+import { printForInStatementBody, printForOfStatementBody } from "./clause.js";
 import { printDoWhileStatement } from "./do-while-statement.js";
 import { printExpressionStatement } from "./expression-statement.js";
 import { printForStatement } from "./for-statement.js";
@@ -40,11 +41,7 @@ import { printHtmlBinding } from "./html-binding.js";
 import { printIfStatement } from "./if-statement.js";
 import { printLiteral } from "./literal.js";
 import { printMemberExpression } from "./member.js";
-import {
-  printClause,
-  printDefiniteToken,
-  printOptionalToken,
-} from "./miscellaneous.js";
+import { printDefiniteToken, printOptionalToken } from "./miscellaneous.js";
 import {
   printExportDeclaration,
   printImportDeclaration,
@@ -268,7 +265,7 @@ function printEstree(path, options, print, args) {
         " in ",
         print("right"),
         ")",
-        printClause(path, print),
+        printForInStatementBody(path, print),
       ]);
 
     case "ForOfStatement":
@@ -280,7 +277,7 @@ function printEstree(path, options, print, args) {
         " of ",
         print("right"),
         ")",
-        printClause(path, print),
+        printForOfStatementBody(path, print),
       ]);
 
     case "DoExpression":

--- a/src/language-js/print/for-statement.js
+++ b/src/language-js/print/for-statement.js
@@ -6,11 +6,11 @@ import {
   softline,
 } from "../../document/index.js";
 import { printDanglingComments } from "../../main/comments/print.js";
-import { printClause } from "./miscellaneous.js";
+import { printForStatementBody } from "./clause.js";
 
 function printForStatement(path, options, print) {
   const { node } = path;
-  const body = printClause(path, print);
+  const body = printForStatementBody(path, print);
 
   // We want to keep dangling comments above the loop to stay consistent.
   // Any comment positioned between the for statement and the parentheses

--- a/src/language-js/print/if-statement.js
+++ b/src/language-js/print/if-statement.js
@@ -2,19 +2,20 @@ import { group, hardline } from "../../document/index.js";
 import { printDanglingComments } from "../../main/comments/print.js";
 import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
 import { needsHardlineAfterDanglingComment } from "../utilities/needs-hardline-after-dangling-comment.js";
-import { printClause, printIfStatementCondition } from "./miscellaneous.js";
+import {
+  printIfStatementAlternate,
+  printIfStatementConsequent,
+} from "./clause.js";
+import { printIfStatementCondition } from "./miscellaneous.js";
 
 /**
  * @import AstPath from "../../common/ast-path.js"
  * @import {Doc} from "../../document/index.js"
  */
 
-const printConsequent = (path, print) => printClause(path, print, "consequent");
-const printAlternate = (path, print) => printClause(path, print, "alternate");
-
 function printIfStatement(path, options, print) {
   const { node } = path;
-  const consequent = printConsequent(path, print);
+  const consequent = printIfStatementConsequent(path, print);
   const opening = group([
     "if (",
     printIfStatementCondition(path, options, print),
@@ -41,7 +42,7 @@ function printIfStatement(path, options, print) {
       );
     }
 
-    parts.push("else", group(printAlternate(path, print)));
+    parts.push("else", group(printIfStatementAlternate(path, print)));
   }
 
   return parts;

--- a/src/language-js/print/miscellaneous.js
+++ b/src/language-js/print/miscellaneous.js
@@ -3,7 +3,6 @@ import {
   hardline,
   ifBreak,
   indent,
-  line,
   softline,
 } from "../../document/index.js";
 import { printDanglingComments } from "../../main/comments/print.js";
@@ -111,27 +110,6 @@ function printAbstractToken({ node }) {
   return node.abstract || isTsAbstractNode(node) ? "abstract " : "";
 }
 
-function printClause(path, print, property = "body") {
-  return path.call(({ node }) => {
-    const doc = print();
-
-    if (node.type === "EmptyStatement") {
-      return hasComment(node, CommentCheckFlags.Leading) ? [" ", doc] : doc;
-    }
-
-    if (
-      node.type === "BlockStatement" ||
-      (node.type === "IfStatement" &&
-        path.parent.type === "IfStatement" &&
-        path.key === "alternate")
-    ) {
-      return [" ", doc];
-    }
-
-    return indent([line, doc]);
-  }, property);
-}
-
 function printTypeScriptAccessibilityToken(node) {
   return node.accessibility ? node.accessibility + " " : "";
 }
@@ -220,7 +198,6 @@ function printTrailingComma(options, level = "es5") {
 
 export {
   printAbstractToken,
-  printClause,
   printDanglingCommentsInList,
   printDeclareToken,
   printDefiniteToken,

--- a/src/language-js/print/while-statement.js
+++ b/src/language-js/print/while-statement.js
@@ -1,5 +1,6 @@
 import { group } from "../../document/index.js";
-import { printClause, printWhileStatementCondition } from "./miscellaneous.js";
+import { printWhileStatementBody } from "./clause.js";
+import { printWhileStatementCondition } from "./miscellaneous.js";
 
 function printWhileStatement(path, options, print) {
   const { node } = path;
@@ -10,7 +11,7 @@ function printWhileStatement(path, options, print) {
     " (",
     printWhileStatementCondition(path, options, print),
     ")",
-    printClause(path, print),
+    printWhileStatementBody(path, print),
   ]);
 }
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

Doing this because I want improve this case, comments should not be forced to print on same line.

**Prettier 3.8.1**
[Playground link](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEBLAZgAgBTohASgB0oB6AKhLwivxPNJOAF8QAaECABxlWgGdkoAIYAnURADuABTEJBKYQBtJwgJ6COAI1HCwAazgwAysIC2cADKoocZOmX84HCFoBWcMDADqurshAuUTgnUQA3O21dAyNjLj0bAHNkGFEAV2cQJzNUFPTMuAAPLjhRVAtYZQB5Et0YCFFpCH5UXmgAhAATdhAi2vKEGGUAFVKoMVQQ+0dMlqhEpTgARTSIeGmlJw43fkLjJMWVtbskB03MgEdV+GkJLgUQYX4AWls4Tvee1OFUJSSAYQgZjMwgCyiUPTmCzgAEEYKlUFo0jdStZbBstiAABYwMxKbxY1oheJgODGeStVBhVpqAJgfiaEBhDIASSgH1gxjAZR4MPZxhgakWGMyQWacF8wn8KCCIVKER6XSq6DRJxASnQPRsoRgt2EiRBIo48VEoQCWmEWjgEONZVg3lQnRgWOQAA4AAwcYJXVDBPUG0GnGYcIZaB1Ol1IABMHDSTmGloUZ0xcDMVs6H06lmE8zS+rgADEGiD4UkwciICBmMwgA)
<!-- prettier-ignore -->
```sh
--parser babel
```

**Input:**
<!-- prettier-ignore -->
```jsx
if (foo)
/*
foo
foo
*/
{}
```

**Output:**
<!-- prettier-ignore -->
```jsx
if (foo) /*
foo
foo
*/
{
}

```


## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
