### PR TITLE
Fix YAML quote preference for mixed quote scalars

### DIFF
--- a/src/language-yaml/printer-yaml.js
+++ b/src/language-yaml/printer-yaml.js
@@ -10,6 +10,11 @@ import {
   lineSuffix,
   replaceEndOfLine,
 } from "../document/index.js";
+import {
+  DOUBLE_QUOTE,
+  getPreferredQuote,
+  SINGLE_QUOTE,
+} from "../utilities/get-preferred-quote.js";
 import isPreviousLineEmpty from "../utilities/is-previous-line-empty.js";
 import UnexpectedNodeError from "../utilities/unexpected-node-error.js";
 import embed from "./embed.js";
@@ -256,9 +261,6 @@ function printNode(path, options, print) {
       );
     case "quoteDouble":
     case "quoteSingle": {
-      const singleQuote = "'";
-      const doubleQuote = '"';
-
       const raw = options.originalText.slice(
         node.position.start.offset + 1,
         node.position.end.offset - 1,
@@ -271,7 +273,7 @@ function printNode(path, options, print) {
         // only quoteDouble can use escape chars
         // and quoteSingle do not need to escape backslashes
         const originalQuote =
-          node.type === "quoteDouble" ? doubleQuote : singleQuote;
+          node.type === "quoteDouble" ? DOUBLE_QUOTE : SINGLE_QUOTE;
         return [
           originalQuote,
           printFlowScalarContent(node.type, raw, options),
@@ -279,40 +281,31 @@ function printNode(path, options, print) {
         ];
       }
 
-      if (raw.includes(doubleQuote)) {
-        return [
-          singleQuote,
-          printFlowScalarContent(
-            node.type,
-            node.type === "quoteDouble"
-              ? raw
-                  // double quote needs to be escaped by backslash in quoteDouble
-                  .replaceAll(String.raw`\"`, doubleQuote)
-                  .replaceAll("'", singleQuote.repeat(2))
-              : raw,
-            options,
-          ),
-          singleQuote,
-        ];
-      }
+      const quote = getPreferredQuote(node.value, options.singleQuote);
+      const content =
+        quote === SINGLE_QUOTE
+          ? node.type === "quoteDouble"
+            ? raw
+                // double quote needs to be escaped by backslash in quoteDouble
+                .replaceAll(String.raw`\"`, DOUBLE_QUOTE)
+                .replaceAll(SINGLE_QUOTE, SINGLE_QUOTE.repeat(2))
+            : raw
+          : node.type === "quoteSingle"
+            ? // single quote needs to be escaped by 2 single quotes in quoteSingle
+              raw
+                .replaceAll(SINGLE_QUOTE.repeat(2), SINGLE_QUOTE)
+                .replaceAll(DOUBLE_QUOTE, String.raw`\"`)
+            : raw;
 
-      if (raw.includes(singleQuote)) {
-        return [
-          doubleQuote,
-          printFlowScalarContent(
-            node.type,
-            node.type === "quoteSingle"
-              ? // single quote needs to be escaped by 2 single quotes in quoteSingle
-                raw.replaceAll("''", singleQuote)
-              : raw,
-            options,
-          ),
-          doubleQuote,
-        ];
-      }
-
-      const quote = options.singleQuote ? singleQuote : doubleQuote;
-      return [quote, printFlowScalarContent(node.type, raw, options), quote];
+      return [
+        quote,
+        printFlowScalarContent(
+          quote === SINGLE_QUOTE ? "quoteSingle" : "quoteDouble",
+          content,
+          options,
+        ),
+        quote,
+      ];
     }
     case "blockFolded":
     case "blockLiteral":

--- a/tests/format/yaml/quote/__snapshots__/format.test.js.snap
+++ b/tests/format/yaml/quote/__snapshots__/format.test.js.snap
@@ -348,6 +348,8 @@ proseWrap: "always"
 - '\\n123'
 - "\\n123"
 - "'a\\"b"
+- "'foo' 'bar' 'baz' \\"qux\\""
+- "curl POST 'https://example.com' -H 'Foo: Bar' --data-raw '[\\"baz\\"]'"
 
 =====================================output=====================================
 - "123"
@@ -358,7 +360,9 @@ proseWrap: "always"
 - '""'
 - '\\n123'
 - "\\n123"
-- '''a"b'
+- "'a\\"b"
+- "'foo' 'bar' 'baz' \\"qux\\""
+- "curl POST 'https://example.com' -H 'Foo: Bar' --data-raw '[\\"baz\\"]'"
 
 ================================================================================
 `;
@@ -378,6 +382,8 @@ proseWrap: "never"
 - '\\n123'
 - "\\n123"
 - "'a\\"b"
+- "'foo' 'bar' 'baz' \\"qux\\""
+- "curl POST 'https://example.com' -H 'Foo: Bar' --data-raw '[\\"baz\\"]'"
 
 =====================================output=====================================
 - "123"
@@ -388,7 +394,9 @@ proseWrap: "never"
 - '""'
 - '\\n123'
 - "\\n123"
-- '''a"b'
+- "'a\\"b"
+- "'foo' 'bar' 'baz' \\"qux\\""
+- "curl POST 'https://example.com' -H 'Foo: Bar' --data-raw '[\\"baz\\"]'"
 
 ================================================================================
 `;
@@ -408,6 +416,8 @@ singleQuote: true
 - '\\n123'
 - "\\n123"
 - "'a\\"b"
+- "'foo' 'bar' 'baz' \\"qux\\""
+- "curl POST 'https://example.com' -H 'Foo: Bar' --data-raw '[\\"baz\\"]'"
 
 =====================================output=====================================
 - '123'
@@ -419,6 +429,8 @@ singleQuote: true
 - '\\n123'
 - "\\n123"
 - '''a"b'
+- "'foo' 'bar' 'baz' \\"qux\\""
+- "curl POST 'https://example.com' -H 'Foo: Bar' --data-raw '[\\"baz\\"]'"
 
 ================================================================================
 `;
@@ -437,6 +449,8 @@ parsers: ["yaml"]
 - '\\n123'
 - "\\n123"
 - "'a\\"b"
+- "'foo' 'bar' 'baz' \\"qux\\""
+- "curl POST 'https://example.com' -H 'Foo: Bar' --data-raw '[\\"baz\\"]'"
 
 =====================================output=====================================
 - "123"
@@ -447,7 +461,9 @@ parsers: ["yaml"]
 - '""'
 - '\\n123'
 - "\\n123"
-- '''a"b'
+- "'a\\"b"
+- "'foo' 'bar' 'baz' \\"qux\\""
+- "curl POST 'https://example.com' -H 'Foo: Bar' --data-raw '[\\"baz\\"]'"
 
 ================================================================================
 `;

--- a/tests/format/yaml/quote/quote.yml
+++ b/tests/format/yaml/quote/quote.yml
@@ -7,3 +7,5 @@
 - '\n123'
 - "\n123"
 - "'a\"b"
+- "'foo' 'bar' 'baz' \"qux\""
+- "curl POST 'https://example.com' -H 'Foo: Bar' --data-raw '[\"baz\"]'"


### PR DESCRIPTION
## Summary
- use the shared quote-preference helper when choosing YAML flow scalar quotes
- preserve the existing backslash-sensitive guardrails while avoiding unnecessary quote flipping
- add regression coverage for mixed-quote scalars and update the YAML quote snapshots

## Root cause
The YAML printer picked the enclosing quote from the raw source with a hardcoded preference that forced single-quoted output whenever the scalar content contained double quotes. For scalars that contain both quote types, that ignored escape cost and made `singleQuote` behave inconsistently.

## Impact
Mixed-quote YAML scalars now choose the outer quote that needs fewer escapes, while still preserving the existing raw/backslash handling for YAML quoted scalars.

## Reproduction of the bug that was fixed

https://prettier.io/playground/#N4Igxg9gdgLgprEAuEBtAOlABFg5AMwglwBpMd0QAjAQwCdKzsty9LCJKXr6vLaAXpVKthHXHlp0JuQbkajm8kBz48GIboK65cARwCuAD10jmYojKlWaAiegchDRh5QXmlYA3QA2WAAoA8gDKACrcABYwMAAOAM5IAPSJcEY0ALYxPnAAdJDpXAC0ABLcAGJESFgAQryahYUAJjQwNIV0NADu3Ki6crgAusJMFODefkFheFGxCcmpGVm5+RIleBUQVbXSWA3Nre1deBiO2o4DykwDICQgEDEwAJbQccig9HQQnf70CK8oNB8nRoAE9XrcqB0wABrOAwYIZOAAGUeUDgyHwgLicFuECoACs4GAYAB1DoxZAgGJ0ODYugAN3REKhsPhMRoYFRAHNkDA6AYcSBselHrz+YLUjE4HRHukEK0fIEpR0YBA6P4IHFHk9oJSEI0biBJdLZfLAaFpVB6I9aRisYKtVAudkAIoGCDwO0+bG3fFxIzBbmu92epCY72CwweuD+T7xSk0OKFNFwRqpw18miPHzcgDCEHS6RoCZ8PkNjudcAAgtEZVQDPB-NKUWivT6QFF0j4SRFtbT2WA4ME-trHvTtSDKWA4uCQPSBQBJKBp2DBMAyh5V5fBGAg7JtwXUzVwMk0Ckoam06WMw36wL4FvolA+fCG1F0mCxmhcosH27sug6UpEEMjLf8ZVgElHkaGAImQAAOAAGW4aUMR4aS-H9izDe1blaKgoJguCkAAJluAxsVCGgqH+cN2zgdIqFTNNGiRGgnQMb84AqOgi2ibkEwbCAQAAXxEoA

parser: `YAML`

**Input:**

```yaml
[
  'foo',
  "bar",
  
  '"foo" "bar" "baz"',
  "'foo' 'bar' 'baz'",
  
  '"foo" "bar" "baz" ''qux''',
  "'foo' 'bar' 'baz' \"qux\"",
  
  'curl POST "https://example.com" -H "Foo: Bar" --data-raw "[''baz'']"',
  "curl POST 'https://example.com' -H 'Foo: Bar' --data-raw '[\"baz\"]'",
]
```

**Actual output with `--single-quote: false`:** 

```yaml
[
  "foo",
  "bar",

  '"foo" "bar" "baz"',
  "'foo' 'bar' 'baz'",

  '"foo" "bar" "baz" ''qux''',
  '''foo'' ''bar'' ''baz'' "qux"',

  'curl POST "https://example.com" -H "Foo: Bar" --data-raw "[''baz'']"',
  'curl POST ''https://example.com'' -H ''Foo: Bar'' --data-raw ''["baz"]''',
]
```

**Expected output with `--single-quote: false`:**

```yaml
[
  'foo',
  'bar',

  '"foo" "bar" "baz"',
  "'foo' 'bar' 'baz'",

  '"foo" "bar" "baz" ''qux''',
  "'foo' 'bar' 'baz' \"qux\"",

  'curl POST "https://example.com" -H "Foo: Bar" --data-raw "[''baz'']"',
  "curl POST 'https://example.com' -H 'Foo: Bar' --data-raw '[\"baz\"]'",
]
```

**Actual output with `--single-quote: true`:** 

```yaml
[
  'foo',
  'bar',

  '"foo" "bar" "baz"',
  "'foo' 'bar' 'baz'",

  '"foo" "bar" "baz" ''qux''',
  '''foo'' ''bar'' ''baz'' "qux"',

  'curl POST "https://example.com" -H "Foo: Bar" --data-raw "[''baz'']"',
  'curl POST ''https://example.com'' -H ''Foo: Bar'' --data-raw ''["baz"]''',
]
```

**Expected output with `--single-quote: true`:**

```yaml
[
  'foo',
  'bar',

  '"foo" "bar" "baz"',
  "'foo' 'bar' 'baz'",

  '"foo" "bar" "baz" ''qux''',
  "'foo' 'bar' 'baz' \"qux\"",

  'curl POST "https://example.com" -H "Foo: Bar" --data-raw "[''baz'']"',
  "curl POST 'https://example.com' -H 'Foo: Bar' --data-raw '[\"baz\"]'",
]
```

## ***LLM usage disclosure***

_This fix and the PR were prepared by LLM (Codex, local work on a cloned repo)._