### PR TITLE
docs: clarify eslint-config-prettier guidance on install page

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -165,7 +165,7 @@ And being able to run Prettier from the command line is still a good fallback, a
 
 ## ESLint (and other linters)
 
-If you use ESLint, install [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier#installation) to make ESLint and Prettier play nice with each other. It turns off all ESLint rules that are unnecessary or might conflict with Prettier. There’s a similar config for Stylelint: [stylelint-config-prettier](https://github.com/prettier/stylelint-config-prettier)
+If you use ESLint, recent versions of ESLint and popular plugins typically don't conflict with Prettier anymore. However, if your config enables formatting rules, install [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier#installation) to turn off all ESLint rules that are unnecessary or might conflict with Prettier. There’s a similar config for Stylelint: [stylelint-config-prettier](https://github.com/prettier/stylelint-config-prettier)
 
 (See [Prettier vs. Linters](comparison.md) to learn more about formatting vs linting, [Integrating with Linters](integrating-with-linters.md) for more in-depth information on configuring your linters, and [Related projects](related-projects.md) for even more integration possibilities, if needed.)
 

--- a/website/versioned_docs/version-stable/install.md
+++ b/website/versioned_docs/version-stable/install.md
@@ -165,7 +165,7 @@ And being able to run Prettier from the command line is still a good fallback, a
 
 ## ESLint (and other linters)
 
-If you use ESLint, install [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier#installation) to make ESLint and Prettier play nice with each other. It turns off all ESLint rules that are unnecessary or might conflict with Prettier. There’s a similar config for Stylelint: [stylelint-config-prettier](https://github.com/prettier/stylelint-config-prettier)
+If you use ESLint, recent versions of ESLint and popular plugins typically don't conflict with Prettier anymore. However, if your config enables formatting rules, install [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier#installation) to turn off all ESLint rules that are unnecessary or might conflict with Prettier. There’s a similar config for Stylelint: [stylelint-config-prettier](https://github.com/prettier/stylelint-config-prettier)
 
 (See [Prettier vs. Linters](comparison.md) to learn more about formatting vs linting, [Integrating with Linters](integrating-with-linters.md) for more in-depth information on configuring your linters, and [Related projects](related-projects.md) for even more integration possibilities, if needed.)
 


### PR DESCRIPTION
## Description

- update the install docs so they do not recommend `eslint-config-prettier` to every ESLint user
- keep the recommendation for setups that still enable formatting rules
- mirror the same wording in the stable versioned install page

Fixes #18859.

## Checklist

- [ ] I've added tests to confirm my change works.
- [x] (If changing the API or CLI) I've documented the changes I've made (in the `docs/` directory).
- [ ] (If the change is user-facing) I've added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I've read the contributing guidelines.

## Validation

- Tests were not run because this is a docs wording change only.
- A changelog entry was not added because this PR only clarifies existing documentation guidance.
