### PR TITLE
Print `async` keyword for component declarations

### DIFF
--- a/changelog_unreleased/flow/19053.md
+++ b/changelog_unreleased/flow/19053.md
@@ -1,0 +1,13 @@
+#### Print `async` keyword for component declarations (#19053 by @mvitousek)
+
+<!-- prettier-ignore -->
+```flow
+// Input
+async component MyAsyncComponent() {}
+
+// Prettier stable
+component MyAsyncComponent() {}
+
+// Prettier main
+async component MyAsyncComponent() {}
+```

--- a/src/language-js/print/component.js
+++ b/src/language-js/print/component.js
@@ -15,7 +15,11 @@ import { printDeclareToken, printSemicolon } from "./miscellaneous.js";
 function printComponent(path, options, print) {
   const { node } = path;
 
-  const parts = [printDeclareToken(path), node.async ? "async " : "", "component"];
+  const parts = [
+    printDeclareToken(path),
+    node.async ? "async " : "",
+    "component",
+  ];
   if (node.id) {
     parts.push(" ", print("id"));
   }

--- a/src/language-js/print/component.js
+++ b/src/language-js/print/component.js
@@ -15,7 +15,7 @@ import { printDeclareToken, printSemicolon } from "./miscellaneous.js";
 function printComponent(path, options, print) {
   const { node } = path;
 
-  const parts = [printDeclareToken(path), "component"];
+  const parts = [printDeclareToken(path), node.async ? "async " : "", "component"];
   if (node.id) {
     parts.push(" ", print("id"));
   }

--- a/src/language-js/types/flow-estree.d.ts
+++ b/src/language-js/types/flow-estree.d.ts
@@ -431,6 +431,7 @@ export interface ComponentParameter extends BaseNode {
 
 export interface ComponentDeclaration extends BaseNode {
   type: "ComponentDeclaration";
+  async: boolean;
   body: BlockStatement;
   id: Identifier;
   params: ReadonlyArray<ComponentParameterAndRestElement>;
@@ -440,6 +441,7 @@ export interface ComponentDeclaration extends BaseNode {
 
 export interface HookDeclaration extends BaseNode {
   type: "HookDeclaration";
+  async: boolean;
   id: Identifier;
   body: BlockStatement;
   params: ReadonlyArray<FunctionParameter>;

--- a/tests/format/flow/component/__snapshots__/format.test.js.snap
+++ b/tests/format/flow/component/__snapshots__/format.test.js.snap
@@ -72,6 +72,16 @@ component MyComponent(
 
 component MyComponent() /* Trailing comment */ {}
 
+async component MyAsyncComponent() {}
+
+async component MyAsyncComponent() renders SomeComponent {}
+
+async component MyAsyncComponent(bar: string, baz: number) {
+  return <OtherComponent />;
+}
+
+export async component MyExportedAsyncComponent() {}
+
 =====================================output=====================================
 component MyComponent() {}
 
@@ -173,6 +183,16 @@ component MyComponent(
 ) {}
 
 component MyComponent() /* Trailing comment */ {}
+
+async component MyAsyncComponent() {}
+
+async component MyAsyncComponent() renders SomeComponent {}
+
+async component MyAsyncComponent(bar: string, baz: number) {
+  return <OtherComponent />;
+}
+
+export async component MyExportedAsyncComponent() {}
 
 ================================================================================
 `;

--- a/tests/format/flow/component/component-declaration.js
+++ b/tests/format/flow/component/component-declaration.js
@@ -64,3 +64,13 @@ component MyComponent(
 ) {}
 
 component MyComponent() /* Trailing comment */ {}
+
+async component MyAsyncComponent() {}
+
+async component MyAsyncComponent() renders SomeComponent {}
+
+async component MyAsyncComponent(bar: string, baz: number) {
+  return <OtherComponent />;
+}
+
+export async component MyExportedAsyncComponent() {}

--- a/tests/format/flow/hook/__snapshots__/format.test.js.snap
+++ b/tests/format/flow/hook/__snapshots__/format.test.js.snap
@@ -297,6 +297,14 @@ hook useFoo14<
   T: Fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo,
 >(): any {};
 
+async hook useAsyncFoo1() {}
+
+export async hook useAsyncFoo2() {}
+
+async hook useAsyncFoo3(): string {}
+
+async hook useAsyncFoo4(foo: Foo, ...bar: Bar) {}
+
 =====================================output=====================================
 hook useFoo1() {}
 
@@ -336,6 +344,14 @@ hook useFoo13(
 hook useFoo14<
   T: Fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo,
 >(): any {}
+
+async hook useAsyncFoo1() {}
+
+export async hook useAsyncFoo2() {}
+
+async hook useAsyncFoo3(): string {}
+
+async hook useAsyncFoo4(foo: Foo, ...bar: Bar) {}
 
 ================================================================================
 `;

--- a/tests/format/flow/hook/hook-declaration.js
+++ b/tests/format/flow/hook/hook-declaration.js
@@ -28,3 +28,11 @@ hook useFoo13(foo: Array<Foooooooooooooooooooooooooooooooooooooooooooooooooooooo
 hook useFoo14<
   T: Fooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo,
 >(): any {};
+
+async hook useAsyncFoo1() {}
+
+export async hook useAsyncFoo2() {}
+
+async hook useAsyncFoo3(): string {}
+
+async hook useAsyncFoo4(foo: Foo, ...bar: Bar) {}


### PR DESCRIPTION
## Description

Support the `async` keyword on Flow's `ComponentDeclaration`:
- `async component Foo() { ... }`

`HookDeclaration` already works via the function printer which checks `node.async`. This change adds the same support to `printComponent` for `ComponentDeclaration`, and adds `async` to both type definitions along with test coverage.

## Related

- Follows the pattern of #18801 (keyof support)

## Checklist

- [x] Added tests
- [x] Added changelog entry
- [x] Read the [Contributing Guide](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md)