### PR TITLE
Adding `undefined` and `null` as possible values for `path.node`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -489,7 +489,11 @@ export interface Printer<T = any> {
     path: AstPath<T>,
     options: ParserOptions<T>,
     print: (
-      selector?: string | number | Array<string | number> | AstPath<T>,
+      selector?:
+        | string
+        | number
+        | Array<string | number>
+        | AstPath<T | undefined | null>,
       args?: unknown,
     ) => Doc,
     args?: unknown,
@@ -498,7 +502,11 @@ export interface Printer<T = any> {
     path: AstPath<T>,
     options: ParserOptions<T>,
     print: (
-      selector?: string | number | Array<string | number> | AstPath<T>,
+      selector?:
+        | string
+        | number
+        | Array<string | number>
+        | AstPath<T | undefined | null>,
       args?: unknown,
     ) => Doc,
     args?: unknown,


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->
After being more familiar with the print function, I noticed that it takes care of possible `undefined` or `null` values automatically, so I figured it should not be a responsibility for the generic value `T` in `Printer<T>`.
This way developers can focus on describing just the actual values instead of edge cases. Unless you want them to be very aware of these instances.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
