### PR TITLE
Fix HTML comments in markdown getting endlessly indented

### DIFF
--- a/src/language-markdown/print/mdast.js
+++ b/src/language-markdown/print/mdast.js
@@ -249,7 +249,7 @@ function printMdast(path, options, print) {
       const isHtmlComment = /^<!--.*-->$/s.test(value);
 
       return replaceEndOfLine(
-        value,
+        isHtmlComment ? dedentHtmlComment(value) : value,
         isHtmlComment ? hardline : markAsRoot(literalline),
       );
     }
@@ -542,6 +542,42 @@ function printImageAlt(node, options) {
   }
 
   return node.alt || "";
+}
+
+/**
+ * Strip common leading whitespace from lines after the first in an HTML comment.
+ * This prevents indentation from growing endlessly when the comment is inside
+ * a list, since the printer's own alignment handles the base indentation.
+ * @param {string} value
+ * @returns {string}
+ */
+function dedentHtmlComment(value) {
+  const lines = value.split("\n");
+  if (lines.length <= 1) {
+    return value;
+  }
+
+  // Find minimum indentation of non-empty lines after the first
+  let minIndent = Number.POSITIVE_INFINITY;
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    // Skip empty or whitespace-only lines for the purpose of finding min indent
+    if (line.trim().length === 0) {
+      continue;
+    }
+    const indent = line.match(/^ */)[0].length;
+    minIndent = Math.min(minIndent, indent);
+  }
+
+  if (minIndent === 0 || minIndent === Number.POSITIVE_INFINITY) {
+    return value;
+  }
+
+  // Strip the common indentation from all lines after the first
+  return [
+    lines[0],
+    ...lines.slice(1).map((line) => line.slice(minIndent)),
+  ].join("\n");
 }
 
 export { printMdast };

--- a/tests/format/markdown/html/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/html/__snapshots__/format.test.js.snap
@@ -204,6 +204,136 @@ proseWrap: "preserve"
 ================================================================================
 `;
 
+exports[`comment-in-list.md - {"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+proseWrap: "always"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+- Something:
+  - [ ] Foo
+  - [ ] Bar
+        <!--
+          Something else
+        -->
+
+- Item
+  <!--
+    Line 1
+      Line 2 (more indented)
+    Line 3
+  -->
+
+- Item
+  <!-- single line comment -->
+
+=====================================output=====================================
+- Something:
+  - [ ] Foo
+  - [ ] Bar <!--
+          Something else
+        -->
+
+- Item
+  <!--
+    Line 1
+      Line 2 (more indented)
+    Line 3
+  -->
+
+- Item
+  <!-- single line comment -->
+
+================================================================================
+`;
+
+exports[`comment-in-list.md - {"proseWrap":"never"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+proseWrap: "never"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+- Something:
+  - [ ] Foo
+  - [ ] Bar
+        <!--
+          Something else
+        -->
+
+- Item
+  <!--
+    Line 1
+      Line 2 (more indented)
+    Line 3
+  -->
+
+- Item
+  <!-- single line comment -->
+
+=====================================output=====================================
+- Something:
+  - [ ] Foo
+  - [ ] Bar <!--
+          Something else
+        -->
+
+- Item
+  <!--
+    Line 1
+      Line 2 (more indented)
+    Line 3
+  -->
+
+- Item
+  <!-- single line comment -->
+
+================================================================================
+`;
+
+exports[`comment-in-list.md - {"proseWrap":"preserve"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+proseWrap: "preserve"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+- Something:
+  - [ ] Foo
+  - [ ] Bar
+        <!--
+          Something else
+        -->
+
+- Item
+  <!--
+    Line 1
+      Line 2 (more indented)
+    Line 3
+  -->
+
+- Item
+  <!-- single line comment -->
+
+=====================================output=====================================
+- Something:
+  - [ ] Foo
+  - [ ] Bar
+        <!--
+          Something else
+        -->
+
+- Item
+  <!--
+    Line 1
+      Line 2 (more indented)
+    Line 3
+  -->
+
+- Item
+  <!-- single line comment -->
+
+================================================================================
+`;
+
 exports[`inline-html.md - {"proseWrap":"always"} format 1`] = `
 ====================================options=====================================
 parsers: ["markdown"]

--- a/tests/format/markdown/html/comment-in-list.md
+++ b/tests/format/markdown/html/comment-in-list.md
@@ -1,0 +1,16 @@
+- Something:
+  - [ ] Foo
+  - [ ] Bar
+        <!--
+          Something else
+        -->
+
+- Item
+  <!--
+    Line 1
+      Line 2 (more indented)
+    Line 3
+  -->
+
+- Item
+  <!-- single line comment -->


### PR DESCRIPTION
## Summary

Fixes #18066

- HTML comments inside markdown lists get their indentation increased by one space on every re-format, growing endlessly
- Root cause: the markdown parser preserves relative indentation in the HTML node's `value`, while the printer adds its own indentation via `align`/`hardline` -- these compound on each format cycle
- Fix: dedent the HTML comment value (strip common leading whitespace from lines after the first) before printing, so the printer's alignment is the sole source of base indentation. Relative indentation within the comment is preserved.

## Test plan

- Added test cases in `tests/format/markdown/html/comment-in-list.md` covering:
  - Multi-line HTML comment inside a nested checkbox list (the exact case from the issue)
  - Multi-line HTML comment with varying internal indentation
  - Single-line HTML comment in a list (unchanged behavior)
- Verified idempotency: formatting the output again produces identical results
- All 1495 existing markdown tests continue to pass