### PR TITLE
Add `prettier-plugin-yaml` to Community Plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -85,6 +85,7 @@ Strings provided to `plugins` are ultimately passed to [`import()` expression](h
 - [`prettier-plugin-svelte`](https://github.com/sveltejs/prettier-plugin-svelte) by [**@sveltejs**](https://github.com/sveltejs)
 - [`prettier-plugin-toml`](https://github.com/un-ts/prettier/tree/master/packages/toml) by [**@JounQin**](https://github.com/JounQin) and [**@so1ve**](https://github.com/so1ve)
 - [`prettier-plugin-xquery`](https://github.com/drrataplan/prettier-plugin-xquery) by [**@DrRataplan**](https://github.com/drrataplan)
+- [`prettier-plugin-yaml`](https://github.com/porada/prettier-plugin-yaml) by [**@porada**](https://github.com/porada)
 
 ## Developing Plugins
 

--- a/website/versioned_docs/version-stable/plugins.md
+++ b/website/versioned_docs/version-stable/plugins.md
@@ -75,6 +75,7 @@ Strings provided to `plugins` are ultimately passed to [`import()` expression](h
 - [`prettier-plugin-svelte`](https://github.com/sveltejs/prettier-plugin-svelte) by [**@sveltejs**](https://github.com/sveltejs)
 - [`prettier-plugin-toml`](https://github.com/un-ts/prettier/tree/master/packages/toml) by [**@JounQin**](https://github.com/JounQin) and [**@so1ve**](https://github.com/so1ve)
 - [`prettier-plugin-xquery`](https://github.com/drrataplan/prettier-plugin-xquery) by [**@DrRataplan**](https://github.com/drrataplan)
+- [`prettier-plugin-yaml`](https://github.com/porada/prettier-plugin-yaml) by [**@porada**](https://github.com/porada)
 
 ## Developing Plugins
 


### PR DESCRIPTION
For your consideration.

Even though Prettier supports YAML out of the box, [**prettier-plugin-yaml**](https://github.com/porada/prettier-plugin-yaml) adds a few formatting options that fall outside of Prettier’s [option philosophy](https://prettier.io/docs/option-philosophy).