### PR TITLE
docs: clarify that editorconfig is an API-only option

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -215,6 +215,17 @@ If a [`.editorconfig` file](https://editorconfig.org/) is in your project, Prett
 
 :::note
 
+The `editorconfig` option is not a Prettier configuration file option.
+Adding `editorconfig: true` to `.prettierrc` will produce an "unknown
+option" warning. The CLI reads `.editorconfig` by default (disable with
+`--no-editorconfig`). In the [Node.js API](api.md), pass
+`{ editorconfig: true }` to `prettier.resolveConfig()` to enable
+`.editorconfig` support.
+
+:::
+
+:::note
+
 Unlike the EditorConfig spec, the search for `.editorconfig` file will stop on the project root and won't proceed further.
 
 :::


### PR DESCRIPTION
### Summary

Clarify in the EditorConfig section of `configuration.md` that the CLI always reads `.editorconfig` files automatically, and that the `editorconfig` option only exists in the Node.js API.

### Problem

Users frequently try to add `editorconfig: true` to their `.prettierrc` file and get an "unknown option" warning. The current documentation doesn't explicitly state that:

1. The CLI and editor integrations **always** read `.editorconfig` — there's no opt-in
2. The `editorconfig` option only exists as a parameter to `prettier.resolveConfig()` in the Node.js API
3. It is **not** a configuration file option

This confusion is well-documented in #15255 (24 👍).

### Changes

Add a note block before the existing EditorConfig note that explicitly states:
- CLI/editors always read `.editorconfig`
- The option is API-only (`resolveConfig`)
- Adding it to config files produces a warning

Fixes: https://github.com/prettier/prettier/issues/15255