### PR TITLE
fix(typescript): don't add semicolon before non-generic call signature in --no-semi mode

### DIFF
--- a/changelog_unreleased/typescript/18858.md
+++ b/changelog_unreleased/typescript/18858.md
@@ -1,0 +1,25 @@
+#### Fix spurious semicolon before non-generic call signature in `--no-semi` mode (#18858 by @DORI2001)
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+export interface MyInterface {
+  someMethod: (a: number) => Promise<number>
+  anotherMethod: (a: string) => Promise<string>
+  (a: string): Promise<string>
+}
+
+// Prettier stable
+export interface MyInterface {
+  someMethod: (a: number) => Promise<number>
+  anotherMethod: (a: string) => Promise<string>;
+  (a: string): Promise<string>
+}
+
+// Prettier main
+export interface MyInterface {
+  someMethod: (a: number) => Promise<number>
+  anotherMethod: (a: string) => Promise<string>
+  (a: string): Promise<string>
+}
+```

--- a/src/language-js/print/class-body.js
+++ b/src/language-js/print/class-body.js
@@ -323,7 +323,11 @@ function shouldPrintSemicolonAfterInterfaceProperty(
 
   switch (nextNode.type) {
     case "TSCallSignatureDeclaration":
-      return true;
+      // A semicolon is only needed when the call signature has type parameters
+      // (e.g. `<T>(): T`), to prevent the previous line's ending from being
+      // ambiguously parsed as a comparison operator (e.g. `X<T>`).
+      // Non-generic call signatures (e.g. `(): T`) do not create ambiguity.
+      return nextNode.typeParameters != null;
   }
 
   return false;

--- a/tests/format/typescript/interface/no-semi/18858.ts
+++ b/tests/format/typescript/interface/no-semi/18858.ts
@@ -1,0 +1,21 @@
+// https://github.com/prettier/prettier/issues/18858
+// Arrow function property followed by call signature should not get spurious semicolon
+
+export interface MyInterface {
+  someMethod: (a: number) => Promise<number>
+  anotherMethod: (a: string) => Promise<string>
+  (a: string): Promise<string>
+}
+
+// Generic call signature still needs semicolon before it
+interface WithGenericCallSig {
+  foo: string
+  <T>(a: T): T
+}
+
+// Multiple arrow function properties, last followed by call signature
+interface MultipleProps {
+  method1: (a: string) => void
+  method2: (b: number) => boolean
+  (): string
+}

--- a/tests/format/typescript/interface/no-semi/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/interface/no-semi/__snapshots__/format.test.js.snap
@@ -114,11 +114,11 @@ type A2 = {
 type A3 = { foo; <T>(): T }
 
 interface B1 {
-  foo;
+  foo
   (): X
 }
 type B2 = {
-  foo;
+  foo
   (): X
 }
 type B3 = { foo; (): X }
@@ -182,6 +182,60 @@ type H2 = {
   <T>(): T
 }
 type H3 = { foo: X; <T>(): T }
+
+================================================================================
+`;
+
+exports[`18858.ts - {"semi":false} format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// https://github.com/prettier/prettier/issues/18858
+// Arrow function property followed by call signature should not get spurious semicolon
+
+export interface MyInterface {
+  someMethod: (a: number) => Promise<number>
+  anotherMethod: (a: string) => Promise<string>
+  (a: string): Promise<string>
+}
+
+// Generic call signature still needs semicolon before it
+interface WithGenericCallSig {
+  foo: string
+  <T>(a: T): T
+}
+
+// Multiple arrow function properties, last followed by call signature
+interface MultipleProps {
+  method1: (a: string) => void
+  method2: (b: number) => boolean
+  (): string
+}
+
+=====================================output=====================================
+// https://github.com/prettier/prettier/issues/18858
+// Arrow function property followed by call signature should not get spurious semicolon
+
+export interface MyInterface {
+  someMethod: (a: number) => Promise<number>
+  anotherMethod: (a: string) => Promise<string>
+  (a: string): Promise<string>
+}
+
+// Generic call signature still needs semicolon before it
+interface WithGenericCallSig {
+  foo: string;
+  <T>(a: T): T
+}
+
+// Multiple arrow function properties, last followed by call signature
+interface MultipleProps {
+  method1: (a: string) => void
+  method2: (b: number) => boolean
+  (): string
+}
 
 ================================================================================
 `;


### PR DESCRIPTION
Fixes #18858

## Root cause

PR #18118 added a rule to `shouldPrintSemicolonAfterInterfaceProperty` that prints a semicolon after a `TSPropertySignature` whenever the **next** node is a `TSCallSignatureDeclaration`. This was intended to prevent ambiguity when a generic call signature (`<T>(): T`) follows a property, because without a semicolon `X<T>` could be misread as a comparison.

However, the rule was applied too broadly — it also fires for **non-generic** call signatures (`(): T`, `(a: string): T`), where no such ambiguity exists.

## Fix

Only return `true` (add semicolon) when the call signature has type parameters (`nextNode.typeParameters != null`).

## Before / After

```typescript
// --no-semi
export interface MyInterface {
  someMethod: (a: number) => Promise<number>
  anotherMethod: (a: string) => Promise<string>;  // ← spurious ; (before)
  (a: string): Promise<string>
}

// After fix — no spurious semicolon:
export interface MyInterface {
  someMethod: (a: number) => Promise<number>
  anotherMethod: (a: string) => Promise<string>
  (a: string): Promise<string>
}
```

Generic call signatures still correctly get a preceding semicolon:

```typescript
interface WithGenericCallSig {
  foo: string;   // ← kept, needed to prevent `string<T>` ambiguity
  <T>(a: T): T
}
```

## Tests

- Added `tests/format/typescript/interface/no-semi/18858.ts` with the reproduction case from the issue
- Updated snapshot for `14040.ts` — `foo` before non-generic `(): X` no longer gets an unnecessary semicolon
- All existing tests pass