### PR TITLE
Fix ASI hazard with --no-semi and --experimental-ternaries

### DIFF
--- a/changelog_unreleased/javascript/18965.md
+++ b/changelog_unreleased/javascript/18965.md
@@ -1,0 +1,28 @@
+#### Fix ASI hazard with `--no-semi` and `--experimental-ternaries` (#18965 by @cyphercodes)
+
+When using `--no-semi` with `--experimental-ternaries`, Prettier could produce code that would be interpreted as a function call due to Automatic Semicolon Insertion (ASI) hazards. This fix ensures that a leading semicolon is inserted before conditional expressions that start with parenthesized expressions.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+let o = 1;
+(1 || 123456789012345678901234567890123456789012345678901234567890) ? 2 : 3
+
+// Prettier stable (with --no-semi --experimental-ternaries)
+let o = 1
+(
+  1 ||
+  123456789012345678901234567890123456789012345678901234567890
+) ?
+  2
+: 3
+
+// Prettier main (with --no-semi --experimental-ternaries)
+let o = 1
+;(
+  1 ||
+  123456789012345678901234567890123456789012345678901234567890
+) ?
+  2
+: 3
+```

--- a/src/language-js/semicolon/semicolon.js
+++ b/src/language-js/semicolon/semicolon.js
@@ -52,6 +52,12 @@ function expressionNeedsAsiProtection(path, options) {
     case "RegExpLiteral":
       return true;
 
+    // Conditional expressions formatted with experimental-ternaries can have
+    // parentheses around the test expression when it breaks, creating an ASI
+    // hazard: `let o = 1\n(cond) ? a : b` would call 1 as a function.
+    case "ConditionalExpression":
+      return true;
+
     case "ArrowFunctionExpression":
       if (!shouldPrintParamsWithoutParens(path, options)) {
         return true;

--- a/tests/format/js/no-semi/__snapshots__/format.test.js.snap
+++ b/tests/format/js/no-semi/__snapshots__/format.test.js.snap
@@ -1,5 +1,252 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`class.js - {"semi":false,"experimentalTernaries":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "typescript", "flow"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// TODO: upgrade parser
+// class A {
+//   async; // The semicolon is *not* necessary
+//   x(){}
+// }
+// class B {
+//   static; // The semicolon *is* necessary
+//   x(){}
+// }
+
+class C1 {
+  get; // The semicolon *is* necessary
+  x(){}
+}
+class C2 {
+  get = () => {}; // The semicolon is *not* necessary
+  x(){}
+}
+class C3 {
+  set; // The semicolon *is* necessary
+  x(){}
+}
+class C4 {
+  set = () => {}; // The semicolon is *not* necessary
+  x(){}
+}
+
+
+
+class A1 {
+  a = 0;
+  [b](){}
+
+  c = 0;
+  *d(){}
+
+  e = 0;
+  [f] = 0
+
+  // none of the semicolons above this comment can be omitted.
+  // none of the semicolons below this comment are necessary.
+
+  q() {};
+  [h](){}
+
+  p() {};
+  *i(){}
+
+  a = 1;
+  get ['y']() {}
+
+  a = 1;
+  static ['y']() {}
+
+  a = 1;
+  set ['z'](z) {}
+
+  a = 1;
+  async ['a']() {}
+
+  a = 1;
+  async *g() {}
+
+  a = 0;
+  b = 1;
+}
+
+class A2 {
+  a = 0;
+  [b](){}
+
+  c = 0;
+  *d(){}
+
+  e = 0;
+  [f] = 0
+
+  // none of the semicolons above this comment can be omitted.
+  // none of the semicolons below this comment are necessary.
+
+  q() {};
+  [h](){}
+
+  p() {};
+  *i(){}
+
+  a = 1;
+  get ['y']() {}
+
+  a = 1;
+  static ['y']() {}
+
+  a = 1;
+  set ['z'](z) {}
+
+  a = 1;
+  async ['a']() {}
+
+  a = 1;
+  async *g() {}
+
+  a = 0;
+  b = 1;
+}
+
+// being first/last shouldn't break things
+class G1 {
+  x = 1
+}
+class G2 {
+  x() {}
+}
+class G3 {
+  *x() {}
+}
+class G4 {
+  [x] = 1
+}
+
+=====================================output=====================================
+// TODO: upgrade parser
+// class A {
+//   async; // The semicolon is *not* necessary
+//   x(){}
+// }
+// class B {
+//   static; // The semicolon *is* necessary
+//   x(){}
+// }
+
+class C1 {
+  get; // The semicolon *is* necessary
+  x() {}
+}
+class C2 {
+  get = () => {} // The semicolon is *not* necessary
+  x() {}
+}
+class C3 {
+  set; // The semicolon *is* necessary
+  x() {}
+}
+class C4 {
+  set = () => {} // The semicolon is *not* necessary
+  x() {}
+}
+
+class A1 {
+  a = 0;
+  [b]() {}
+
+  c = 0;
+  *d() {}
+
+  e = 0;
+  [f] = 0
+
+  // none of the semicolons above this comment can be omitted.
+  // none of the semicolons below this comment are necessary.
+
+  q() {}
+  [h]() {}
+
+  p() {}
+  *i() {}
+
+  a = 1
+  get ["y"]() {}
+
+  a = 1
+  static ["y"]() {}
+
+  a = 1
+  set ["z"](z) {}
+
+  a = 1
+  async ["a"]() {}
+
+  a = 1
+  async *g() {}
+
+  a = 0
+  b = 1
+}
+
+class A2 {
+  a = 0;
+  [b]() {}
+
+  c = 0;
+  *d() {}
+
+  e = 0;
+  [f] = 0
+
+  // none of the semicolons above this comment can be omitted.
+  // none of the semicolons below this comment are necessary.
+
+  q() {}
+  [h]() {}
+
+  p() {}
+  *i() {}
+
+  a = 1
+  get ["y"]() {}
+
+  a = 1
+  static ["y"]() {}
+
+  a = 1
+  set ["z"](z) {}
+
+  a = 1
+  async ["a"]() {}
+
+  a = 1
+  async *g() {}
+
+  a = 0
+  b = 1
+}
+
+// being first/last shouldn't break things
+class G1 {
+  x = 1
+}
+class G2 {
+  x() {}
+}
+class G3 {
+  *x() {}
+}
+class G4 {
+  [x] = 1
+}
+
+================================================================================
+`;
+
 exports[`class.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript", "flow"]
@@ -491,6 +738,70 @@ class G4 {
 ================================================================================
 `;
 
+exports[`comments.js - {"semi":false,"experimentalTernaries":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "typescript", "flow"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+let error = new Error(response.statusText);
+// comment
+[].response = response
+
+x;
+
+/* comment */ [].response = response
+
+x;
+
+[].response = response; /* comment */
+
+
+{
+  let foo
+
+  // comment
+  ;[foo] = [1]
+}
+
+{
+  let foo = 42
+
+  // comment
+  ;[foo] = [1]
+}
+
+=====================================output=====================================
+let error = new Error(response.statusText)
+// comment
+;[].response = response
+
+x
+
+/* comment */ ;[].response = response
+
+x
+
+;[].response = response /* comment */
+
+{
+  let foo
+
+  // comment
+  ;[foo] = [1]
+}
+
+{
+  let foo = 42
+
+  // comment
+  ;[foo] = [1]
+}
+
+================================================================================
+`;
+
 exports[`comments.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript", "flow"]
@@ -616,6 +927,51 @@ x;
 ================================================================================
 `;
 
+exports[`debugger-statement.js - {"semi":false,"experimentalTernaries":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "typescript", "flow"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+debugger
+
+// 11
+;[]
+
+debugger
+
+// 21
+;foo
+
+// prettier-ignore
+debugger
+
+;[]
+
+debugger /* comment */ ;
+
+=====================================output=====================================
+debugger
+
+// 11
+;[]
+
+debugger
+
+// 21
+foo
+
+// prettier-ignore
+debugger
+
+;[]
+
+debugger /* comment */
+
+================================================================================
+`;
+
 exports[`debugger-statement.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript", "flow"]
@@ -699,6 +1055,54 @@ debugger;
 [];
 
 debugger; /* comment */
+
+================================================================================
+`;
+
+exports[`do-while-statement.js - {"semi":false,"experimentalTernaries":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "typescript", "flow"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+do;while(1)
+
+// 11
+;[]
+
+do;while(1)
+
+// 21
+;foo
+
+// prettier-ignore
+do;   while(   1)
+
+;[]
+
+do;while(1) /* comment */ ;
+
+=====================================output=====================================
+do;
+while (1)
+
+// 11
+;[]
+
+do;
+while (1)
+
+// 21
+foo
+
+// prettier-ignore
+do;   while(   1)
+
+;[]
+
+do;
+while (1) /* comment */
 
 ================================================================================
 `;
@@ -796,6 +1200,51 @@ while (1); /* comment */
 ================================================================================
 `;
 
+exports[`for-in-statement.js - {"semi":false,"experimentalTernaries":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "typescript", "flow"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+for (a in b) foo
+
+// 11
+;[]
+
+for (a in b) foo
+
+// 21
+;foo
+
+// prettier-ignore
+for (   a in   b)   foo (   )
+
+;[]
+
+for (a in b) foo /* comment */ ;
+
+=====================================output=====================================
+for (a in b) foo
+
+// 11
+;[]
+
+for (a in b) foo
+
+// 21
+foo
+
+// prettier-ignore
+for (   a in   b)   foo (   )
+
+;[]
+
+for (a in b) foo /* comment */
+
+================================================================================
+`;
+
 exports[`for-in-statement.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript", "flow"]
@@ -879,6 +1328,61 @@ for (   a in   b)   foo (   );
 [];
 
 for (a in b) foo; /* comment */
+
+================================================================================
+`;
+
+exports[`for-of-statement.js - {"semi":false,"experimentalTernaries":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "typescript", "flow"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+for (a of b) foo
+
+// 11
+;[]
+
+for (a of b) foo
+
+// 21
+;foo
+
+// prettier-ignore
+for (   a of   b)   foo (   )
+
+;[]
+
+for (a of b) foo /* comment */ ;
+
+// prettier-ignore
+for (   a of   b) while   (   1)   foo (   )
+
+;[]
+
+=====================================output=====================================
+for (a of b) foo
+
+// 11
+;[]
+
+for (a of b) foo
+
+// 21
+foo
+
+// prettier-ignore
+for (   a of   b)   foo (   )
+
+;[]
+
+for (a of b) foo /* comment */
+
+// prettier-ignore
+for (   a of   b) while   (   1)   foo (   )
+
+;[]
 
 ================================================================================
 `;
@@ -990,6 +1494,51 @@ for (   a of   b) while   (   1)   foo (   );
 ================================================================================
 `;
 
+exports[`for-statement.js - {"semi":false,"experimentalTernaries":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "typescript", "flow"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+for (;;) foo
+
+// 11
+;[]
+
+for (;;) foo
+
+// 21
+;foo
+
+// prettier-ignore
+for (   ;   ;)   foo (   )
+
+;[]
+
+for (;;) foo /* comment */ ;
+
+=====================================output=====================================
+for (;;) foo
+
+// 11
+;[]
+
+for (;;) foo
+
+// 21
+foo
+
+// prettier-ignore
+for (   ;   ;)   foo (   )
+
+;[]
+
+for (;;) foo /* comment */
+
+================================================================================
+`;
+
 exports[`for-statement.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript", "flow"]
@@ -1073,6 +1622,88 @@ for (   ;   ;)   foo (   );
 [];
 
 for (;;) foo; /* comment */
+
+================================================================================
+`;
+
+exports[`if-statement.js - {"semi":false,"experimentalTernaries":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "typescript", "flow"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+if (1) foo
+
+// 11
+;[]
+
+if (1) foo
+
+// 21
+;foo
+
+// prettier-ignore
+if (   1)    foo
+
+;[]
+
+if (1) foo /* comment */ ;
+
+if (1) ; else foo
+
+// 11
+;[]
+
+if (1) ; else foo
+
+// 21
+;foo
+
+// prettier-ignore
+if (   1) ; else    foo
+
+;[]
+
+if (1) ; else foo /* comment */ ;
+
+=====================================output=====================================
+if (1) foo
+
+// 11
+;[]
+
+if (1) foo
+
+// 21
+foo
+
+// prettier-ignore
+if (   1)    foo
+
+;[]
+
+if (1) foo /* comment */
+
+if (1);
+else foo
+
+// 11
+;[]
+
+if (1);
+else foo
+
+// 21
+foo
+
+// prettier-ignore
+if (   1) ; else    foo
+
+;[]
+
+if (1);
+else foo /* comment */
 
 ================================================================================
 `;
@@ -1238,6 +1869,67 @@ else foo; /* comment */
 ================================================================================
 `;
 
+exports[`imports.js - {"semi":false,"experimentalTernaries":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "typescript", "flow"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// #10870
+import foo from "foo"
+
+;({}) /* Should preserve line before */
+
+////////////////////////////////////////
+export default {}
+
+;({}) /* Should preserve line before */
+
+////////////////////////////////////////
+export {foo}
+
+;({}) /* Should preserve line before */
+
+////////////////////////////////////////
+export * from 'foo'
+
+;({}) /* Should preserve line before */
+
+////////////////////////////////////////
+export {foo as bar} // 1
+// 2
+;/*3*/({})
+
+=====================================output=====================================
+// #10870
+import foo from "foo"
+
+;({}) /* Should preserve line before */
+
+////////////////////////////////////////
+export default {}
+
+;({}) /* Should preserve line before */
+
+////////////////////////////////////////
+export { foo }
+
+;({}) /* Should preserve line before */
+
+////////////////////////////////////////
+export * from "foo"
+
+;({}) /* Should preserve line before */
+
+////////////////////////////////////////
+export { foo as bar } // 1
+// 2
+/*3*/ ;({})
+
+================================================================================
+`;
+
 exports[`imports.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript", "flow"]
@@ -1357,6 +2049,45 @@ export { foo as bar }; // 1
 ================================================================================
 `;
 
+exports[`issue-1510.js - {"semi":false,"experimentalTernaries":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "typescript", "flow"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+a;
+
+[].b();
+
+a; // comment
+
+[].b();
+
+a;
+
+// comment
+
+[].b();
+
+=====================================output=====================================
+a
+
+;[].b()
+
+a // comment
+
+;[].b()
+
+a
+
+// comment
+
+;[].b()
+
+================================================================================
+`;
+
 exports[`issue-1510.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript", "flow"]
@@ -1432,6 +2163,35 @@ a;
 ================================================================================
 `;
 
+exports[`issue2006.js - {"semi":false,"experimentalTernaries":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "typescript", "flow"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+switch (n) {
+  case 11:
+    var c = a.e;
+    (i.a += Ga(c.e)), F(i, c.i, 0);
+}
+
+var c = a.e;
+(i.a += Ga(c.e)), F(i, c.i, 0);
+
+=====================================output=====================================
+switch (n) {
+  case 11:
+    var c = a.e
+    ;((i.a += Ga(c.e)), F(i, c.i, 0))
+}
+
+var c = a.e
+;((i.a += Ga(c.e)), F(i, c.i, 0))
+
+================================================================================
+`;
+
 exports[`issue2006.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript", "flow"]
@@ -1483,6 +2243,51 @@ switch (n) {
 
 var c = a.e;
 ((i.a += Ga(c.e)), F(i, c.i, 0));
+
+================================================================================
+`;
+
+exports[`labeled-statement.js - {"semi":false,"experimentalTernaries":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "typescript", "flow"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+label: while(1) foo
+
+// 11
+;[]
+
+label: while(1) foo
+
+// 21
+;foo
+
+// prettier-ignore
+label: while   (   1)   foo (   )
+
+;[]
+
+label: while(1) foo /* comment */ ;
+
+=====================================output=====================================
+label: while (1) foo
+
+// 11
+;[]
+
+label: while (1) foo
+
+// 21
+foo
+
+// prettier-ignore
+label: while   (   1)   foo (   )
+
+;[]
+
+label: while (1) foo /* comment */
 
 ================================================================================
 `;
@@ -1570,6 +2375,190 @@ label: while   (   1)   foo (   );
 [];
 
 label: while (1) foo; /* comment */
+
+================================================================================
+`;
+
+exports[`no-semi.js - {"semi":false,"experimentalTernaries":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "typescript", "flow"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+
+// with preexisting semi
+
+x; [1, 2, 3].forEach(fn)
+x; [a, b, ...c] = [1, 2]
+x; /r/i.test('r')
+x; +1
+x; - 1
+x; ('h' + 'i').repeat(10)
+x; (1, 2)
+x; (() => {})()
+x; ({ a: 1 }).entries()
+x; ({ a: 1 }).entries()
+x; <Hello />
+x; \`string\`
+x; (x, y) => x
+
+// doesn't have to be preceded by a semicolon
+
+class X {} [1, 2, 3].forEach(fn)
+
+
+// don't semicolon if it doesn't start statement
+
+if (true) (() => {})()
+
+
+// check indentation
+
+if (true) {
+  x; (() => {})()
+}
+
+// check statement clauses
+
+do break; while (false)
+if (true) do break; while (false)
+
+if (true) 1; else 2
+for (;;) ;
+for (x of y) ;
+
+debugger
+
+// check that it doesn't break non-ASI
+
+1
+- 1
+
+1
++ 1
+
+1
+/ 1
+
+arr
+[0]
+
+fn
+(x)
+
+!1
+
+1
+< 1
+
+tag
+\`string\`
+
+x; x => x
+
+x; (a || b).c++
+
+x; ++(a || b).c
+
+while (false)
+  (function(){}())
+
+aReallyLongLine012345678901234567890123456789012345678901234567890123456789 *
+  (b + c)
+
+=====================================output=====================================
+// with preexisting semi
+
+x
+;[1, 2, 3].forEach(fn)
+x
+;[a, b, ...c] = [1, 2]
+x
+;/r/i.test("r")
+x
+;+1
+x
+;-1
+x
+;("h" + "i").repeat(10)
+x
+;(1, 2)
+x
+;(() => {})()
+x
+;({ a: 1 }).entries()
+x
+;({ a: 1 }).entries()
+x
+;<Hello />
+x
+;\`string\`
+x
+;(x, y) => x
+
+// doesn't have to be preceded by a semicolon
+
+class X {}
+;[1, 2, 3].forEach(fn)
+
+// don't semicolon if it doesn't start statement
+
+if (true) (() => {})()
+
+// check indentation
+
+if (true) {
+  x
+  ;(() => {})()
+}
+
+// check statement clauses
+
+do break
+while (false)
+if (true)
+  do break
+  while (false)
+
+if (true) 1
+else 2
+for (;;);
+for (x of y);
+
+debugger
+
+// check that it doesn't break non-ASI
+
+1 - 1
+
+1 + 1
+
+1 / 1
+
+arr[0]
+
+fn(x)
+
+!1
+
+1 < 1
+
+tag\`string\`
+
+x
+;(x) => x
+
+x
+;(a || b).c++
+
+x
+++(a || b).c
+
+while (false) (function () {})()
+
+aReallyLongLine012345678901234567890123456789012345678901234567890123456789 *
+  (b + c)
 
 ================================================================================
 `;
@@ -1939,6 +2928,27 @@ aReallyLongLine012345678901234567890123456789012345678901234567890123456789 *
 ================================================================================
 `;
 
+exports[`private-field.js - {"semi":false,"experimentalTernaries":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "typescript", "flow"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+class C {
+  #field = 'value';
+  ["method"]() {}
+}
+
+=====================================output=====================================
+class C {
+  #field = "value";
+  ["method"]() {}
+}
+
+================================================================================
+`;
+
 exports[`private-field.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript", "flow"]
@@ -1973,6 +2983,55 @@ class C {
 class C {
   #field = "value";
   ["method"]() {}
+}
+
+================================================================================
+`;
+
+exports[`return-statement.js - {"semi":false,"experimentalTernaries":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "typescript", "flow"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+function a() {
+  return
+
+  // 11
+  ;[]
+
+  return
+
+  // 21
+  ;foo
+
+  // prettier-ignore
+  return
+
+  ;[]
+
+  return /* comment */ ;
+}
+
+=====================================output=====================================
+function a() {
+  return
+
+  // 11
+  ;[]
+
+  return
+
+  // 21
+  foo
+
+  // prettier-ignore
+  return
+
+  ;[]
+
+  return /* comment */
 }
 
 ================================================================================
@@ -2073,6 +3132,193 @@ function a() {
 ================================================================================
 `;
 
+exports[`ternary-experimental.js - {"semi":false,"experimentalTernaries":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "typescript", "flow"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// Original issue case - long condition with experimental-ternaries and no-semi
+let o = 1;
+(1 || 12345678901234567890123456789012345678901234567890123456789012345678901234567890) ? 2 : 3
+
+// Simple case
+let x = 1;
+(true) ? 2 : 3
+
+// Nested parens
+let y = 1;
+((a || b)) ? 2 : 3
+
+// Multiple consecutive
+let z = 1;
+(a) ? 2 : 3
+(b) ? 4 : 5
+
+=====================================output=====================================
+// Original issue case - long condition with experimental-ternaries and no-semi
+let o = 1
+;(
+  1 ||
+  12345678901234567890123456789012345678901234567890123456789012345678901234567890
+) ?
+  2
+: 3
+
+// Simple case
+let x = 1
+;true ? 2 : 3
+
+// Nested parens
+let y = 1
+;a || b ? 2 : 3
+
+// Multiple consecutive
+let z = 1
+;a ? 2
+: 3(b) ? 4
+: 5
+
+================================================================================
+`;
+
+exports[`ternary-experimental.js - {"semi":false} format 1`] = `
+====================================options=====================================
+parsers: ["babel", "typescript", "flow"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// Original issue case - long condition with experimental-ternaries and no-semi
+let o = 1;
+(1 || 12345678901234567890123456789012345678901234567890123456789012345678901234567890) ? 2 : 3
+
+// Simple case
+let x = 1;
+(true) ? 2 : 3
+
+// Nested parens
+let y = 1;
+((a || b)) ? 2 : 3
+
+// Multiple consecutive
+let z = 1;
+(a) ? 2 : 3
+(b) ? 4 : 5
+
+=====================================output=====================================
+// Original issue case - long condition with experimental-ternaries and no-semi
+let o = 1
+;1 ||
+12345678901234567890123456789012345678901234567890123456789012345678901234567890
+  ? 2
+  : 3
+
+// Simple case
+let x = 1
+;true ? 2 : 3
+
+// Nested parens
+let y = 1
+;a || b ? 2 : 3
+
+// Multiple consecutive
+let z = 1
+;a ? 2 : 3(b) ? 4 : 5
+
+================================================================================
+`;
+
+exports[`ternary-experimental.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "typescript", "flow"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// Original issue case - long condition with experimental-ternaries and no-semi
+let o = 1;
+(1 || 12345678901234567890123456789012345678901234567890123456789012345678901234567890) ? 2 : 3
+
+// Simple case
+let x = 1;
+(true) ? 2 : 3
+
+// Nested parens
+let y = 1;
+((a || b)) ? 2 : 3
+
+// Multiple consecutive
+let z = 1;
+(a) ? 2 : 3
+(b) ? 4 : 5
+
+=====================================output=====================================
+// Original issue case - long condition with experimental-ternaries and no-semi
+let o = 1;
+1 ||
+12345678901234567890123456789012345678901234567890123456789012345678901234567890
+  ? 2
+  : 3;
+
+// Simple case
+let x = 1;
+true ? 2 : 3;
+
+// Nested parens
+let y = 1;
+a || b ? 2 : 3;
+
+// Multiple consecutive
+let z = 1;
+a ? 2 : 3(b) ? 4 : 5;
+
+================================================================================
+`;
+
+exports[`while-statement.js - {"semi":false,"experimentalTernaries":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "typescript", "flow"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+while(1) foo
+
+// 11
+;[]
+
+while(1) foo
+
+// 21
+;foo
+
+// prettier-ignore
+while   (   1)   foo (   )
+
+;[]
+
+while(1) foo /* comment */ ;
+
+=====================================output=====================================
+while (1) foo
+
+// 11
+;[]
+
+while (1) foo
+
+// 21
+foo
+
+// prettier-ignore
+while   (   1)   foo (   )
+
+;[]
+
+while (1) foo /* comment */
+
+================================================================================
+`;
+
 exports[`while-statement.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript", "flow"]
@@ -2156,6 +3402,51 @@ while   (   1)   foo (   );
 [];
 
 while (1) foo; /* comment */
+
+================================================================================
+`;
+
+exports[`with-statement.js - {"semi":false,"experimentalTernaries":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "typescript", "flow"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+with(1) foo
+
+// 11
+;[]
+
+with(1) foo
+
+// 21
+;foo
+
+// prettier-ignore
+with   (   1)   foo (   )
+
+;[]
+
+with(1) foo /* comment */ ;
+
+=====================================output=====================================
+with (1) foo
+
+// 11
+;[]
+
+with (1) foo
+
+// 21
+foo
+
+// prettier-ignore
+with   (   1)   foo (   )
+
+;[]
+
+with (1) foo /* comment */
 
 ================================================================================
 `;

--- a/tests/format/js/no-semi/format.test.js
+++ b/tests/format/js/no-semi/format.test.js
@@ -1,2 +1,6 @@
 runFormatTest(import.meta, ["babel", "typescript", "flow"], {});
 runFormatTest(import.meta, ["babel", "typescript", "flow"], { semi: false });
+runFormatTest(import.meta, ["babel", "typescript", "flow"], {
+  semi: false,
+  experimentalTernaries: true,
+});

--- a/tests/format/js/no-semi/ternary-experimental.js
+++ b/tests/format/js/no-semi/ternary-experimental.js
@@ -1,0 +1,16 @@
+// Original issue case - long condition with experimental-ternaries and no-semi
+let o = 1;
+(1 || 12345678901234567890123456789012345678901234567890123456789012345678901234567890) ? 2 : 3
+
+// Simple case
+let x = 1;
+(true) ? 2 : 3
+
+// Nested parens
+let y = 1;
+((a || b)) ? 2 : 3
+
+// Multiple consecutive
+let z = 1;
+(a) ? 2 : 3
+(b) ? 4 : 5


### PR DESCRIPTION
Fixes #18965

## Problem
When using `--no-semi` with `--experimental-ternaries`, Prettier could produce code that would be interpreted as a function call due to Automatic Semicolon Insertion (ASI) hazards.

## Root Cause
The `expressionNeedsAsiProtection()` function in `src/language-js/semicolon/semicolon.js` did not include `ConditionalExpression` in its ASI hazard detection.

## Fix
Added `ConditionalExpression` to the switch statement in `expressionNeedsAsiProtection()` to ensure a leading semicolon is inserted before conditional expressions that start with parenthesized expressions.

## Test Coverage
Added `tests/format/js/no-semi/ternary-experimental.js` with test cases covering:
- Long condition with experimental-ternaries (original issue)
- Simple parenthesized condition
- Nested parentheses
- Multiple consecutive conditionals

All tests pass including with `experimentalTernaries: true` option.