### PR TITLE
docs: fix typos in markdown documentation

### DIFF
--- a/changelog_unreleased/typescript/18827.md
+++ b/changelog_unreleased/typescript/18827.md
@@ -1,4 +1,4 @@
-#### Remove extra indention for union type in conditional type (#18827 by @fisker)
+#### Remove extra indentation for union type in conditional type (#18827 by @fisker)
 
 <!-- prettier-ignore -->
 ```tsx

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -107,7 +107,7 @@ If you're worried that Prettier will change the correctness of your code, add `-
 
 ## `--find-config-path` and `--config`
 
-If you are repeatedly formatting individual files with `prettier`, you will incur a small performance cost when Prettier attempts to look up a [configuration file](configuration.md). In order to skip this, you may ask Prettier to find the config file once, and re-use it later on.
+If you are repeatedly formatting individual files with `prettier`, you will incur a small performance cost when Prettier attempts to look up a [configuration file](configuration.md). In order to skip this, you may ask Prettier to find the config file once, and reuse it later on.
 
 ```console
 $ prettier --find-config-path path/to/file.js

--- a/docs/integrating-with-linters.md
+++ b/docs/integrating-with-linters.md
@@ -20,7 +20,7 @@ First, we have plugins that let you run Prettier as if it was a linter rule:
 - [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier)
 - [stylelint-prettier](https://github.com/prettier/stylelint-prettier)
 
-These plugins were especially useful when Prettier was new. By running Prettier inside your linters, you didn’t have to set up any new infrastructure and you could re-use your editor integrations for the linters. But these days you can run `prettier --check .` and most editors have Prettier support.
+These plugins were especially useful when Prettier was new. By running Prettier inside your linters, you didn’t have to set up any new infrastructure and you could reuse your editor integrations for the linters. But these days you can run `prettier --check .` and most editors have Prettier support.
 
 The downsides of those plugins are:
 

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -13,7 +13,7 @@ The first requirement of Prettier is to output valid code that has the exact sam
 
 ### Strings
 
-Double or single quotes? Prettier chooses the one which results in the fewest number of escapes. `"It's gettin' better!"`, not `'It\'s gettin\' better!'`. In case of a tie or the string not containing any quotes, Prettier defaults to double quotes (but that can be changed via the [singleQuote](/docs/options#quotes) option).
+Double or single quotes? Prettier chooses the one which results in the fewest number of escapes. `"It's getting' better!"`, not `'It\'s getting\' better!'`. In case of a tie or the string not containing any quotes, Prettier defaults to double quotes (but that can be changed via the [singleQuote](/docs/options#quotes) option).
 
 JSX has its own option for quotes: [jsxSingleQuote](/docs/options#jsx-quotes).
 JSX takes its roots from HTML, where the dominant use of quotes for attributes is double quotes. Browser developer tools also follow this convention by always displaying HTML with double quotes, even if the source code uses single quotes. A separate option allows using single quotes for JS and double quotes for "HTML" (JSX).

--- a/tests/format/markdown/blockquote/notext-end.md
+++ b/tests/format/markdown/blockquote/notext-end.md
@@ -10,10 +10,10 @@
 >> `a` > `b`
 
 
-> This is a quote with an italic _across multuple lines
+> This is a quote with an italic _across multiple lines
 > which should just work_. So make sure there is no > if we set
 > proseWrap to `never`
 
-> This is a quote with a link [across multuple lines
+> This is a quote with a link [across multiple lines
 > which should just work](). So make sure there is no > if we set
 > proseWrap to `never`

--- a/tests/format/markdown/html/multiline-with-trailing-space.md
+++ b/tests/format/markdown/html/multiline-with-trailing-space.md
@@ -1,4 +1,4 @@
-1.  Some test text, the goal is to have the html table below nested within this number. When formating on save Prettier will continue to add an indent each time pushing the table further and further out of sync. 
+1.  Some test text, the goal is to have the html table below nested within this number. When formatting on save Prettier will continue to add an indent each time pushing the table further and further out of sync. 
 
     <table class="table table-striped">
     <tr>

--- a/tests/format/markdown/html/multiline.md
+++ b/tests/format/markdown/html/multiline.md
@@ -1,4 +1,4 @@
-1.  Some test text, the goal is to have the html table below nested within this number. When formating on save Prettier will continue to add an indent each time pushing the table further and further out of sync. 
+1.  Some test text, the goal is to have the html table below nested within this number. When formatting on save Prettier will continue to add an indent each time pushing the table further and further out of sync. 
 
     <table class="table table-striped">
     <tr>

--- a/tests/format/markdown/markdown/real-world-case.md
+++ b/tests/format/markdown/markdown/real-world-case.md
@@ -256,7 +256,7 @@ Note that `--write` cannot be used with `--debug-check`.
 
 If you are repeatedly formatting individual files with `prettier`, you will incur a small performance cost
 when prettier attempts to look up a [configuration file](#configuration-file). In order to skip this, you may
-ask prettier to find the config file once, and re-use it later on.
+ask prettier to find the config file once, and reuse it later on.
 
 ```bash
 prettier --find-config-path ./my/file.js

