### PR TITLE
docs: fix various typos in comments and documentation

### DIFF
--- a/benchmarks/string-buffer-compress.js
+++ b/benchmarks/string-buffer-compress.js
@@ -3,10 +3,10 @@ import { runBenchmark } from "./utilities.js";
 
 for (const size of [1e1, 1e2, 1e3, 1e4, 1e5]) {
   const maxLength = 10;
-  const seperator = "|";
+  const separator = "|";
   const strings = Array.from({ length: size }, () => "_");
   const expected = {
-    length: strings.join(seperator).length,
+    length: strings.join(separator).length,
     times: Math.floor(size / maxLength) - 1,
   };
 
@@ -23,13 +23,13 @@ for (const size of [1e1, 1e2, 1e3, 1e4, 1e5]) {
         for (let index = 0; index < strings.length; index++) {
           result.push(strings[index]);
           if (result.length > maxLength) {
-            result.splice(0, Number.POSITIVE_INFINITY, result.join(seperator));
+            result.splice(0, Number.POSITIVE_INFINITY, result.join(separator));
             assert.equal(result.length, 1);
             times++;
           }
         }
 
-        return { length: result.join(seperator).length, times };
+        return { length: result.join(separator).length, times };
       },
       "let reassign"() {
         let result = [];
@@ -38,13 +38,13 @@ for (const size of [1e1, 1e2, 1e3, 1e4, 1e5]) {
         for (let index = 0; index < strings.length; index++) {
           result.push(strings[index]);
           if (result.length > maxLength) {
-            result = [result.join(seperator)];
+            result = [result.join(separator)];
             assert.equal(result.length, 1);
             times++;
           }
         }
 
-        return { length: result.join(seperator).length, times };
+        return { length: result.join(separator).length, times };
       },
     },
   );

--- a/changelog_unreleased/typescript/18827.md
+++ b/changelog_unreleased/typescript/18827.md
@@ -1,4 +1,4 @@
-#### Remove extra indention for union type in conditional type (#18827 by @fisker)
+#### Remove extra indentation for union type in conditional type (#18827 by @fisker)
 
 <!-- prettier-ignore -->
 ```tsx

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -107,7 +107,7 @@ If you're worried that Prettier will change the correctness of your code, add `-
 
 ## `--find-config-path` and `--config`
 
