### PR TITLE
docs: mention Markdown code block formatting on landing page

### DIFF
--- a/website/data/languages.yml
+++ b/website/data/languages.yml
@@ -29,6 +29,7 @@
   variants:
     - "[CommonMark](https://commonmark.org/)"
     - "[GitHub-Flavored Markdown](https://github.github.com/gfm/)"
+    - "[Embedded code blocks](/docs/options#embedded-language-formatting) in supported languages"
     - "[MDX v1](https://mdxjs.com/)"
 - name: GraphQL
   nameLink: https://graphql.org


### PR DESCRIPTION
## Description

- mention on the landing page that Prettier formats fenced code blocks in Markdown when they use a supported language
- keep the existing CommonMark, GFM, and MDX references in the Markdown card
- align the copy with the behavior discussed in #4768

Fixes #4768.

## Checklist

- [ ] I've added tests to confirm my change works.
- [ ] (If changing the API or CLI) I've documented the changes I've made (in the `docs/` directory).
- [ ] (If the change is user-facing) I've added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I've read the contributing guidelines.

## Validation

- Tests were not run because this is a website wording change only.
- A changelog entry was not added because this PR only clarifies existing documentation on the landing page.
