### PR TITLE
docs: add prettier-plugin-matryoshka to community plugins

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -158,6 +158,7 @@
         "Marek",
         "Mariusz",
         "marko",
+        "matryoshka",
         "Masad",
         "Matejka",
         "Mateusz",

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -73,6 +73,7 @@ Strings provided to `plugins` are ultimately passed to [`import()` expression](h
 - [`prettier-plugin-jsonata`](https://github.com/Stedi/prettier-plugin-jsonata) by [**@Stedi**](https://github.com/Stedi)
 - [`prettier-plugin-kotlin`](https://github.com/Angry-Potato/prettier-plugin-kotlin) by [**@Angry-Potato**](https://github.com/Angry-Potato)
 - [`prettier-plugin-marko`](https://github.com/marko-js/prettier) by [**@marko-js**](https://github.com/marko-js)
+- [`prettier-plugin-matryoshka`](https://github.com/yunusemrejs/prettier-plugin-matryoshka) by [**@yunusemrejs**](https://github.com/yunusemrejs)
 - [`prettier-plugin-motoko`](https://github.com/dfinity/prettier-plugin-motoko) by [**@dfinity**](https://github.com/dfinity)
 - [`prettier-plugin-nginx`](https://github.com/joedeandev/prettier-plugin-nginx) by [**@joedeandev**](https://github.com/joedeandev)
 - [`prettier-plugin-prisma`](https://github.com/umidbekk/prettier-plugin-prisma) by [**@umidbekk**](https://github.com/umidbekk)

--- a/website/versioned_docs/version-stable/plugins.md
+++ b/website/versioned_docs/version-stable/plugins.md
@@ -63,6 +63,7 @@ Strings provided to `plugins` are ultimately passed to [`import()` expression](h
 - [`prettier-plugin-jsonata`](https://github.com/Stedi/prettier-plugin-jsonata) by [**@Stedi**](https://github.com/Stedi)
 - [`prettier-plugin-kotlin`](https://github.com/Angry-Potato/prettier-plugin-kotlin) by [**@Angry-Potato**](https://github.com/Angry-Potato)
 - [`prettier-plugin-marko`](https://github.com/marko-js/prettier) by [**@marko-js**](https://github.com/marko-js)
+- [`prettier-plugin-matryoshka`](https://github.com/yunusemrejs/prettier-plugin-matryoshka) by [**@yunusemrejs**](https://github.com/yunusemrejs)
 - [`prettier-plugin-motoko`](https://github.com/dfinity/prettier-plugin-motoko) by [**@dfinity**](https://github.com/dfinity)
 - [`prettier-plugin-nginx`](https://github.com/joedeandev/prettier-plugin-nginx) by [**@joedeandev**](https://github.com/joedeandev)
 - [`prettier-plugin-prisma`](https://github.com/umidbekk/prettier-plugin-prisma) by [**@umidbekk**](https://github.com/umidbekk)


### PR DESCRIPTION
## Description

Add `prettier-plugin-matryoshka` to Prettier's community plugins list.

Plugin links:
- Repository: https://github.com/yunusemrejs/prettier-plugin-matryoshka
- npm: https://www.npmjs.com/package/prettier-plugin-matryoshka

This PR follows recent merged plugin-list updates by:
- adding the entry in `docs/plugins.md` in alphabetical order,
- mirroring the same entry in `website/versioned_docs/version-stable/plugins.md`,
- adding `matryoshka` to `cspell.json`.

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
