### PR TITLE
Fix leading comments placed outside parentheses for ObjectExpression

### DIFF
--- a/tests/format/js/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/js/comments/__snapshots__/format.test.js.snap
@@ -3458,6 +3458,137 @@ testFunction =
 ================================================================================
 `;
 
+exports[`issue-18817.js - {"semi":false} format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+{
+  foo: (
+    // comment
+    {
+      bar: "baz",
+    }
+  )
+}
+
+{
+  foo: (
+    /* block comment */
+    {
+      bar: "baz",
+    }
+  )
+}
+
+{
+  bar: (
+    // first comment
+    // second comment
+    {
+      baz: "qux",
+    }
+  )
+}
+
+=====================================output=====================================
+{
+  foo: (
+    // comment
+    {
+      bar: "baz",
+    }
+  )
+}
+
+{
+  foo: (
+    /* block comment */
+    {
+      bar: "baz",
+    }
+  )
+}
+
+{
+  bar: (
+    // first comment
+    // second comment
+    {
+      baz: "qux",
+    }
+  )
+}
+
+================================================================================
+`;
+
+exports[`issue-18817.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+{
+  foo: (
+    // comment
+    {
+      bar: "baz",
+    }
+  )
+}
+
+{
+  foo: (
+    /* block comment */
+    {
+      bar: "baz",
+    }
+  )
+}
+
+{
+  bar: (
+    // first comment
+    // second comment
+    {
+      baz: "qux",
+    }
+  )
+}
+
+=====================================output=====================================
+{
+  foo: (
+    // comment
+    {
+      bar: "baz",
+    }
+  );
+}
+
+{
+  foo: (
+    /* block comment */
+    {
+      bar: "baz",
+    }
+  );
+}
+
+{
+  bar: (
+    // first comment
+    // second comment
+    {
+      baz: "qux",
+    }
+  );
+}
+
+================================================================================
+`;
+
 exports[`issues.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]

--- a/tests/format/js/comments/issue-18817.js
+++ b/tests/format/js/comments/issue-18817.js
@@ -1,0 +1,27 @@
+{
+  foo: (
+    // comment
+    {
+      bar: "baz",
+    }
+  )
+}
+
+{
+  foo: (
+    /* block comment */
+    {
+      bar: "baz",
+    }
+  )
+}
+
+{
+  bar: (
+    // first comment
+    // second comment
+    {
+      baz: "qux",
+    }
+  )
+}


### PR DESCRIPTION
Fixes #18817

## Root Cause Analysis

When a `ParenthesizedExpression` wrapping an `ObjectExpression` contains a leading comment (between `(` and `{`), prettier's postprocessor unwraps the `ParenthesizedExpression`, setting `extra.parenthesized: true` on the inner `ObjectExpression`. The comment becomes a **leading comment** of the `ObjectExpression`.

Later, `needsParentheses` re-adds parentheses because `{` at the start of an `ExpressionStatement` is ambiguous with a block statement. However, `callPluginPrintFunction` in `ast-to-doc.js` calls `printComments` **after** `printer.print` returns — this places the leading comments **outside** the newly-added parentheses, producing incorrect output.

### Before (incorrect)
```js
// Input
{
  foo: (
    // comment
    {
      bar: "baz",
    }
  )
}

// Output — comment escapes the parens, semicolon appears
{
  foo: // comment
  ({
    bar: "baz",
  });
}
```

### After (correct & idempotent)
```js
{
  foo: (
    // comment
    {
      bar: "baz",
    }
  );
}
```

## Fix

In the `print` function in `src/language-js/print/index.js`, when `needsParentheses` adds parens to an `ObjectExpression` that has leading comments, those leading comments are now printed **inside** the parentheses using the same `indent([softline, ...]), softline` pattern already used by `printCommentsForFunction` for IIFE callee comments. The comments are then added to the `printedComments` set so `callPluginPrintFunction` does not double-print them.

The fix is scoped to `ObjectExpression` only to avoid regressions in other `needsParentheses` cases (e.g. precedence-based parens for binary expressions with trailing comments, or `ClassExpression` with `prettier-ignore` decorators).

## Test plan

- [x] Added test file `tests/format/js/comments/issue-18817.js` covering line comments, block comments, and multiple comments
- [x] All 28,668 format tests pass (JS, TypeScript, Flow)
- [x] Output is idempotent (formatting the output again produces the same result)