### PR TITLE
feat: add configuration support with defineConfig and related files

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
       "require": "./src/index.cjs",
       "default": "./src/index.js"
     },
+    "./config": {
+      "types": "./src/config.d.ts",
+      "import": "./src/config.js",
+      "require": "./src/config.cjs"
+    },
     "./standalone": "./src/standalone.js",
     "./plugins/*": "./src/plugins/*.js",
     "./*": "./*"

--- a/src/config.cjs
+++ b/src/config.cjs
@@ -1,0 +1,5 @@
+"use strict";
+
+const prettierConfig = require("../src/config.js");
+
+module.exports = prettierConfig;

--- a/src/config.d.ts
+++ b/src/config.d.ts
@@ -1,0 +1,3 @@
+import type { Config } from "./index.js";
+
+export function defineConfig(options: Config): Config;

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,3 @@
+export function defineConfig(options) {
+  return options;
+}

--- a/tests/integration/__tests__/config-resolution.js
+++ b/tests/integration/__tests__/config-resolution.js
@@ -477,3 +477,14 @@ test("'config' option should accept `URL` and `string`", async () => {
     ).resolves.toStrictEqual({ tabWidth: 7 });
   }
 });
+
+test(".js config file with defineConfig from prettier/config", async () => {
+  const file = new URL(
+    "../cli/config/define-config/prettier.config.js",
+    import.meta.url,
+  );
+  await expect(prettier.resolveConfig(file)).resolves.toMatchObject({
+    trailingComma: "all",
+    singleQuote: true,
+  });
+});

--- a/tests/integration/cli/config/define-config/file.js
+++ b/tests/integration/cli/config/define-config/file.js
@@ -1,0 +1,1 @@
+const foo = 'bar';

--- a/tests/integration/cli/config/define-config/jsfmt.spec.js
+++ b/tests/integration/cli/config/define-config/jsfmt.spec.js
@@ -1,0 +1,1 @@
+const foo = "bar";

--- a/tests/integration/cli/config/define-config/prettier.config.js
+++ b/tests/integration/cli/config/define-config/prettier.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from "prettier/config";
+
+export default defineConfig({
+  trailingComma: "all",
+  singleQuote: true,
+});


### PR DESCRIPTION
## Description

This PR adds configuration support via `prettier/config` by introducing a `defineConfig()` helper for JavaScript config files.

### What changed

- export a new `prettier/config` entry point
- add `defineConfig(options)` for config authoring
- add CommonJS and TypeScript support files for the new config entry
- add an integration test covering `prettier.config.js` usage with `defineConfig`

### Example

```js
import { defineConfig } from "prettier/config";

export default defineConfig({
  trailingComma: "all",
  singleQuote: true,
});