### PR TITLE
Add dedentString unit coverage

### DIFF
--- a/tests/unit/whitespace-utilities.js
+++ b/tests/unit/whitespace-utilities.js
@@ -115,3 +115,16 @@ describe("split", () => {
     });
   }
 });
+
+describe("dedentString", () => {
+  for (const [string, expected] of [
+    ["foo\n  bar", "foo\n  bar"],
+    ["  foo\n    bar", "foo\n  bar"],
+    ["\n    foo\n      bar\n    ", "\nfoo\n  bar\n"],
+    ["    \n  foo\n    bar\n    ", "  \nfoo\n  bar\n  "],
+  ]) {
+    it(JSON.stringify(string), () => {
+      expect(utils.dedentString(string)).toBe(expected);
+    });
+  }
+});


### PR DESCRIPTION

**Repo:** prettier/prettier (⭐ 50000)
**Type:** test
**Files changed:** 1
**Lines:** +13/-0

## What
Adds direct unit coverage for `WhitespaceUtilities.dedentString()` in `tests/unit/whitespace-utilities.js`. The new cases verify that dedenting preserves already-minimal text, removes shared indentation from multi-line input, and correctly ignores blank or whitespace-only lines when computing the minimum indentation level.

## Why
`dedentString()` is a core helper used by Prettier's HTML and Handlebars paths, but it previously had no focused unit coverage. Locking down its behavior around blank lines and indentation-only lines makes regressions easier to catch without changing formatter behavior or expanding the patch beyond a single low-risk test file.

## Testing
Attempted to run `yarn test tests/unit/whitespace-utilities.js --runInBand`, but this clone does not have a Yarn install state file, so Jest could not start. Static review of the updated test file completed successfully.

## Risk
Low - test-only change with no runtime code modifications.
