### PR TITLE
Add PrettierX64 to Visual Studio extensions list

### DIFF
--- a/website/data/editors.yml
+++ b/website/data/editors.yml
@@ -28,6 +28,7 @@
   name: Visual Studio
   content: |
     [`JavaScriptPrettier`](https://github.com/madskristensen/JavaScriptPrettier)
+    [`PrettierX64`](https://github.com/KennethScott/PrettierX64)
 - image: /images/editors/editor_vscode.svg
   name: VS Code
   content: |


### PR DESCRIPTION
## Description

Added PrettierX64 to the list of Visual Studio extensions.  PrettierX64 is a forked and updated VS2022/VS2026 x64-compatible version of Mads Kristensen's original JavascriptPrettier (already on the list).