--- a/tests/format/markdown/paragraph/lorem.md
+++ b/tests/format/markdown/paragraph/lorem.md
@@ -3,7 +3,7 @@ Iusto sapiente impedit. Laudantium ut id non et aperiam ab.
  
 Sit minus architecto quas quibusdam sed ipsam aut eum.
 Dolores tempora reiciendis magni blanditiis laborum aliquid rem corporis enim. Et consectetur quo sed excepturi soluta repudiandae commodi id.
-Eum possimus optio distinctio incidunt quasi optio culpa accusamus.
+Eum possimus option distinctio incidunt quasi option culpa accusamus.
 Architecto esse ut aut autem ullam consequatur reiciendis aliquid dolorum.
  
 Et quam mollitia velit iste enim exercitationem nemo.

--- a/website/blog/2017-06-28-1.5.0.md
+++ b/website/blog/2017-06-28-1.5.0.md
@@ -85,7 +85,7 @@ I'm really excited because we only put a few days to build the initial CSS suppo
 
 #### CSS: Every selector is now printed in its own line ([#2047](https://github.com/prettier/prettier/pull/2047)) by [@yuchi](https://github.com/yuchi)
 
-The biggest unknown when printing CSS was how to deal with multiple selectors. The initial approach we took was to use the 80 columns rule where we would only split if it was bigger than that. Many people reported that they were using another strategy for this: always break after a `,`. It turns out that many popular codebases are using this approach and it feels good as you can see the structure of the selectors when layed out on-top of each others.
+The biggest unknown when printing CSS was how to deal with multiple selectors. The initial approach we took was to use the 80 columns rule where we would only split if it was bigger than that. Many people reported that they were using another strategy for this: always break after a `,`. It turns out that many popular codebases are using this approach and it feels good as you can see the structure of the selectors when laid out on-top of each others.
 
 <!-- prettier-ignore -->
 ```css

--- a/website/blog/2018-11-07-1.15.0.md
+++ b/website/blog/2018-11-07-1.15.0.md
@@ -1709,7 +1709,7 @@ This issue has been fixed in Prettier 1.15.
 {x: long}
 
 # Output (Prettier 1.14)
-SyntaxError: The "undefine...ndefined" key is too long
+SyntaxError: The "undefine...undefined" key is too long
 
 # Output (Prettier 1.15)
 {

--- a/website/blog/2022-03-16-2.6.0.md
+++ b/website/blog/2022-03-16-2.6.0.md
@@ -622,7 +622,7 @@ PostCSS values can start with digits. Prettier interprets this as a number follo
         (
             foreground-color: $custom-foreground-color,
             disabled-foreground-color: null,
-            r: null, // TODO som
+            r: null, // TODO some
         )
     );
 }

--- a/website/blog/2023-07-05-3.0.0.md
+++ b/website/blog/2023-07-05-3.0.0.md
@@ -809,7 +809,7 @@ foo(/* HTML */ `
 `);
 ```
 
