### PR TITLE
Update `--ignore-path` docs for clarity

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -127,7 +127,7 @@ If you don’t have a configuration file, or want to ignore it if it does exist,
 ## `--ignore-path`
 
 Path to a file containing patterns that describe files to ignore. By default, Prettier looks for `./.gitignore` and `./.prettierignore`.\
-Multiple values are accepted.
+Multiple values are accepted by providing multiple `--ignore-path` options: `prettier --ignore-path=myignores --ignore-path=my-ignores2`. Specifying an `--ignore-path` overrides the default rather than adding to it, so to add a new ignore file while keeping `./.gitignore` and `./.prettierignore` as well, specify `prettier --ignore-path=.gitignore --ignorepath=.prettierignore --ignore-path=myignores`.
 
 ## `--list-different`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -127,7 +127,7 @@ If you don’t have a configuration file, or want to ignore it if it does exist,
 ## `--ignore-path`
 
 Path to a file containing patterns that describe files to ignore. By default, Prettier looks for `./.gitignore` and `./.prettierignore`.\
-Multiple values are accepted by providing multiple `--ignore-path` options: `prettier --ignore-path=myignores --ignore-path=my-ignores2`. Specifying an `--ignore-path` overrides the default rather than adding to it, so to add a new ignore file while keeping `./.gitignore` and `./.prettierignore` as well, specify `prettier --ignore-path=.gitignore --ignorepath=.prettierignore --ignore-path=myignores`.
+Multiple values are accepted by providing multiple `--ignore-path` options: `prettier --ignore-path=myignores --ignore-path=my-ignores2`. Specifying an `--ignore-path` overrides the default rather than adding to it, so to add a new ignore file while keeping `./.gitignore` and `./.prettierignore` as well, specify `prettier --ignore-path=.gitignore --ignore-path=.prettierignore --ignore-path=myignores`.
 
 ## `--list-different`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -126,8 +126,9 @@ If you don’t have a configuration file, or want to ignore it if it does exist,
 
 ## `--ignore-path`
 
-Path to a file containing patterns that describe files to ignore. By default, Prettier looks for `./.gitignore` and `./.prettierignore`.\
-Multiple values are accepted by providing multiple `--ignore-path` options: `prettier --ignore-path=myignores --ignore-path=my-ignores2`. Specifying an `--ignore-path` overrides the default rather than adding to it, so to add a new ignore file while keeping `./.gitignore` and `./.prettierignore` as well, specify `prettier --ignore-path=.gitignore --ignore-path=.prettierignore --ignore-path=myignores`.
+Path to a file containing patterns that describe files to ignore. By default, Prettier looks for `./.gitignore` and `./.prettierignore`.
+
+Multiple values are accepted by providing multiple `--ignore-path` options: `prettier --ignore-path=foo-ignore --ignore-path=bar-ignore`. Specifying an `--ignore-path` overrides the default rather than adding to it, so to add a new ignore file while keeping `./.gitignore` and `./.prettierignore` as well, specify `prettier --ignore-path=.gitignore --ignore-path=.prettierignore --ignore-path=foo-ignore`.
 
 ## `--list-different`
 


### PR DESCRIPTION

## Description

The docs say that multiple `--ignore-path`s are allowed, but doesn't describe how to specify them (by providing multiple `--ignore-path` options; searching on this suggests it might be with a JS list, or comma-separated, which are wrong); clarify it for the benefit of doc readers. Also explicitly point out that setting `--ignore-path` unsets the default, so if you have a custom ignore file then the default `.prettierignore` is not loaded, which can trip people up. (It did us!)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
