### PR TITLE
docs: clarify proseWrap scope for YAML

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -426,6 +426,8 @@ or
 
 _First available in v1.8.2_
 
+This option applies to prose in Markdown, MDX, and YAML files.
+
 By default, Prettier will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket. To have Prettier wrap prose to the print width, change this option to "always". If you want Prettier to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use `"never"`.
 
 Valid options:

--- a/website/versioned_docs/version-stable/options.md
+++ b/website/versioned_docs/version-stable/options.md
@@ -426,6 +426,8 @@ or
 
 _First available in v1.8.2_
 
+This option applies to prose in Markdown, MDX, and YAML files.
+
 By default, Prettier will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket. To have Prettier wrap prose to the print width, change this option to "always". If you want Prettier to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use `"never"`.
 
 Valid options:


### PR DESCRIPTION
## Description

- clarify that `proseWrap` applies to YAML as well as Markdown-based formats
- keep the existing explanation about Markdown line wrapping behavior
- update both the current docs and the stable versioned docs

Fixes #16127.

## Checklist

- [ ] I've added tests to confirm my change works.
- [ ] (If changing the API or CLI) I've documented the changes I've made (in the `docs/` directory).
- [ ] (If the change is user-facing) I've added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I've read the contributing guidelines.

## Validation

- Tests were not run because this is a documentation wording change only.
- A changelog entry was not added because this PR only updates documentation.
