### PR TITLE
add binary builds of the package to each realese

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,86 @@
+name: Release Binaries
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to attach binaries to
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x64
+            runner: ubuntu-latest
+            target: bun-linux-x64
+            artifact: prettier-linux-x64
+          - name: linux-arm64
+            runner: ubuntu-latest
+            target: bun-linux-arm64
+            artifact: prettier-linux-arm64
+          - name: darwin-x64
+            runner: macos-latest
+            target: bun-darwin-x64
+            artifact: prettier-darwin-x64
+          - name: darwin-arm64
+            runner: macos-latest
+            target: bun-darwin-arm64
+            artifact: prettier-darwin-arm64
+          - name: windows-x64
+            runner: windows-latest
+            target: bun-windows-x64
+            artifact: prettier-windows-x64.exe
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          cache: "yarn"
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build prettier
+        run: yarn build
+
+      - name: Compile standalone binary
+        shell: bash
+        run: |
+          bun build --compile --minify \
+            --target=${{ matrix.target }} \
+            ./scripts/compile-entry.mjs \
+            --outfile ${{ matrix.artifact }}
+
+      - name: Smoke test
+        shell: bash
+        run: ./${{ matrix.artifact }} --version
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+          if-no-files-found: error
+
+      - name: Attach to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        shell: bash
+        run: gh release upload "$TAG" "${{ matrix.artifact }}" --clobber --repo "$GITHUB_REPOSITORY"

--- a/changelog_unreleased/misc/19078.md
+++ b/changelog_unreleased/misc/19078.md
@@ -1,0 +1,4 @@
+#### Publish standalone binaries with each release (#19078 by @bgalek)
+
+Each GitHub release now includes standalone Prettier executables for Linux, macOS, and Windows (x64 + arm64), built with Bun.
+Users can download and run Prettier without installing Node.js or npm.

--- a/scripts/compile-entry.mjs
+++ b/scripts/compile-entry.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env bun
+import * as legacy from "../dist/prettier/internal/legacy-cli.mjs";
+import * as experimental from "../dist/prettier/internal/experimental-cli.mjs";
+
+const index = process.argv.indexOf("--experimental-cli");
+if (process.env.PRETTIER_EXPERIMENTAL_CLI || index !== -1) {
+  if (index !== -1) process.argv.splice(index, 1);
+  await experimental.__promise;
+} else {
+  await legacy.run();
+}


### PR DESCRIPTION
## Description
Ths PR adds a GitHub Actions workflow that builds standalone `Prettier` binaries for Linux, macOS, and Windows (x64 + arm64) using Bun's `--compile`, and attaches them to each published GitHub release. 

fixes #19078

This is just an example to show how much work is required for the first steps into this direction ;)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
