### PR TITLE
fix(typescript): avoid extra semicolon before call signatures in --no-semi mode

### DIFF
--- a/changelog_unreleased/typescript/19063.md
+++ b/changelog_unreleased/typescript/19063.md
@@ -1,0 +1,22 @@
+#### Avoid extra semicolons before interface call signatures in `no-semi` mode (#19063 by @lawrence3699)
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+export interface MyInterface {
+  anotherMethod: (a: string) => Promise<string>
+  (a: string): Promise<string>
+}
+
+// Prettier stable (--no-semi)
+export interface MyInterface {
+  anotherMethod: (a: string) => Promise<string>;
+  (a: string): Promise<string>
+}
+
+// Prettier main (--no-semi)
+export interface MyInterface {
+  anotherMethod: (a: string) => Promise<string>
+  (a: string): Promise<string>
+}
+```

--- a/src/language-js/print/class-body.js
+++ b/src/language-js/print/class-body.js
@@ -323,7 +323,10 @@ function shouldPrintSemicolonAfterInterfaceProperty(
 
   switch (nextNode.type) {
     case "TSCallSignatureDeclaration":
-      return true;
+      return (
+        nextNode.typeParameters ||
+        node.typeAnnotation?.typeAnnotation?.type !== "TSFunctionType"
+      );
   }
 
   return false;

--- a/tests/format/typescript/interface/no-semi/18858.ts
+++ b/tests/format/typescript/interface/no-semi/18858.ts
@@ -1,0 +1,5 @@
+export interface MyInterface {
+  someMethod: (a: number) => Promise<number>
+  anotherMethod: (a: string) => Promise<string>
+  (a: string): Promise<string>
+}

--- a/tests/format/typescript/interface/no-semi/18858.ts
+++ b/tests/format/typescript/interface/no-semi/18858.ts
@@ -3,3 +3,9 @@ export interface MyInterface {
   anotherMethod: (a: string) => Promise<string>
   (a: string): Promise<string>
 }
+
+export type MyType = {
+  someMethod: (a: number) => Promise<number>
+  anotherMethod: (a: string) => Promise<string>
+  (a: string): Promise<string>
+}

--- a/tests/format/typescript/interface/no-semi/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/interface/no-semi/__snapshots__/format.test.js.snap
@@ -185,3 +185,25 @@ type H3 = { foo: X; <T>(): T }
 
 ================================================================================
 `;
+
+exports[`18858.ts - {"semi":false} format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+export interface MyInterface {
+  someMethod: (a: number) => Promise<number>
+  anotherMethod: (a: string) => Promise<string>
+  (a: string): Promise<string>
+}
+
+=====================================output=====================================
+export interface MyInterface {
+  someMethod: (a: number) => Promise<number>
+  anotherMethod: (a: string) => Promise<string>
+  (a: string): Promise<string>
+}
+
+================================================================================
+`;

--- a/tests/format/typescript/interface/no-semi/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/interface/no-semi/__snapshots__/format.test.js.snap
@@ -198,8 +198,20 @@ export interface MyInterface {
   (a: string): Promise<string>
 }
 
+export type MyType = {
+  someMethod: (a: number) => Promise<number>
+  anotherMethod: (a: string) => Promise<string>
+  (a: string): Promise<string>
+}
+
 =====================================output=====================================
 export interface MyInterface {
+  someMethod: (a: number) => Promise<number>
+  anotherMethod: (a: string) => Promise<string>
+  (a: string): Promise<string>
+}
+
+export type MyType = {
   someMethod: (a: number) => Promise<number>
   anotherMethod: (a: string) => Promise<string>
   (a: string): Promise<string>


### PR DESCRIPTION
## Description

Fixes #18858.

After #18118, Prettier started always printing a protective semicolon before interface and type literal call signatures in `--no-semi` mode. That protection is still needed for generic call signatures and non-function-typed properties, but it is unnecessary when a property already ends in a function type.

This keeps the existing `14040` coverage intact while allowing the reported case to format without the extra semicolon.

## Checklist

- [x] Added tests
- [x] Added changelog entry
- [x] Read the [Contributing Guide](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md)
