### PR TITLE
fix: match `useCheckSum` casing expected by file-entry-cache v11

### DIFF
--- a/changelog_unreleased/cli/18914.md
+++ b/changelog_unreleased/cli/18914.md
@@ -1,0 +1,3 @@
+#### Fix `--cache-strategy content` not working (#18914 by @paulofduarte)
+
+`file-entry-cache` v11 renamed the `useChecksum` option to `useCheckSum`. Prettier was still passing the old casing, so content-based cache comparison was silently disabled and only file size was compared.

--- a/src/cli/format-results-cache.js
+++ b/src/cli/format-results-cache.js
@@ -43,10 +43,10 @@ class FormatResultsCache {
    * @param {string} cacheStrategy
    */
   constructor(cacheFileLocation, cacheStrategy) {
-    const useChecksum = cacheStrategy === "content";
+    const useCheckSum = cacheStrategy === "content";
     const fileEntryCacheOptions = {
-      useChecksum,
-      useModifiedTime: !useChecksum,
+      useCheckSum,
+      useModifiedTime: !useCheckSum,
       restrictAccessToCwd: false,
     };
 

--- a/tests/integration/__tests__/cache.js
+++ b/tests/integration/__tests__/cache.js
@@ -492,6 +492,35 @@ describe("--cache option", () => {
       );
     });
 
+    it("re-formats when content changes but file size stays the same", async () => {
+      const cliArguments = [
+        "--cache",
+        "--cache-strategy",
+        "content",
+        "--write",
+        "*.js",
+      ];
+
+      // First run — populates cache
+      await runCliWithoutGitignore(dir, cliArguments);
+
+      // Replace with different content of the same byte length
+      const sameSizeContent = contentA.replace(
+        'console.log("this is a.js")',
+        'console.log("that is a.js")',
+      );
+      await fs.writeFile(path.join(dir, "a.js"), sameSizeContent);
+
+      // Second run — must detect the content change
+      const { stdout } = await runCliWithoutGitignore(dir, cliArguments);
+      expect(stdout.split("\n")).toStrictEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\) \(cached\)$/),
+        ]),
+      );
+    });
+
     it("re-formats when options has been updated.", async () => {
       const { stdout: firstStdout } = await runCliWithoutGitignore(dir, [
         "--cache",


### PR DESCRIPTION
## Description

Fix `--cache-strategy content` being silently ignored since the `file-entry-cache` v10 → v11 upgrade.

`file-entry-cache` v11 renamed its option from `useChecksum` (lowercase `s`) to `useCheckSum` (capital `S`). Prettier still passes the old casing, so the option is silently ignored — content hashing never activates and the cache falls back to file-size-only comparison.

Fixes #18913.

## Checklist

- [x] I've added tests to confirm my change works.
- [x] (If changing the API or CLI) I've documented the changes I've made (in the `docs/` directory).
- [x] (If the change is user-facing) I've added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I've read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).