### PR TITLE
Fix leading comment in parenthesized return expression moving to inco…

### DIFF
--- a/src/language-js/print/member-chain.js
+++ b/src/language-js/print/member-chain.js
@@ -4,11 +4,15 @@ import {
   group,
   hardline,
   indent,
+  inheritLabel,
   join,
   label,
   willBreak,
 } from "../../document/index.js";
-import { printComments } from "../../main/comments/print.js";
+import {
+  printComments,
+  printCommentsSeparately,
+} from "../../main/comments/print.js";
 import getNextNonSpaceNonCommentCharacterIndex from "../../utilities/get-next-non-space-non-comment-character-index.js";
 import isNextLineEmptyAfterIndex from "../../utilities/is-next-line-empty.js";
 import { locEnd } from "../location/index.js";
@@ -65,6 +69,12 @@ function printMemberChain(path, options, print) {
   /** @type {PrintedNode[]}} */
   const printedNodes = [];
 
+  // Leading comments on intermediate chain nodes (CallExpression,
+  // MemberExpression) need to be moved to the base node so they don't
+  // end up between a member lookup and its call arguments.
+  /** @type {Doc[]} */
+  const chainLeadingComments = [];
+
   // Here we try to retain one typed empty line after each call expression or
   // the first group whether it is in parentheses or not
   function shouldInsertEmptyLineAfter(node) {
@@ -96,19 +106,22 @@ function printMemberChain(path, options, print) {
       !needsParentheses(path, options)
     ) {
       const hasTrailingEmptyLine = shouldInsertEmptyLineAfter(node);
+      const { leading, trailing } = printCommentsSeparately(path, options);
+      if (leading) {
+        chainLeadingComments.unshift(leading);
+      }
+      const callDoc = [
+        printOptionalToken(path),
+        print("typeArguments"),
+        printCallArguments(path, options, print),
+      ];
       printedNodes.unshift({
         node,
         hasTrailingEmptyLine,
         printed: [
-          printComments(
-            path,
-            [
-              printOptionalToken(path),
-              print("typeArguments"),
-              printCallArguments(path, options, print),
-            ],
-            options,
-          ),
+          trailing
+            ? inheritLabel(callDoc, (doc) => [doc, trailing])
+            : callDoc,
           hasTrailingEmptyLine ? hardline : "",
         ],
       });
@@ -161,6 +174,14 @@ function printMemberChain(path, options, print) {
 
   if (node.callee) {
     path.call(rec, "callee");
+  }
+
+  // Prepend any leading comments from intermediate chain nodes to the base node
+  if (chainLeadingComments.length > 0) {
+    printedNodes[0].printed = [
+      ...chainLeadingComments,
+      printedNodes[0].printed,
+    ];
   }
 
   // Once we have a linear list of printed nodes, we want to create groups out

--- a/tests/format/js/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/js/comments/__snapshots__/format.test.js.snap
@@ -5695,9 +5695,9 @@ function memberOutside() {
 
 function memberInAndOutWithCalls() {
   return (
+    // Reason for a
     aFunction
-      .b// Reason for a
-      ()
+      .b()
       .c.d()
   )
 }
@@ -6062,9 +6062,9 @@ function memberOutside() {
 
 function memberInAndOutWithCalls() {
   return (
+    // Reason for a
     aFunction
-      .b// Reason for a
-      ()
+      .b()
       .c.d()
   );
 }


### PR DESCRIPTION
…rrect place in member chain

When a return statement had a parenthesized expression with a leading comment followed by a member chain outside the parens, the comment was incorrectly placed between the member lookup and its call arguments.

Fixes #18843

## Description

<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
