### PR TITLE
chore: resolve Node.js version-gated TODOs (AggregateError, Error.pro…

### DIFF
--- a/src/common/parser-create-error.js
+++ b/src/common/parser-create-error.js
@@ -1,5 +1,6 @@
 function createError(message, options) {
-  // TODO: Use `Error.prototype.cause` when we drop support for Node.js<18.7.0
+  const { cause, ...restOptions } = options;
+  const errorOptions = cause ? { cause } : undefined;
 
   // Construct an error similar to the ones thrown by Babel.
   const error = new SyntaxError(
@@ -9,9 +10,10 @@ function createError(message, options) {
       ":" +
       options.loc.start.column +
       ")",
+    errorOptions,
   );
 
-  return Object.assign(error, options);
+  return Object.assign(error, restOptions);
 }
 
 export default createError;

--- a/src/utilities/try-combinations.js
+++ b/src/utilities/try-combinations.js
@@ -13,9 +13,7 @@ function tryCombinationsSync(combinations) {
     }
   }
 
-  // TODO: Use `AggregateError` when we drop Node.js v14
-  // throw new AggregateError(errors, "All combinations failed");
-  throw Object.assign(new Error("All combinations failed"), { errors });
+  throw new AggregateError(errors, "All combinations failed");
 }
 
 export { tryCombinationsSync };


### PR DESCRIPTION
This PR resolves a couple of old `TODO` comments in the codebase that were contingent upon dropping support for older Node.js versions (v14 and v18.7.0). Under `package.json`, the `engines.node` minimum version is now `>=20`, meaning we can safely use modern, native ES APIs for error handling.

Changes made:
1. **`src/utilities/try-combinations.js`**:
   - Replaced a custom thrown object combining an array of errors with the native `AggregateError`.
   - Node.js `v15.0.0+` has full built-in support for `AggregateError`, meaning the fallback `throw Object.assign(new Error(...), { errors })` is no longer needed.

2. **`src/common/parser-create-error.js`**:
   - Updated the `SyntaxError` constructor to natively accept an `options.cause` argument (e.g., `{ cause }`) instead of manually running `Object.assign` to graft the cause property onto an Error.
   - Node.js `v18.7.0+` natively supports `Error.prototype.cause`.

These are purely un-blocking tech debt cleanups and introduce native language enhancements over workarounds. Tests (`yarn test`) run properly without any issues.

## Checklist

- [x] I’ve added tests to confirm my change works. (N/A — Refactoring using built-in APIs, covered by existing test suites)
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory). (N/A)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`. (Since this is an internal refactor/chore, a changelog unreleased entry might not be required, but one provides down below just in case).
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

---
#### Resolve Node.js version-gated TODOs around Error handling (by @NssGourav)

Refactored internal error management to utilize modern, native ECMAScript tools, specifically `AggregateError` and `Error.prototype.cause`, replacing custom polyfill approaches. These enhancements were enabled by our newer Node.js >= 20 minimum engine.
