### PR TITLE
Add `proseWrap` examples to options guide

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -430,9 +430,39 @@ By default, Prettier will not change wrapping in markdown text since some servic
 
 Valid options:
 
-- `"always"` - Wrap prose if it exceeds the print width.
-- `"never"` - Un-wrap each block of prose into one line.
-- `"preserve"` - Do nothing, leave prose as-is. _First available in v1.9.0_
+- `"always"` - Wrap prose to the `printWidth`.
+- `"never"` - Put each prose block on a single line.
+- `"preserve"` - Keep the existing wrapping as-is. _First available in v1.9.0_
+
+For example, given this Markdown paragraph:
+
+```md
+The quick brown
+fox jumps over the lazy dog.
+```
+
+With `printWidth: 20`, Prettier formats it as:
+
+- `"always"`
+
+  ```md
+  The quick brown fox
+  jumps over the lazy
+  dog.
+  ```
+
+- `"never"`
+
+  ```md
+  The quick brown fox jumps over the lazy dog.
+  ```
+
+- `"preserve"`
+
+  ```md
+  The quick brown
+  fox jumps over the lazy dog.
+  ```
 
 | Default      | CLI Override                                                 | API Override                                                 |
 | ------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |

--- a/website/versioned_docs/version-stable/options.md
+++ b/website/versioned_docs/version-stable/options.md
@@ -430,9 +430,39 @@ By default, Prettier will not change wrapping in markdown text since some servic
 
 Valid options:
 
-- `"always"` - Wrap prose if it exceeds the print width.
-- `"never"` - Un-wrap each block of prose into one line.
-- `"preserve"` - Do nothing, leave prose as-is. _First available in v1.9.0_
+- `"always"` - Wrap prose to the `printWidth`.
+- `"never"` - Put each prose block on a single line.
+- `"preserve"` - Keep the existing wrapping as-is. _First available in v1.9.0_
+
+For example, given this Markdown paragraph:
+
+```md
+The quick brown
+fox jumps over the lazy dog.
+```
+
+With `printWidth: 20`, Prettier formats it as:
+
+- `"always"`
+
+  ```md
+  The quick brown fox
+  jumps over the lazy
+  dog.
+  ```
+
+- `"never"`
+
+  ```md
+  The quick brown fox jumps over the lazy dog.
+  ```
+
+- `"preserve"`
+
+  ```md
+  The quick brown
+  fox jumps over the lazy dog.
+  ```
 
 | Default      | CLI Override                                                 | API Override                                                 |
 | ------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |


### PR DESCRIPTION
## Description

- add a concrete `proseWrap` example to show how `always`, `never`, and `preserve` differ in practice
- clarify the option descriptions so `never` and `preserve` are easier to distinguish
- update both the current docs and the stable versioned docs

Fixes #11599.

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [ ] I’ve added or updated the release notes if my change affects user-visible behavior.
- [x] I’ve read the contributing guidelines.

## Validation

- Tests were not run because this is a documentation-only change.
