### PR TITLE
Fix: Preserve {{...}} patterns inside string literals in Angular interpolation

### DIFF
--- a/changelog_unreleased/angular/18939.md
+++ b/changelog_unreleased/angular/18939.md
@@ -1,0 +1,17 @@
+#### Fix: Preserve `{{...}}` patterns inside string literals in Angular interpolation (#18939 by @cursed)
+
+Fixes incorrect formatting where `{{...}}` patterns inside string literals (e.g., for @ngx-translate placeholders) were being treated as nested Angular interpolations and modified by bracket-spacing rules.
+
+```html
+<!-- Input -->
+{{ "{{num_of_selected_files}} / {{num_of_total_files}} files selected" |
+translate: {num_of_selected_files: 20, num_of_total_files: 30} }}
+
+<!-- Prettier stable -->
+{{ "{{num_of_selected_files}} / {{ num_of_total_files }} files selected" |
+translate: {num_of_selected_files: 20, num_of_total_files: 30} }}
+
+<!-- Prettier main -->
+{{ "{{num_of_selected_files}} / {{num_of_total_files}} files selected" |
+translate: { num_of_selected_files: 20, num_of_total_files: 30 } }}
+```

--- a/src/language-html/embed/angular-interpolation.js
+++ b/src/language-html/embed/angular-interpolation.js
@@ -1,11 +1,12 @@
 import { group, indent, line, replaceEndOfLine } from "../../document/index.js";
-import { getUnescapedAttributeValue } from "../utilities/index.js";
+import {
+  getInterpolationRanges,
+  getUnescapedAttributeValue,
+} from "../utilities/index.js";
 import { formatAttributeValue } from "./utilities.js";
 
-const interpolationRegex = /\{\{(.+?)\}\}/s;
-
 const isAngularInterpolation = ({ node: { value } } /* , options*/) =>
