### PR TITLE
fix(js): object-wrap collapse should respect print width

### DIFF
--- a/changelog_unreleased/javascript/19052.md
+++ b/changelog_unreleased/javascript/19052.md
@@ -1,0 +1,39 @@
+#### Fix `--object-wrap collapse` to respect print width (#19052 by @galsakuri)
+
+Objects with content that can't fit on one line no longer collapse when using `--object-wrap collapse`.
+
+<!-- prettier-ignore -->
+```js
+// Input
+someMethod([
+  {
+    $group: {
+      _id: groupByField,
+      opinions: {
+        $push: includeFields.reduce(
+          (acc, field) => ({ ...acc, [field]: field }),
+          {},
+        ),
+      },
+    },
+  },
+]);
+
+// Prettier stable (bug: collapses past print width)
+someMethod([{ $group: { _id: groupByField, opinions: { $push: includeFields.reduce((acc, field) => ({ ...acc, [field]: field }), {}) } } }]);
+
+// Prettier main
+someMethod([
+  {
+    $group: {
+      _id: groupByField,
+      opinions: {
+        $push: includeFields.reduce(
+          (acc, field) => ({ ...acc, [field]: field }),
+          {},
+        ),
+      },
+    },
+  },
+]);
+```

--- a/src/language-js/print/object.js
+++ b/src/language-js/print/object.js
@@ -5,6 +5,7 @@ import {
   indent,
   line,
   softline,
+  willBreak,
 } from "../../document/index.js";
 import { printDanglingComments } from "../../main/comments/print.js";
 import hasNewline from "../../utilities/has-newline.js";
@@ -193,7 +194,13 @@ function printObject(path, options, print) {
     return content;
   }
 
