### PR TITLE
Improve semicolon check in `printVariableDeclaration`

### DIFF
--- a/src/language-js/print/variable-declaration.js
+++ b/src/language-js/print/variable-declaration.js
@@ -15,12 +15,12 @@ function printVariableDeclaration(path, options, print) {
       (path.parent.type === "ForInStatement" ||
         path.parent.type === "ForOfStatement"));
 
-  const hasValue = node.declarations.some((decl) => decl.init);
+  const hasValue = node.declarations.some((declarator) => declarator.init);
 
   let firstVariable;
   if (printed.length === 1 && !hasComment(node.declarations[0])) {
     firstVariable = printed[0];
-  } else if (printed.length > 0) {
+  } else {
     // Indent first var to comply with eslint one-var rule
     firstVariable = indent(printed[0]);
   }


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

- The original `parentNode.body !== node` check is confusing, explicitly check `ForStatement.init` & `For{In,Of}Statement.left`
- Also removed declarator length check, it's not possible to have empty `declarations`

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