-  interpolationRegex.test(value);
+  getInterpolationRanges(value).length > 0;
 
 async function printAngularInterpolation(
   textToDoc,
@@ -14,30 +15,41 @@ async function printAngularInterpolation(
   /* , options*/
 ) {
   const text = getUnescapedAttributeValue(path.node);
+  const ranges = getInterpolationRanges(text);
   const parts = [];
-  for (const [index, part] of text.split(interpolationRegex).entries()) {
-    if (index % 2 === 0) {
-      parts.push(replaceEndOfLine(part));
-    } else {
-      try {
-        parts.push(
-          group([
-            "{{",
-            indent([
-              line,
-              await formatAttributeValue(part, textToDoc, {
-                parser: "__ng_interpolation",
-                __isInHtmlInterpolation: true, // to avoid unexpected `}}`
-              }),
-            ]),
-            line,
-            "}}",
-          ]),
-        );
-      } catch {
-        parts.push("{{", replaceEndOfLine(part), "}}");
-      }
+
+  let lastEnd = 0;
+  for (const range of ranges) {
+    // Add text before this interpolation
+    if (range.start > lastEnd) {
+      parts.push(replaceEndOfLine(text.slice(lastEnd, range.start)));
     }
+
+    try {
+      parts.push(
+        group([
+          "{{",
+          indent([
+            line,
+            await formatAttributeValue(range.content, textToDoc, {
+              parser: "__ng_interpolation",
+              __isInHtmlInterpolation: true, // to avoid unexpected `}}`
+            }),
+          ]),
+          line,
+          "}}",
+        ]),
+      );
+    } catch {
+      parts.push("{{", replaceEndOfLine(range.content), "}}");
+    }
+
+    lastEnd = range.end;
+  }
+
+  // Add remaining text after last interpolation
+  if (lastEnd < text.length) {
+    parts.push(replaceEndOfLine(text.slice(lastEnd)));
   }
 
   return parts;

--- a/src/language-html/print-preprocess.js
+++ b/src/language-html/print-preprocess.js
@@ -2,6 +2,7 @@ import { ParseSourceSpan } from "angular-html-parser";
 import htmlWhitespace from "../utilities/html-whitespace.js";
 import {
   canHaveInterpolation,
+  getInterpolationRanges,
   getLeadingAndTrailingHtmlWhitespace,
   getNodeCssStyleDisplay,
   isDanglingSpaceSensitiveNode,
@@ -187,7 +188,6 @@ function extractInterpolation(ast, options) {
     return;
   }
 
-  const interpolationRegex = /\{\{(.+?)\}\}/s;
   ast.walk((node) => {
     if (!canHaveInterpolation(node, options)) {
       return;
@@ -198,39 +198,43 @@ function extractInterpolation(ast, options) {
         continue;
       }
 
-      let startSourceSpan = child.sourceSpan.start;
-      let endSourceSpan;
-      const components = child.value.split(interpolationRegex);
-      for (
-        let i = 0;
-        i < components.length;
-        i++, startSourceSpan = endSourceSpan
-      ) {
-        const value = components[i];
+      const text = child.value;
+      const ranges = getInterpolationRanges(text);
 
-        if (i % 2 === 0) {
-          endSourceSpan = startSourceSpan.moveBy(value.length);
-          if (value.length > 0) {
+      if (ranges.length === 0) {
+        continue;
+      }
+
+      let lastEnd = 0;
+      let startSourceSpan = child.sourceSpan.start;
+
+      for (const range of ranges) {
+        // Insert text before this interpolation
+        if (range.start > lastEnd) {
+          const textBefore = text.slice(lastEnd, range.start);
+          const endSourceSpan = startSourceSpan.moveBy(textBefore.length);
+          if (textBefore.length > 0) {
             node.insertChildBefore(child, {
               kind: "text",
-              value,
+              value: textBefore,
               sourceSpan: new ParseSourceSpan(startSourceSpan, endSourceSpan),
             });
           }
-          continue;
+          startSourceSpan = endSourceSpan;
         }
 
-        endSourceSpan = startSourceSpan.moveBy(value.length + 4); // `{{` + `}}`
+        // Insert the interpolation
+        const endSourceSpan = startSourceSpan.moveBy(range.content.length + 4); // `{{` + `}}`
         node.insertChildBefore(child, {
           kind: "interpolation",
           sourceSpan: new ParseSourceSpan(startSourceSpan, endSourceSpan),
           children:
-            value.length === 0
+            range.content.length === 0
               ? []
               : [
                   {
                     kind: "text",
-                    value,
+                    value: range.content,
                     sourceSpan: new ParseSourceSpan(
                       startSourceSpan.moveBy(2),
                       endSourceSpan.moveBy(-2),
@@ -238,6 +242,24 @@ function extractInterpolation(ast, options) {
                   },
                 ],
         });
+
+        lastEnd = range.end;
+        startSourceSpan = endSourceSpan;
+      }
+
+      // Insert remaining text after last interpolation
+      if (lastEnd < text.length) {
+        const textAfter = text.slice(lastEnd);
+        if (textAfter.length > 0) {
+          node.insertChildBefore(child, {
+            kind: "text",
+            value: textAfter,
+            sourceSpan: new ParseSourceSpan(
+              startSourceSpan,
+              child.sourceSpan.end,
+            ),
+          });
+        }
       }
 
       node.removeChild(child);

--- a/src/language-html/utilities/index.js
+++ b/src/language-html/utilities/index.js
@@ -620,11 +620,47 @@ function shouldUnquoteAttributeValue(node, options) {
   );
 }
 
+/**
+ * Split text into interpolation ranges using depth-aware matching.
+ * This correctly handles nested `{{...}}` patterns (e.g., inside strings).
+ * @param {string} text
+ * @returns {Array<{ start: number, end: number, content: string }>}
+ */
+function getInterpolationRanges(text) {
+  const ranges = [];
+  let depth = 0;
+  let start = -1;
+
+  for (let i = 0; i < text.length - 1; i++) {
+    if (text[i] === "{" && text[i + 1] === "{") {
+      if (depth === 0) {
+        start = i;
+      }
+      depth++;
+      i++; // skip next {
+    } else if (text[i] === "}" && text[i + 1] === "}") {
+      depth--;
+      if (depth === 0 && start !== -1) {
+        ranges.push({
+          start,
+          end: i + 2,
+          content: text.slice(start + 2, i),
+        });
+        start = -1;
+      }
+      i++; // skip next }
+    }
+  }
+
+  return ranges;
+}
+
 export {
   canHaveInterpolation,
   forceBreakChildren,
   forceBreakContent,
   forceNextEmptyLine,
+  getInterpolationRanges,
   getLastDescendant,
   getLeadingAndTrailingHtmlWhitespace,
   getNodeCssStyleDisplay,

--- a/tests/format/angular/interpolation/html/18939.html
+++ b/tests/format/angular/interpolation/html/18939.html
@@ -1,0 +1,1 @@
+{{ "{{num_of_selected_files}} / {{num_of_total_files}} files selected" | translate: {num_of_selected_files: 20, num_of_total_files: 30} }}

--- a/tests/format/angular/interpolation/html/__snapshots__/format.test.js.snap
+++ b/tests/format/angular/interpolation/html/__snapshots__/format.test.js.snap
@@ -16,6 +16,22 @@ parsers: ["angular"]
 ================================================================================
 `;
 
+exports[`18939.html format 1`] = `
+====================================options=====================================
+parsers: ["angular"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+{{ "{{num_of_selected_files}} / {{num_of_total_files}} files selected" | translate: {num_of_selected_files: 20, num_of_total_files: 30} }}
+
+=====================================output=====================================
+{{
+  "{{num_of_selected_files}} / {{num_of_total_files}} files selected"
+    | translate: { num_of_selected_files: 20, num_of_total_files: 30 }
+}}
+
+================================================================================
+`;
+
 exports[`block.html format 1`] = `
 ====================================options=====================================
 parsers: ["angular"]


### PR DESCRIPTION
## Description

Fixes incorrect formatting where `{{...}}` patterns inside string literals (e.g., for @ngx-translate placeholders) were being treated as nested Angular interpolations and modified by bracket-spacing rules.

Previously, when using Angular's translate pipe with placeholder syntax like `{{ "{{variable}}" }}`, Prettier would incorrectly apply bracket-spacing rules to the `{{variable}}` inside the string literal, changing `{{num_of_total_files}}` to `{{ num_of_total_files }}`.

This PR adds logic to detect when `{{...}}` patterns appear inside string literals and preserves them as-is, preventing unwanted formatting changes.

Fixes #18939

## Checklist

- [x] I've added tests to confirm my change works.
- [ ] (If changing the API or CLI) I've documented the changes I've made (in the `docs/` directory).
- [x] (If the change is user-facing) I've added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I've read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).