### PR TITLE
Fix caching of invalid files

### DIFF
--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -380,6 +380,9 @@ async function formatFiles(context) {
       }
       output = result.formatted;
     } catch (error) {
+      // invalidate cache on format error
+      formatResultsCache?.removeFormatResultsCache(filename);
+
       const errorIsIgnored = handleError(
         context,
         fileNameToDisplay,

--- a/tests/integration/__tests__/cache.js
+++ b/tests/integration/__tests__/cache.js
@@ -362,6 +362,45 @@ describe("--cache option", () => {
       expect(secondStdout).toBe("a.js");
     });
 
+    it("doesn't cache files that fail to format due to syntax errors", async () => {
+      await runCliWithoutGitignore(dir, [
+        "--cache",
+        "--write",
+        "--cache-strategy",
+        "metadata",
+        "a.js",
+      ]);
+
+      // Overwrite with content that has a syntax error
+      await fs.writeFile(path.join(dir, "a.js"), "const a = 1;\n}\n");
+
+      // Running with --check should report the syntax error
+      const { stderr: secondStderr, status: secondStatus } =
+        await runCliWithoutGitignore(dir, [
+          "--cache",
+          "--check",
+          "--cache-strategy",
+          "metadata",
+          "a.js",
+        ]);
+      expect(secondStatus).toBe(2);
+      expect(secondStderr).toStrictEqual(
+        expect.stringContaining("SyntaxError"),
+      );
+
+      // Running with --check again should also report the syntax error
+      const { stderr: thirdStderr, status: thirdStatus } =
+        await runCliWithoutGitignore(dir, [
+          "--cache",
+          "--check",
+          "--cache-strategy",
+          "metadata",
+          "a.js",
+        ]);
+      expect(thirdStatus).toBe(2);
+      expect(thirdStderr).toStrictEqual(expect.stringContaining("SyntaxError"));
+    });
+
     it("removes cache file when run Prettier without `--cache` option", async () => {
       await runCliWithoutGitignore(dir, [
         "--cache",
@@ -646,6 +685,45 @@ describe("--cache option", () => {
         "*.js",
       ]);
       expect(secondStdout).toBe("a.js");
+    });
+
+    it("doesn't cache files that fail to format due to syntax errors", async () => {
+      await runCliWithoutGitignore(dir, [
+        "--cache",
+        "--write",
+        "--cache-strategy",
+        "content",
+        "a.js",
+      ]);
+
+      // Overwrite with content that has a syntax error
+      await fs.writeFile(path.join(dir, "a.js"), "const a = 1;\n}\n");
+
+      // Running with --check should report the syntax error
+      const { stderr: secondStderr, status: secondStatus } =
+        await runCliWithoutGitignore(dir, [
+          "--cache",
+          "--check",
+          "--cache-strategy",
+          "content",
+          "a.js",
+        ]);
+      expect(secondStatus).toBe(2);
+      expect(secondStderr).toStrictEqual(
+        expect.stringContaining("SyntaxError"),
+      );
+
+      // Running with --check again should also report the syntax error
+      const { stderr: thirdStderr, status: thirdStatus } =
+        await runCliWithoutGitignore(dir, [
+          "--cache",
+          "--check",
+          "--cache-strategy",
+          "content",
+          "a.js",
+        ]);
+      expect(thirdStatus).toBe(2);
+      expect(thirdStderr).toStrictEqual(expect.stringContaining("SyntaxError"));
     });
 
     it("removes cache file when run Prettier without `--cache` option", async () => {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->
Fixes caching of invalid files described in issue #19085.

The first commit adds tests, which fail with the current code.  
The second commit should fix the problem so the tests pass.


## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