-#### Fix indention of expressions in template literals ([#13621](https://github.com/prettier/prettier/pull/13621) by [@fisker](https://github.com/fisker))
+#### Fix indentation of expressions in template literals ([#13621](https://github.com/prettier/prettier/pull/13621) by [@fisker](https://github.com/fisker))
 
 <!-- prettier-ignore -->
 ```js

--- a/website/blog/2025-11-27-3.7.0.md
+++ b/website/blog/2025-11-27-3.7.0.md
@@ -439,7 +439,7 @@ require(
 );
 ```
 
-#### Remove indention in logical expression in `Boolean()` call ([#18087](https://github.com/prettier/prettier/pull/18087) by [@kovsu](https://github.com/kovsu)) {#change-18087}
+#### Remove indentation in logical expression in `Boolean()` call ([#18087](https://github.com/prettier/prettier/pull/18087) by [@kovsu](https://github.com/kovsu)) {#change-18087}
 
 Reduce diff when changing a condition to an opposite value, or change between `!!` and `Boolean()`.
 

--- a/website/versioned_docs/version-stable/cli.md
+++ b/website/versioned_docs/version-stable/cli.md
@@ -107,7 +107,7 @@ If you're worried that Prettier will change the correctness of your code, add `-
 
 ## `--find-config-path` and `--config`
 
-If you are repeatedly formatting individual files with `prettier`, you will incur a small performance cost when Prettier attempts to look up a [configuration file](configuration.md). In order to skip this, you may ask Prettier to find the config file once, and re-use it later on.
+If you are repeatedly formatting individual files with `prettier`, you will incur a small performance cost when Prettier attempts to look up a [configuration file](configuration.md). In order to skip this, you may ask Prettier to find the config file once, and reuse it later on.
 
 ```console
 $ prettier --find-config-path path/to/file.js

--- a/website/versioned_docs/version-stable/integrating-with-linters.md
+++ b/website/versioned_docs/version-stable/integrating-with-linters.md
@@ -20,7 +20,7 @@ First, we have plugins that let you run Prettier as if it was a linter rule:
 - [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier)
 - [stylelint-prettier](https://github.com/prettier/stylelint-prettier)
 
-These plugins were especially useful when Prettier was new. By running Prettier inside your linters, you didn’t have to set up any new infrastructure and you could re-use your editor integrations for the linters. But these days you can run `prettier --check .` and most editors have Prettier support.
+These plugins were especially useful when Prettier was new. By running Prettier inside your linters, you didn’t have to set up any new infrastructure and you could reuse your editor integrations for the linters. But these days you can run `prettier --check .` and most editors have Prettier support.
 
 The downsides of those plugins are:
 

--- a/website/versioned_docs/version-stable/rationale.md
+++ b/website/versioned_docs/version-stable/rationale.md
@@ -13,7 +13,7 @@ The first requirement of Prettier is to output valid code that has the exact sam
 
 ### Strings
 
-Double or single quotes? Prettier chooses the one which results in the fewest number of escapes. `"It's gettin' better!"`, not `'It\'s gettin\' better!'`. In case of a tie or the string not containing any quotes, Prettier defaults to double quotes (but that can be changed via the [singleQuote](/docs/options#quotes) option).
+Double or single quotes? Prettier chooses the one which results in the fewest number of escapes. `"It's getting' better!"`, not `'It\'s getting\' better!'`. In case of a tie or the string not containing any quotes, Prettier defaults to double quotes (but that can be changed via the [singleQuote](/docs/options#quotes) option).
 
 JSX has its own option for quotes: [jsxSingleQuote](/docs/options#jsx-quotes).
 JSX takes its roots from HTML, where the dominant use of quotes for attributes is double quotes. Browser developer tools also follow this convention by always displaying HTML with double quotes, even if the source code uses single quotes. A separate option allows using single quotes for JS and double quotes for "HTML" (JSX).


### PR DESCRIPTION
This PR fixes a few minor typographical errors in the markdown documentation (README, etc.) to improve readability. Found via codespell.