### PR TITLE
chore: fix trim-indentation comment typo

### DIFF
--- a/src/document/printer/trim-indentation.js
+++ b/src/document/printer/trim-indentation.js
@@ -2,7 +2,7 @@
 // characters are known to have performance issues.
 
 /**
-Get trailing trailing indention length
+Get trailing indentation length
 
 @param {string} text
 @returns {number}


### PR DESCRIPTION
## Description

- Fixes a duplicated word and spelling mistake in the `trim-indentation` internal comment.

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
