### PR TITLE
fix: use RegExp.escape gracefully in place of escape-string-regexp

### DIFF
--- a/src/language-markdown/print/mdast.js
+++ b/src/language-markdown/print/mdast.js
@@ -505,7 +505,12 @@ function printUrl(url, dangerousCharOrChars = []) {
   ];
 
   return new RegExp(
-    dangerousChars.map((x) => escapeStringRegexp(x)).join("|"),
+    dangerousChars
+      .map((x) =>
+        // @ts-expect-error -- RegExp.escape is a proposal
+        (RegExp.escape ?? escapeStringRegexp)(x),
+      )
+      .join("|"),
   ).test(url)
     ? `<${encodeUrl(url, "<>")}>`
     : url;

--- a/src/utilities/get-max-continuous-count.js
+++ b/src/utilities/get-max-continuous-count.js
@@ -7,7 +7,11 @@ import escapeStringRegexp from "escape-string-regexp";
  */
 function getMaxContinuousCount(text, searchString) {
   let results = text.matchAll(
-    new RegExp(`(?:${escapeStringRegexp(searchString)})+`, "g"),
+    // @ts-expect-error -- RegExp.escape is a proposal
+    new RegExp(
+      `(?:${(RegExp.escape ?? escapeStringRegexp)(searchString)})+`,
+      "g",
+    ),
   );
 
   // TODO: Use `Iterator#reduce` when we drop support for Node.js < 22

--- a/src/utilities/get-min-not-present-continuous-count.js
+++ b/src/utilities/get-min-not-present-continuous-count.js
@@ -11,7 +11,11 @@ import escapeStringRegexp from "escape-string-regexp";
  */
 function getMinNotPresentContinuousCount(text, searchString) {
   const matches = text.match(
-    new RegExp(`(${escapeStringRegexp(searchString)})+`, "g"),
+    // @ts-expect-error -- RegExp.escape is a proposal
+    new RegExp(
+      `(${(RegExp.escape ?? escapeStringRegexp)(searchString)})+`,
+      "g",
+    ),
   );
 
   if (matches === null) {

--- a/src/utilities/whitespace-utilities.js
+++ b/src/utilities/whitespace-utilities.js
@@ -83,7 +83,8 @@ class WhitespaceUtilities {
   }
 
   split(text, captureWhitespace = false) {
-    const pattern = `[${escapeStringRegexp(
+    const pattern = `[${// @ts-expect-error -- RegExp.escape is a proposal
+    (RegExp.escape ?? escapeStringRegexp)(
       [...this.#whitespaceCharacters].join(""),
     )}]+`;
     const regexp = new RegExp(captureWhitespace ? `(${pattern})` : pattern);


### PR DESCRIPTION
Resolves #18137.

This PR addresses issue #18137 by replacing direct calls to `escapeStringRegexp(s)` with `(RegExp.escape ?? escapeStringRegexp)(s)` throughout the codebase.

Since Node 24+ natively supports `RegExp.escape`, this change allows us to start leveraging the built-in ECMAScript function where it's available today, while actively preserving `escape-string-regexp` as a fallback for Node 20/22 and existing iOS 16-17 environments!

To ensure TypeScript compilation passes, I've safely added `// @ts-expect-error` inline, as `RegExp.escape` is still an ES Proposal and thus absent from standard `lib` typings.

## Checklist

- [x] I’ve added tests to confirm my change works. (N/A)
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory). (N/A)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

Replaced usages of the external `escape-string-regexp` package with a native `RegExp.escape` graceful fallback, adopting the impending ECMA standard early for environments like Node 24+ while maintaining backward compatibility.