-If you are repeatedly formatting individual files with `prettier`, you will incur a small performance cost when Prettier attempts to look up a [configuration file](configuration.md). In order to skip this, you may ask Prettier to find the config file once, and re-use it later on.
+If you are repeatedly formatting individual files with `prettier`, you will incur a small performance cost when Prettier attempts to look up a [configuration file](configuration.md). In order to skip this, you may ask Prettier to find the config file once, and reuse it later on.
 
 ```console
 $ prettier --find-config-path path/to/file.js

--- a/docs/integrating-with-linters.md
+++ b/docs/integrating-with-linters.md
@@ -20,7 +20,7 @@ First, we have plugins that let you run Prettier as if it was a linter rule:
 - [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier)
 - [stylelint-prettier](https://github.com/prettier/stylelint-prettier)
 
-These plugins were especially useful when Prettier was new. By running Prettier inside your linters, you didn’t have to set up any new infrastructure and you could re-use your editor integrations for the linters. But these days you can run `prettier --check .` and most editors have Prettier support.
+These plugins were especially useful when Prettier was new. By running Prettier inside your linters, you didn’t have to set up any new infrastructure and you could reuse your editor integrations for the linters. But these days you can run `prettier --check .` and most editors have Prettier support.
 
 The downsides of those plugins are:
 

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -13,7 +13,7 @@ The first requirement of Prettier is to output valid code that has the exact sam
 
 ### Strings
 
-Double or single quotes? Prettier chooses the one which results in the fewest number of escapes. `"It's gettin' better!"`, not `'It\'s gettin\' better!'`. In case of a tie or the string not containing any quotes, Prettier defaults to double quotes (but that can be changed via the [singleQuote](/docs/options#quotes) option).
+Double or single quotes? Prettier chooses the one which results in the fewest number of escapes. `"It's getting' better!"`, not `'It\'s getting\' better!'`. In case of a tie or the string not containing any quotes, Prettier defaults to double quotes (but that can be changed via the [singleQuote](/docs/options#quotes) option).
 
 JSX has its own option for quotes: [jsxSingleQuote](/docs/options#jsx-quotes).
 JSX takes its roots from HTML, where the dominant use of quotes for attributes is double quotes. Browser developer tools also follow this convention by always displaying HTML with double quotes, even if the source code uses single quotes. A separate option allows using single quotes for JS and double quotes for "HTML" (JSX).

--- a/scripts/generate-flow-estree-type-definition.js
+++ b/scripts/generate-flow-estree-type-definition.js
@@ -66,7 +66,7 @@ function toDts(text) {
   text = text.replaceAll("'use strict';", "  ");
 
   // `{+foo: string}` -> `{foo: string}`
-  text = text.replaceAll(/(?<=\n)(?<indention>[ {2}]+)\+/g, "$<indention>");
+  text = text.replaceAll(/(?<=\n)(?<indentation>[ {2}]+)\+/g, "$<indentation>");
 
   // `{foo: interface {}}` -> `{foo: {}}`
   text = text.replaceAll(": interface {", ": {");
@@ -91,8 +91,8 @@ function toDts(text) {
 
   // `{[string]: T}` -> `{[key: string]: T}`
   text = text.replaceAll(
-    /(?<=\n)(?<indention>[ {2}]+)\[(?<type>string)\](?=: )/g,
-    "$<indention>[key: $<type>]",
+    /(?<=\n)(?<indentation>[ {2}]+)\[(?<type>string)\](?=: )/g,
+    "$<indentation>[key: $<type>]",
   );
 
   return text;

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -102,7 +102,7 @@ function genericPrint(path, options, print) {
       const printed = getTextValueParts(node);
 
       const suffix = printClosingTagSuffix(node, options);
-      // We cant use `fill([prefix, printed, suffix])` because it violates rule of fill: elements with odd indices must be line break
+      // We can't use `fill([prefix, printed, suffix])` because it violates rule of fill: elements with odd indices must be line break
       printed[0] = [prefix, printed[0]];
       // @ts-expect-error -- Need investigate how `replaceEndOfLine` works
       printed.push([printed.pop(), suffix]);

--- a/src/language-js/parentheses/needs-parentheses.js
+++ b/src/language-js/parentheses/needs-parentheses.js
@@ -221,7 +221,7 @@ function needsParentheses(path, options) {
         case "UpdateExpression":
           return true;
         case "UnaryExpression":
-          // `UnaryExpression` adds parentheses and indention when argument has comment
+          // `UnaryExpression` adds parentheses and indentation when argument has comment
           if (!hasComment(node)) {
             return true;
           }

--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -85,7 +85,7 @@ function printBinaryishExpression(path, options, print) {
   //   ).call()
   if (
     (key === "callee" && isCallOrNewExpression(parent)) ||
-    // `UnaryExpression` adds parentheses and indention when argument has comment
+    // `UnaryExpression` adds parentheses and indentation when argument has comment
     (parent.type === "UnaryExpression" && !hasComment(node)) ||
     (isMemberExpression(parent) && !parent.computed)
   ) {

--- a/src/language-markdown/massage-ast/index.js
+++ b/src/language-markdown/massage-ast/index.js
@@ -26,7 +26,7 @@ function massageAstNode(original, cloned, parent) {
     delete cloned.spread;
   }
 
-  // texts can be splitted or merged
+  // texts can be split or merged
   if (original.type === "text") {
     return null;
   }

--- a/src/language-markdown/print/word.js
+++ b/src/language-markdown/print/word.js
@@ -123,7 +123,7 @@ function printWordLegacy(path) {
           ? `${text1}${underscore1}`
           : `${underscore2}${text2}`
         ).replaceAll("_", String.raw`\_`),
-    ); // escape all `_` except concating with non-punctuation, e.g. `1_2_3` is not considered emphasis
+    ); // escape all `_` except concatenating with non-punctuation, e.g. `1_2_3` is not considered emphasis
 
   const isFirstSentence = (node, name, index) =>
     node.type === "sentence" && index === 0;

--- a/website/blog/2017-06-28-1.5.0.md
+++ b/website/blog/2017-06-28-1.5.0.md
@@ -85,7 +85,7 @@ I'm really excited because we only put a few days to build the initial CSS suppo
 
 #### CSS: Every selector is now printed in its own line ([#2047](https://github.com/prettier/prettier/pull/2047)) by [@yuchi](https://github.com/yuchi)
 
-The biggest unknown when printing CSS was how to deal with multiple selectors. The initial approach we took was to use the 80 columns rule where we would only split if it was bigger than that. Many people reported that they were using another strategy for this: always break after a `,`. It turns out that many popular codebases are using this approach and it feels good as you can see the structure of the selectors when layed out on-top of each others.
+The biggest unknown when printing CSS was how to deal with multiple selectors. The initial approach we took was to use the 80 columns rule where we would only split if it was bigger than that. Many people reported that they were using another strategy for this: always break after a `,`. It turns out that many popular codebases are using this approach and it feels good as you can see the structure of the selectors when laid out on-top of each others.
 
 <!-- prettier-ignore -->
 ```css