-  return group(content, { shouldBreak });
+  return group(content, {
+    shouldBreak:
+      shouldBreak ||
+      (node.type !== "ObjectPattern" &&
+        options.objectWrap === "collapse" &&
+        willBreak(content)),
+  });
 }
 
 function hasNewLineAfterOpeningBrace(node, firstProperty, options) {

--- a/tests/format/js/object-multiline/__snapshots__/format.test.js.snap
+++ b/tests/format/js/object-multiline/__snapshots__/format.test.js.snap
@@ -1,5 +1,169 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`collapse-print-width.js - {"objectWrap":"collapse"} format 1`] = `
+====================================options=====================================
+objectWrap: "collapse"
+parsers: ["babel"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// Objects whose content has forced breaks should NOT collapse even with
+// objectWrap: collapse, because the object cannot truly fit on one line.
+
+// Property value forces a multi-line break (args too long to fit on one line).
+const a = [
+  {
+    $push: includeFields.reduce(
+      (acc, field) => ({ ...acc, [field]: field }),
+      {},
+    ),
+  },
+];
+
+// Short simple objects that fit on one line should still collapse.
+const b = [
+  {
+    $set: { [groupByField]: "$_id" },
+  },
+  {
+    $unset: "_id",
+  },
+];
+
+// Nested object whose collapsed form would exceed print width.
+const c = [
+  {
+    $group: {
+      _id: groupByField,
+      opinions: {
+        $push: includeFields.reduce(
+          (acc, field) => ({ ...acc, [field]: field }),
+          {},
+        ),
+      },
+    },
+  },
+];
+
+=====================================output=====================================
+// Objects whose content has forced breaks should NOT collapse even with
+// objectWrap: collapse, because the object cannot truly fit on one line.
+
+// Property value forces a multi-line break (args too long to fit on one line).
+const a = [
+  {
+    $push: includeFields.reduce(
+      (acc, field) => ({ ...acc, [field]: field }),
+      {},
+    ),
+  },
+];
+
+// Short simple objects that fit on one line should still collapse.
+const b = [{ $set: { [groupByField]: "$_id" } }, { $unset: "_id" }];
+
+// Nested object whose collapsed form would exceed print width.
+const c = [
+  {
+    $group: {
+      _id: groupByField,
+      opinions: {
+        $push: includeFields.reduce(
+          (acc, field) => ({ ...acc, [field]: field }),
+          {},
+        ),
+      },
+    },
+  },
+];
+
+================================================================================
+`;
+
+exports[`collapse-print-width.js format 1`] = `
+====================================options=====================================
+parsers: ["babel"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// Objects whose content has forced breaks should NOT collapse even with
+// objectWrap: collapse, because the object cannot truly fit on one line.
+
+// Property value forces a multi-line break (args too long to fit on one line).
+const a = [
+  {
+    $push: includeFields.reduce(
+      (acc, field) => ({ ...acc, [field]: field }),
+      {},
+    ),
+  },
+];
+
+// Short simple objects that fit on one line should still collapse.
+const b = [
+  {
+    $set: { [groupByField]: "$_id" },
+  },
+  {
+    $unset: "_id",
+  },
+];
+
+// Nested object whose collapsed form would exceed print width.
+const c = [
+  {
+    $group: {
+      _id: groupByField,
+      opinions: {
+        $push: includeFields.reduce(
+          (acc, field) => ({ ...acc, [field]: field }),
+          {},
+        ),
+      },
+    },
+  },
+];
+
+=====================================output=====================================
+// Objects whose content has forced breaks should NOT collapse even with
+// objectWrap: collapse, because the object cannot truly fit on one line.
+
+// Property value forces a multi-line break (args too long to fit on one line).
+const a = [
+  {
+    $push: includeFields.reduce(
+      (acc, field) => ({ ...acc, [field]: field }),
+      {},
+    ),
+  },
+];
+
+// Short simple objects that fit on one line should still collapse.
+const b = [
+  {
+    $set: { [groupByField]: "$_id" },
+  },
+  {
+    $unset: "_id",
+  },
+];
+
+// Nested object whose collapsed form would exceed print width.
+const c = [
+  {
+    $group: {
+      _id: groupByField,
+      opinions: {
+        $push: includeFields.reduce(
+          (acc, field) => ({ ...acc, [field]: field }),
+          {},
+        ),
+      },
+    },
+  },
+];
+
+================================================================================
+`;
+
 exports[`multiline.js - {"objectWrap":"collapse"} format 1`] = `
 ====================================options=====================================
 objectWrap: "collapse"

--- a/tests/format/js/object-multiline/collapse-print-width.js
+++ b/tests/format/js/object-multiline/collapse-print-width.js
@@ -1,0 +1,37 @@
+// Objects whose content has forced breaks should NOT collapse even with
+// objectWrap: collapse, because the object cannot truly fit on one line.
+
+// Property value forces a multi-line break (args too long to fit on one line).
+const a = [
+  {
+    $push: includeFields.reduce(
+      (acc, field) => ({ ...acc, [field]: field }),
+      {},
+    ),
+  },
+];
+
+// Short simple objects that fit on one line should still collapse.
+const b = [
+  {
+    $set: { [groupByField]: "$_id" },
+  },
+  {
+    $unset: "_id",
+  },
+];
+
+// Nested object whose collapsed form would exceed print width.
+const c = [
+  {
+    $group: {
+      _id: groupByField,
+      opinions: {
+        $push: includeFields.reduce(
+          (acc, field) => ({ ...acc, [field]: field }),
+          {},
+        ),
+      },
+    },
+  },
+];


### PR DESCRIPTION
I ran into #19052 where `--object-wrap collapse` collapses objects onto one line even when the result blows past the configured print width. The problem is that when a parent group is in flat mode, inner groups with `shouldBreak: false` inherit that flat mode without any `fits()` measurement. Since collapse mode always sets `shouldBreak: false` on object expressions, they collapse blindly.

The fix is a small addition to `printObject` in `src/language-js/print/object.js`. Before returning the group, I check `willBreak(content)` when `objectWrap === "collapse"`. If the content already contains forced breaks (hardlines from things like multi-line function calls), there's no way the object can truly fit on one line, so I set `shouldBreak: true` to keep it expanded.

I also added a test fixture in `tests/format/js/object-multiline/collapse-print-width.js` that covers the failing case from the issue, a nested object that also can't collapse, and a couple of short objects that should still collapse fine. All existing tests pass.