### PR TITLE
fix(angular): format = spacing in @for let clauses with multiple bindings

### DIFF
--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -58,8 +58,17 @@ function genericPrint(path, options, print) {
       return printAngularControlFlowBlock(path, options, print);
     case "angularControlFlowBlockParameters":
       return printAngularControlFlowBlockParameters(path, options, print);
-    case "angularControlFlowBlockParameter":
-      return htmlWhitespace.trim(node.expression);
+    case "angularControlFlowBlockParameter": {
+      const expression = htmlWhitespace.trim(node.expression);
+      // Normalize spaces around '=' in let clauses — handles the case where
+      // parseTemplateBindings fails on the whole parameters block (e.g. when a
+      // let clause contains multiple comma-separated bindings like
+      // "let i=$index, f=$first") and each parameter falls back to raw text.
+      if (/^let\s/.test(expression)) {
+        return expression.replace(/\s*=\s*/g, " = ");
+      }
+      return expression;
+    }
 
     case "angularLetDeclaration":
       // print like "break-after-operator" layout assignment in estree printer

--- a/tests/format/angular/control-flow/__snapshots__/format.test.js.snap
+++ b/tests/format/angular/control-flow/__snapshots__/format.test.js.snap
@@ -317,6 +317,24 @@ item of
   <div *ngFor="item of items; let i = $index; let count = $count; track block"></div>
 </div>
 
+<div>
+  @for (item of items; track item.id; let i=$index, f=$first) {
+    <p>{{ item }}</p>
+  }
+</div>
+
+<div>
+  @for (item of items; track item.id; let i=$index, f=$first, e=$even) {
+    <p>{{ item }}</p>
+  }
+</div>
+
+<div>
+  @for (item of items; track item.id; let i=$index, f=$first; let count=$count) {
+    <p>{{ item }}</p>
+  }
+</div>
+
 =====================================output=====================================
 <ul>
   @for (let item of items; index as i; trackBy: trackByFn) {
@@ -376,6 +394,29 @@ item of
   <div
     *ngFor="item of items; let i = $index; let count = $count; track block"
   ></div>
+</div>
+
+<div>
+  @for (item of items; track item.id; let i = $index, f = $first) {
+    <p>{{ item }}</p>
+  }
+</div>
+
+<div>
+  @for (item of items; track item.id; let i = $index, f = $first, e = $even) {
+    <p>{{ item }}</p>
+  }
+</div>
+
+<div>
+  @for (
+    item of items;
+    track item.id;
+    let i = $index, f = $first;
+    let count = $count
+  ) {
+    <p>{{ item }}</p>
+  }
 </div>
 
 ================================================================================

--- a/tests/format/angular/control-flow/for.html
+++ b/tests/format/angular/control-flow/for.html
@@ -64,3 +64,21 @@ item of
 
   <div *ngFor="item of items; let i = $index; let count = $count; track block"></div>
 </div>
+
+<div>
+  @for (item of items; track item.id; let i=$index, f=$first) {
+    <p>{{ item }}</p>
+  }
+</div>
+
+<div>
+  @for (item of items; track item.id; let i=$index, f=$first, e=$even) {
+    <p>{{ item }}</p>
+  }
+</div>
+
+<div>
+  @for (item of items; track item.id; let i=$index, f=$first; let count=$count) {
+    <p>{{ item }}</p>
+  }
+</div>


### PR DESCRIPTION
Fixes #19081

## Problem

Angular `@for` blocks allow comma-separated bindings in a single `let` clause:

```html
@for (item of items; track item.id; let i=$index, f=$first) { ... }
```

Prettier formats single-binding `let` clauses correctly (`let i = $index`) but leaves multi-binding ones unchanged. The root cause: the entire parameters string is passed to `parseTemplateBindings`, which throws when it encounters `let i=$index, f=$first` (the comma-separated form is not valid `*ngFor` microsyntax). That error is silently swallowed, and all parameters fall back to raw text — so the missing spaces around `=` are never normalized.

## Fix

When the embed path fails and the fallback `angularControlFlowBlockParameter` printer is used, normalize spaces around `=` for any `let` parameter:

| Input | Before | After |
|-------|--------|-------|
| `let i=$index, f=$first` | `let i=$index, f=$first` | `let i = $index, f = $first` |
| `let i = $index, f=$first` | `let i = $index, f=$first` | `let i = $index, f = $first` |
| `let i=$index, f=$first, e=$even` | unchanged | `let i = $index, f = $first, e = $even` |
| `let i=$index` (single, already embed-formatted) | `let i = $index` | `let i = $index` (unchanged) |

The fix is idempotent and only applies to parameters that begin with `let`.