--- a/website/blog/2018-11-07-1.15.0.md
+++ b/website/blog/2018-11-07-1.15.0.md
@@ -1709,7 +1709,7 @@ This issue has been fixed in Prettier 1.15.
 {x: long}
 
 # Output (Prettier 1.14)
-SyntaxError: The "undefine...ndefined" key is too long
+SyntaxError: The "undefine...undefined" key is too long
 
 # Output (Prettier 1.15)
 {

--- a/website/blog/2022-03-16-2.6.0.md
+++ b/website/blog/2022-03-16-2.6.0.md
@@ -622,7 +622,7 @@ PostCSS values can start with digits. Prettier interprets this as a number follo
         (
             foreground-color: $custom-foreground-color,
             disabled-foreground-color: null,
-            r: null, // TODO som
+            r: null, // TODO some
         )
     );
 }

--- a/website/blog/2023-07-05-3.0.0.md
+++ b/website/blog/2023-07-05-3.0.0.md
@@ -809,7 +809,7 @@ foo(/* HTML */ `
 `);
 ```
 
-#### Fix indention of expressions in template literals ([#13621](https://github.com/prettier/prettier/pull/13621) by [@fisker](https://github.com/fisker))
+#### Fix indentation of expressions in template literals ([#13621](https://github.com/prettier/prettier/pull/13621) by [@fisker](https://github.com/fisker))
 
 <!-- prettier-ignore -->
 ```js

--- a/website/blog/2025-11-27-3.7.0.md
+++ b/website/blog/2025-11-27-3.7.0.md
@@ -439,7 +439,7 @@ require(
 );
 ```
 
-#### Remove indention in logical expression in `Boolean()` call ([#18087](https://github.com/prettier/prettier/pull/18087) by [@kovsu](https://github.com/kovsu)) {#change-18087}
+#### Remove indentation in logical expression in `Boolean()` call ([#18087](https://github.com/prettier/prettier/pull/18087) by [@kovsu](https://github.com/kovsu)) {#change-18087}
 
 Reduce diff when changing a condition to an opposite value, or change between `!!` and `Boolean()`.
 

--- a/website/versioned_docs/version-stable/cli.md
+++ b/website/versioned_docs/version-stable/cli.md
@@ -107,7 +107,7 @@ If you're worried that Prettier will change the correctness of your code, add `-
 
 ## `--find-config-path` and `--config`
 
-If you are repeatedly formatting individual files with `prettier`, you will incur a small performance cost when Prettier attempts to look up a [configuration file](configuration.md). In order to skip this, you may ask Prettier to find the config file once, and re-use it later on.
+If you are repeatedly formatting individual files with `prettier`, you will incur a small performance cost when Prettier attempts to look up a [configuration file](configuration.md). In order to skip this, you may ask Prettier to find the config file once, and reuse it later on.
 
 ```console
 $ prettier --find-config-path path/to/file.js

--- a/website/versioned_docs/version-stable/integrating-with-linters.md
+++ b/website/versioned_docs/version-stable/integrating-with-linters.md
@@ -20,7 +20,7 @@ First, we have plugins that let you run Prettier as if it was a linter rule:
 - [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier)
 - [stylelint-prettier](https://github.com/prettier/stylelint-prettier)
 
-These plugins were especially useful when Prettier was new. By running Prettier inside your linters, you didn’t have to set up any new infrastructure and you could re-use your editor integrations for the linters. But these days you can run `prettier --check .` and most editors have Prettier support.
+These plugins were especially useful when Prettier was new. By running Prettier inside your linters, you didn’t have to set up any new infrastructure and you could reuse your editor integrations for the linters. But these days you can run `prettier --check .` and most editors have Prettier support.
 
 The downsides of those plugins are:
 


### PR DESCRIPTION
Fixes a few minor typos across the codebase (e.g. 'indention' -> 'indentation', 'seperator' -> 'separator').