### PR TITLE
replace escape-string-regexp with tiny-escape

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "diff": "8.0.3",
     "editorconfig-without-wasm": "0.0.4",
     "emoji-regex": "10.6.0",
-    "escape-string-regexp": "5.0.0",
+    "tiny-escape": "^1.1.0",
     "espree": "11.1.1",
     "fast-glob": "3.3.3",
     "fast-json-stable-stringify": "2.1.0",

--- a/scripts/build/hacks/modify-typescript-module.js
+++ b/scripts/build/hacks/modify-typescript-module.js
@@ -1,5 +1,5 @@
 import path from "node:path";
-import escapeStringRegexp from "escape-string-regexp";
+import escapeStringRegexp from "tiny-escape";
 import MagicString from "magic-string";
 import { outdent } from "outdent";
 import { PROJECT_ROOT, writeFile } from "../../utilities/index.js";

--- a/src/language-markdown/print/mdast.js
+++ b/src/language-markdown/print/mdast.js
@@ -1,5 +1,5 @@
 import collapseWhiteSpace from "collapse-white-space";
-import escapeStringRegexp from "escape-string-regexp";
+import escapeStringRegexp from "tiny-escape";
 import {
   align,
   DOC_TYPE_STRING,

--- a/src/utilities/get-max-continuous-count.js
+++ b/src/utilities/get-max-continuous-count.js
@@ -1,4 +1,4 @@
-import escapeStringRegexp from "escape-string-regexp";
+import escapeStringRegexp from "tiny-escape";
 
 /**
  * @param {string} text

--- a/src/utilities/get-min-not-present-continuous-count.js
+++ b/src/utilities/get-min-not-present-continuous-count.js
@@ -1,4 +1,4 @@
-import escapeStringRegexp from "escape-string-regexp";
+import escapeStringRegexp from "tiny-escape";
 
 /**
  * Calculates the minimum `n` (>= 1) where `searchString.repeat(n)` is not present in `text`.

--- a/src/utilities/whitespace-utilities.js
+++ b/src/utilities/whitespace-utilities.js
@@ -1,4 +1,4 @@
-import escapeStringRegexp from "escape-string-regexp";
+import escapeStringRegexp from "tiny-escape";
 
 class WhitespaceUtilities {
   #whitespaceCharacters;


### PR DESCRIPTION
tiny-escape has the same API as escape-string-regexp. Ships ESM + CJS with built-in TypeScript types. 192 bytes gzipped, zero deps.

https://npmgraph.js.org/?q=tiny-escape