### PR TITLE
fix(no-semi): insert leading semicolon for ConditionalExpression with experimentalTernaries

### DIFF
--- a/src/language-js/semicolon/semicolon.js
+++ b/src/language-js/semicolon/semicolon.js
@@ -52,6 +52,14 @@ function expressionNeedsAsiProtection(path, options) {
     case "RegExpLiteral":
       return true;
 
+    case "ConditionalExpression":
+      // With experimentalTernaries, the test is wrapped in `ifBreak("(")` at
+      // the document level, so the output starts with `(` when it breaks.
+      if (options.experimentalTernaries) {
+        return true;
+      }
+      break;
+
     case "ArrowFunctionExpression":
       if (!shouldPrintParamsWithoutParens(path, options)) {
         return true;

--- a/tests/format/js/ternaries/__snapshots__/format.test.js.snap
+++ b/tests/format/js/ternaries/__snapshots__/format.test.js.snap
@@ -1,5 +1,52 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`binary.js - {"experimentalTernaries":true,"semi":false,"tabWidth":4,"filepath":"no-semi.js"} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel"]
+semi: false
+tabWidth: 4
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+const funnelSnapshotCard = (report === MY_OVERVIEW &&
+  !ReportGK.xar_metrics_active_capitol_v2) ||
+  (report === COMPANY_OVERVIEW &&
+    !ReportGK.xar_metrics_active_capitol_v2_company_metrics)
+  ? <ReportMetricsFunnelSnapshotCard metrics={metrics} />
+  : null;
+
+room = room.map((row, rowIndex) => (
+  row.map((col, colIndex) => (
+    (rowIndex === 0 || colIndex === 0 || rowIndex === height || colIndex === width) ? 1 : 0
+  ))
+))
+
+=====================================output=====================================
+const funnelSnapshotCard =
+    (
+        (report === MY_OVERVIEW && !ReportGK.xar_metrics_active_capitol_v2) ||
+        (report === COMPANY_OVERVIEW &&
+            !ReportGK.xar_metrics_active_capitol_v2_company_metrics)
+    ) ?
+        <ReportMetricsFunnelSnapshotCard metrics={metrics} />
+    :   null
+
+room = room.map((row, rowIndex) =>
+    row.map((col, colIndex) =>
+        (
+            rowIndex === 0 ||
+            colIndex === 0 ||
+            rowIndex === height ||
+            colIndex === width
+        ) ?
+            1
+        :   0,
+    ),
+)
+
+================================================================================
+`;
+
 exports[`binary.js - {"experimentalTernaries":true,"tabWidth":4} format 1`] = `
 ====================================options=====================================
 experimentalTernaries: true
@@ -348,6 +395,40 @@ room = room.map((row, rowIndex) =>
 ================================================================================
 `;
 
+exports[`func-call.js - {"experimentalTernaries":true,"semi":false,"tabWidth":4,"filepath":"no-semi.js"} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel"]
+semi: false
+tabWidth: 4
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+fn(
+  bifornCringerMoshedPerplexSawder,
+  askTrovenaBeenaDependsRowans,
+  glimseGlyphsHazardNoopsTieTie === averredBathersBoxroomBuggyNurl &&
+    anodyneCondosMalateOverateRetinol
+      ? annularCooeedSplicesWalksWayWay
+      : kochabCooieGameOnOboleUnweave
+);
+// TODO(rattrayalex): try to indent consequent/alternate here.
+
+=====================================output=====================================
+fn(
+    bifornCringerMoshedPerplexSawder,
+    askTrovenaBeenaDependsRowans,
+    (
+        glimseGlyphsHazardNoopsTieTie === averredBathersBoxroomBuggyNurl &&
+            anodyneCondosMalateOverateRetinol
+    ) ?
+        annularCooeedSplicesWalksWayWay
+    :   kochabCooieGameOnOboleUnweave,
+)
+// TODO(rattrayalex): try to indent consequent/alternate here.
+
+================================================================================
+`;
+
 exports[`func-call.js - {"experimentalTernaries":true,"tabWidth":4} format 1`] = `
 ====================================options=====================================
 experimentalTernaries: true
@@ -596,6 +677,340 @@ fn(
     : kochabCooieGameOnOboleUnweave,
 );
 // TODO(rattrayalex): try to indent consequent/alternate here.
+
+================================================================================
+`;
+
+exports[`indent.js - {"experimentalTernaries":true,"semi":false,"tabWidth":4,"filepath":"no-semi.js"} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel"]
+semi: false
+tabWidth: 4
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+aaaaaaaaaaaaaaa ? bbbbbbbbbbbbbbbbbb : ccccccccccccccc ? ddddddddddddddd : eeeeeeeeeeeeeee ? fffffffffffffff : gggggggggggggggg
+
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+?
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+?
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+?
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+:
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+:
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+:
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+a
+    ? {
+        a: 0
+      }
+    : {
+        a: {
+             a: 0
+           }
+            ? {
+                a: 0
+              }
+            : {
+                y: {
+                    a: 0
+                }
+                    ? {
+                        a: 0
+                    }
+                    : {
+                        a: 0
+                    }
+            }
+      }
+
+a
+	? {
+			a: function() {
+				return a
+					? {
+							a: [
+								a
+									? {
+											a: 0,
+											b: [
+												a
+													? [
+															0,
+															1
+													  ]
+													: []
+											]
+									  }
+									: [
+											[
+												0,
+												{
+													a: 0
+												},
+												a
+													? 0
+													: 1
+											],
+											function() {
+												return a
+													? {
+															a: 0
+													  }
+													: [
+															{
+																a: 0
+															},
+															{}
+													  ];
+											}
+									  ]
+							]
+					  }
+					: [
+							a
+								? function() {
+										a
+											? a(
+													a
+														? {
+																a: a(
+																	{
+																		a: 0
+																	}
+																)
+														  }
+														: [
+																0,
+																a(),
+																a(
+																	a(),
+																	{
+																		a: 0
+																	},
+																	a
+																		? a()
+																		: a(
+																				{
+																					a: 0
+																				}
+																		  )
+																),
+																a()
+																	? {
+																			a: a(),
+																			b: []
+																	  }
+																	: {}
+														  ]
+											  ):
+										a(
+											a()
+												? {
+														a: 0
+												  }
+												: (function(a) {
+														return a()
+															? [
+																	{
+																		a: 0,
+																		b: a()
+																	}
+															  ]
+															: a(
+																	[
+																		a
+																			? {
+																					a: 0
+																			  }
+																			: {},
+																		{
+																			a: 0
+																		}
+																	]
+															  );
+												  })(
+														a
+															? function(a) {
+																	return function() {
+																		return 0;
+																	};
+															  }
+															: function(a) {
+																	return function() {
+																		return 1;
+																	}
+															  }
+												  )
+										);
+								  }
+								: function() {
+
+								  }
+					  ];
+			}
+	  }
+    : a;
+
+=====================================output=====================================
+;aaaaaaaaaaaaaaa ? bbbbbbbbbbbbbbbbbb
+: ccccccccccccccc ? ddddddddddddddd
+: eeeeeeeeeeeeeee ? fffffffffffffff
+: gggggggggggggggg
+
+;aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ?
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ?
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ?
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        :   aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    :   aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+:   aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+;a ?
+    {
+        a: 0,
+    }
+:   {
+        a:
+            (
+                {
+                    a: 0,
+                }
+            ) ?
+                {
+                    a: 0,
+                }
+            :   {
+                    y:
+                        (
+                            {
+                                a: 0,
+                            }
+                        ) ?
+                            {
+                                a: 0,
+                            }
+                        :   {
+                                a: 0,
+                            },
+                },
+    }
+
+;a ?
+    {
+        a: function () {
+            return a ?
+                    {
+                        a: [
+                            a ?
+                                {
+                                    a: 0,
+                                    b: [a ? [0, 1] : []],
+                                }
+                            :   [
+                                    [
+                                        0,
+                                        {
+                                            a: 0,
+                                        },
+                                        a ? 0 : 1,
+                                    ],
+                                    function () {
+                                        return a ?
+                                                {
+                                                    a: 0,
+                                                }
+                                            :   [
+                                                    {
+                                                        a: 0,
+                                                    },
+                                                    {},
+                                                ]
+                                    },
+                                ],
+                        ],
+                    }
+                :   [
+                        a ?
+                            function () {
+                                ;a ?
+                                    a(
+                                        a ?
+                                            {
+                                                a: a({
+                                                    a: 0,
+                                                }),
+                                            }
+                                        :   [
+                                                0,
+                                                a(),
+                                                a(
+                                                    a(),
+                                                    {
+                                                        a: 0,
+                                                    },
+                                                    a ? a() : (
+                                                        a({
+                                                            a: 0,
+                                                        })
+                                                    ),
+                                                ),
+                                                a() ?
+                                                    {
+                                                        a: a(),
+                                                        b: [],
+                                                    }
+                                                :   {},
+                                            ],
+                                    )
+                                :   a(
+                                        a() ?
+                                            {
+                                                a: 0,
+                                            }
+                                        :   (function (a) {
+                                                return a() ?
+                                                        [
+                                                            {
+                                                                a: 0,
+                                                                b: a(),
+                                                            },
+                                                        ]
+                                                    :   a([
+                                                            a ?
+                                                                {
+                                                                    a: 0,
+                                                                }
+                                                            :   {},
+                                                            {
+                                                                a: 0,
+                                                            },
+                                                        ])
+                                            })(
+                                                a ?
+                                                    function (a) {
+                                                        return function () {
+                                                            return 0
+                                                        }
+                                                    }
+                                                :   function (a) {
+                                                        return function () {
+                                                            return 1
+                                                        }
+                                                    },
+                                            ),
+                                    )
+                            }
+                        :   function () {},
+                    ]
+        },
+    }
+:   a
 
 ================================================================================
 `;
@@ -3248,6 +3663,637 @@ a
       },
     }
   : a;
+
+================================================================================
+`;
+
+exports[`indent-after-paren.js - {"experimentalTernaries":true,"semi":false,"tabWidth":4,"filepath":"no-semi.js"} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel"]
+semi: false
+tabWidth: 4
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+foo7 = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz)[Fooooooooooo];
+
+foo8 = (condition ? firstValue : secondValue)[SomeType];
+
+const foo9 = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz)[Fooooooooooo];
+
+function foo10() {
+  return (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz)[Fooooooooooo];
+}
+
+function foo11() {
+  throw (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz)[Fooooooooooo];
+}
+
+function foo12() {
+  void (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz)[Fooooooooooo];
+}
+
+foo13 = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz
+).Fooooooooooo.Fooooooooooo;
+
+foo14 = (condition ? firstValue : secondValue)[SomeType];
+
+const foo15 = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz
+).Fooooooooooo.Fooooooooooo;
+
+function foo16() {
+  return (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+  ).Fooooooooooo.Fooooooooooo;
+}
+
+function foo17() {
+  throw (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+  ).Fooooooooooo.Fooooooooooo;
+}
+
+function foo18() {
+  void (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+  ).Fooooooooooo.Fooooooooooo;
+}
+
+foo19 = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo);
+
+foo20 = (condition ? firstValue : secondValue)[SomeType];
+
+const foo21 = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo);
+
+function foo22() {
+  return (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo);
+}
+
+function foo23() {
+  throw (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo);
+}
+
+function foo24() {
+  void (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo);
+}
+
+foo25 = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz)?.(Fooooooooooo.Fooooooooooo);
+
+foo26 = (condition ? firstValue : secondValue)[SomeType];
+
+const foo27 = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz)?.(Fooooooooooo.Fooooooooooo);
+
+function foo28() {
+  return (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz)?.(Fooooooooooo.Fooooooooooo);
+}
+
+function foo29() {
+  throw (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz)?.(Fooooooooooo.Fooooooooooo);
+}
+
+function foo30() {
+  void (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz)?.(Fooooooooooo.Fooooooooooo);
+}
+
+function* foo31() {
+  yield (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz)?.(Fooooooooooo.Fooooooooooo);
+  yield (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo);
+  yield (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz).Fooooooooooo.Fooooooooooo;
+  yield (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz)[Fooooooooooo.Fooooooooooo];
+}
+
+const foo32 = new (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz
+)(Fooooooooooo.Fooooooooooo);
+
+function foo33() {
+  return new (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+  )(Fooooooooooo.Fooooooooooo);
+}
+
+function foo34() {
+  throw new (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+  )(Fooooooooooo.Fooooooooooo);
+}
+
+function foo35() {
+  void new (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+  )(Fooooooooooo.Fooooooooooo);
+}
+
+foo36 = new (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz
+)(Fooooooooooo.Fooooooooooo);
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans +
+  ((glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol)[AnnularCooeedSplicesWalksWayWay]);
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans +
+  ((glimseGlyphsHazardNoopsTieTie === 0 &&
+  kochabCooieGameOnOboleUnweave === Math.PI
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol)[AnnularCooeedSplicesWalksWayWay]);
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans +
+  ((glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol).Fooooooooooo.Fooooooooooo);
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans +
+  ((glimseGlyphsHazardNoopsTieTie === 0 &&
+  kochabCooieGameOnOboleUnweave === Math.PI
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol).Fooooooooooo.Fooooooooooo);
+
+bifornCringerMoshedPerplexSawder =
+    askTrovenaBeenaDependsRowans +
+    ((glimseGlyphsHazardNoopsTieTie === 0
+      ? averredBathersBoxroomBuggyNurl
+      : anodyneCondosMalateOverateRetinol)(Fooooooooooo.Fooooooooooo));
+
+bifornCringerMoshedPerplexSawder =
+    askTrovenaBeenaDependsRowans +
+    ((glimseGlyphsHazardNoopsTieTie === 0 &&
+    kochabCooieGameOnOboleUnweave === Math.PI
+      ? averredBathersBoxroomBuggyNurl
+      : anodyneCondosMalateOverateRetinol)(Fooooooooooo.Fooooooooooo));
+// TODO(rattrayalex): try to fix this case
+
+bifornCringerMoshedPerplexSawder = (
+  glimseGlyphsHazardNoopsTieTie === 0 &&
+  kochabCooieGameOnOboleUnweave === Math.PI
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).annularCooeedSplicesWalksWayWay
+    .annularCooeedSplicesWalksWayWay(annularCooeedSplicesWalksWayWay)
+    .annularCooeedSplicesWalksWayWay();
+
+foo = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz)?.()?.()?.();
+
+foo = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz)()()();
+
+foo =
+  foo.bar.baz[
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  ];
+
+const decorated = (arg, ignoreRequestError) => {
+  return (
+    typeof arg === "string" ||
+    (arg && arg.valueOf && typeof arg.valueOf() === "string")
+      ? $delegate(arg, ignoreRequestError)
+      : handleAsyncOperations(arg, ignoreRequestError)
+  ).foo();
+};
+
+bifornCringerMoshedPerplexSawder = fn(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+);
+
+fn(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+)
+
+bifornCringerMoshedPerplexSawder = fn?.(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+);
+
+fn?.(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+)
+
+bifornCringerMoshedPerplexSawder =
+  fn[
+    (glimseGlyphsHazardNoopsTieTie === 0
+      ? averredBathersBoxroomBuggyNurl
+      : anodyneCondosMalateOverateRetinol
+    ).prop
+  ];
+
+fn[
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+];
+
+bifornCringerMoshedPerplexSawder =
+  fn?.[
+    (glimseGlyphsHazardNoopsTieTie === 0
+      ? averredBathersBoxroomBuggyNurl
+      : anodyneCondosMalateOverateRetinol
+    ).prop
+  ];
+
+fn?.[
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+];
+
+=====================================output=====================================
+foo7 = (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+        baaaaaaaaaaaaaaaaaaaaar
+    :   baaaaaaaaaaaaaaaaaaaaaz)[Fooooooooooo]
+
+foo8 = (condition ? firstValue : secondValue)[SomeType]
+
+const foo9 = (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+        baaaaaaaaaaaaaaaaaaaaar
+    :   baaaaaaaaaaaaaaaaaaaaaz)[Fooooooooooo]
+
+function foo10() {
+    return (
+        coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+            baaaaaaaaaaaaaaaaaaaaar
+        :   baaaaaaaaaaaaaaaaaaaaaz)[Fooooooooooo]
+}
+
+function foo11() {
+    throw (
+        coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+            baaaaaaaaaaaaaaaaaaaaar
+        :   baaaaaaaaaaaaaaaaaaaaaz)[Fooooooooooo]
+}
+
+function foo12() {
+    void (
+        coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+            baaaaaaaaaaaaaaaaaaaaar
+        :   baaaaaaaaaaaaaaaaaaaaaz)[Fooooooooooo]
+}
+
+foo13 = (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+        baaaaaaaaaaaaaaaaaaaaar
+    :   baaaaaaaaaaaaaaaaaaaaaz).Fooooooooooo.Fooooooooooo
+
+foo14 = (condition ? firstValue : secondValue)[SomeType]
+
+const foo15 = (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+        baaaaaaaaaaaaaaaaaaaaar
+    :   baaaaaaaaaaaaaaaaaaaaaz).Fooooooooooo.Fooooooooooo
+
+function foo16() {
+    return (
+        coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+            baaaaaaaaaaaaaaaaaaaaar
+        :   baaaaaaaaaaaaaaaaaaaaaz).Fooooooooooo.Fooooooooooo
+}
+
+function foo17() {
+    throw (
+        coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+            baaaaaaaaaaaaaaaaaaaaar
+        :   baaaaaaaaaaaaaaaaaaaaaz).Fooooooooooo.Fooooooooooo
+}
+
+function foo18() {
+    void (
+        coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+            baaaaaaaaaaaaaaaaaaaaar
+        :   baaaaaaaaaaaaaaaaaaaaaz).Fooooooooooo.Fooooooooooo
+}
+
+foo19 = (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+        baaaaaaaaaaaaaaaaaaaaar
+    :   baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo)
+
+foo20 = (condition ? firstValue : secondValue)[SomeType]
+
+const foo21 = (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+        baaaaaaaaaaaaaaaaaaaaar
+    :   baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo)
+
+function foo22() {
+    return (
+        coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+            baaaaaaaaaaaaaaaaaaaaar
+        :   baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo)
+}
+
+function foo23() {
+    throw (
+        coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+            baaaaaaaaaaaaaaaaaaaaar
+        :   baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo)
+}
+
+function foo24() {
+    void (
+        coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+            baaaaaaaaaaaaaaaaaaaaar
+        :   baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo)
+}
+
+foo25 = (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+        baaaaaaaaaaaaaaaaaaaaar
+    :   baaaaaaaaaaaaaaaaaaaaaz)?.(Fooooooooooo.Fooooooooooo)
+
+foo26 = (condition ? firstValue : secondValue)[SomeType]
+
+const foo27 = (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+        baaaaaaaaaaaaaaaaaaaaar
+    :   baaaaaaaaaaaaaaaaaaaaaz)?.(Fooooooooooo.Fooooooooooo)
+
+function foo28() {
+    return (
+        coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+            baaaaaaaaaaaaaaaaaaaaar
+        :   baaaaaaaaaaaaaaaaaaaaaz)?.(Fooooooooooo.Fooooooooooo)
+}
+
+function foo29() {
+    throw (
+        coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+            baaaaaaaaaaaaaaaaaaaaar
+        :   baaaaaaaaaaaaaaaaaaaaaz)?.(Fooooooooooo.Fooooooooooo)
+}
+
+function foo30() {
+    void (
+        coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+            baaaaaaaaaaaaaaaaaaaaar
+        :   baaaaaaaaaaaaaaaaaaaaaz)?.(Fooooooooooo.Fooooooooooo)
+}
+
+function* foo31() {
+    yield (
+        coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+            baaaaaaaaaaaaaaaaaaaaar
+        :   baaaaaaaaaaaaaaaaaaaaaz)?.(Fooooooooooo.Fooooooooooo)
+    yield (
+        coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+            baaaaaaaaaaaaaaaaaaaaar
+        :   baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo)
+    yield (
+        coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+            baaaaaaaaaaaaaaaaaaaaar
+        :   baaaaaaaaaaaaaaaaaaaaaz).Fooooooooooo.Fooooooooooo
+    yield (
+        coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+            baaaaaaaaaaaaaaaaaaaaar
+        :   baaaaaaaaaaaaaaaaaaaaaz)[Fooooooooooo.Fooooooooooo]
+}
+
+const foo32 = new (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+        baaaaaaaaaaaaaaaaaaaaar
+    :   baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo)
+
+function foo33() {
+    return new (
+        coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+            baaaaaaaaaaaaaaaaaaaaar
+        :   baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo)
+}
+
+function foo34() {
+    throw new (
+        coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+            baaaaaaaaaaaaaaaaaaaaar
+        :   baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo)
+}
+
+function foo35() {
+    void new (
+        coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+            baaaaaaaaaaaaaaaaaaaaar
+        :   baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo)
+}
+
+foo36 = new (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+        baaaaaaaaaaaaaaaaaaaaar
+    :   baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo)
+
+bifornCringerMoshedPerplexSawder =
+    askTrovenaBeenaDependsRowans +
+    (glimseGlyphsHazardNoopsTieTie === 0 ?
+        averredBathersBoxroomBuggyNurl
+    :   anodyneCondosMalateOverateRetinol)[AnnularCooeedSplicesWalksWayWay]
+
+bifornCringerMoshedPerplexSawder =
+    askTrovenaBeenaDependsRowans +
+    ((
+        glimseGlyphsHazardNoopsTieTie === 0 &&
+        kochabCooieGameOnOboleUnweave === Math.PI
+    ) ?
+        averredBathersBoxroomBuggyNurl
+    :   anodyneCondosMalateOverateRetinol)[AnnularCooeedSplicesWalksWayWay]
+
+bifornCringerMoshedPerplexSawder =
+    askTrovenaBeenaDependsRowans +
+    (glimseGlyphsHazardNoopsTieTie === 0 ?
+        averredBathersBoxroomBuggyNurl
+    :   anodyneCondosMalateOverateRetinol
+    ).Fooooooooooo.Fooooooooooo
+
+bifornCringerMoshedPerplexSawder =
+    askTrovenaBeenaDependsRowans +
+    ((
+        glimseGlyphsHazardNoopsTieTie === 0 &&
+        kochabCooieGameOnOboleUnweave === Math.PI
+    ) ?
+        averredBathersBoxroomBuggyNurl
+    :   anodyneCondosMalateOverateRetinol
+    ).Fooooooooooo.Fooooooooooo
+
+bifornCringerMoshedPerplexSawder =
+    askTrovenaBeenaDependsRowans +
+    (glimseGlyphsHazardNoopsTieTie === 0 ?
+        averredBathersBoxroomBuggyNurl
+    :   anodyneCondosMalateOverateRetinol)(Fooooooooooo.Fooooooooooo)
+
+bifornCringerMoshedPerplexSawder =
+    askTrovenaBeenaDependsRowans +
+    ((
+        glimseGlyphsHazardNoopsTieTie === 0 &&
+            kochabCooieGameOnOboleUnweave === Math.PI
+    ) ?
+        averredBathersBoxroomBuggyNurl
+    :   anodyneCondosMalateOverateRetinol)(Fooooooooooo.Fooooooooooo)
+// TODO(rattrayalex): try to fix this case
+
+bifornCringerMoshedPerplexSawder = (
+    (
+        glimseGlyphsHazardNoopsTieTie === 0 &&
+        kochabCooieGameOnOboleUnweave === Math.PI
+    ) ?
+        averredBathersBoxroomBuggyNurl
+    :   anodyneCondosMalateOverateRetinol).annularCooeedSplicesWalksWayWay
+    .annularCooeedSplicesWalksWayWay(annularCooeedSplicesWalksWayWay)
+    .annularCooeedSplicesWalksWayWay()
+
+foo = (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+        baaaaaaaaaaaaaaaaaaaaar
+    :   baaaaaaaaaaaaaaaaaaaaaz)?.()?.()?.()
+
+foo = (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+        baaaaaaaaaaaaaaaaaaaaar
+    :   baaaaaaaaaaaaaaaaaaaaaz)()()()
+
+foo =
+    foo.bar.baz[
+        coooooooooooooooooooooooooooooooooooooooooooooooooooond ?
+            baaaaaaaaaaaaaaaaaaaaar
+        :   baaaaaaaaaaaaaaaaaaaaaz
+    ]
+
+const decorated = (arg, ignoreRequestError) => {
+    return (
+        (
+            typeof arg === "string" ||
+            (arg && arg.valueOf && typeof arg.valueOf() === "string")
+        ) ?
+            $delegate(arg, ignoreRequestError)
+        :   handleAsyncOperations(arg, ignoreRequestError)).foo()
+}
+
+bifornCringerMoshedPerplexSawder = fn(
+    (glimseGlyphsHazardNoopsTieTie === 0 ?
+        averredBathersBoxroomBuggyNurl
+    :   anodyneCondosMalateOverateRetinol
+    ).prop,
+)
+
+fn(
+    (glimseGlyphsHazardNoopsTieTie === 0 ?
+        averredBathersBoxroomBuggyNurl
+    :   anodyneCondosMalateOverateRetinol
+    ).prop,
+)
+
+bifornCringerMoshedPerplexSawder = fn?.(
+    (glimseGlyphsHazardNoopsTieTie === 0 ?
+        averredBathersBoxroomBuggyNurl
+    :   anodyneCondosMalateOverateRetinol
+    ).prop,
+)
+
+fn?.(
+    (glimseGlyphsHazardNoopsTieTie === 0 ?
+        averredBathersBoxroomBuggyNurl
+    :   anodyneCondosMalateOverateRetinol
+    ).prop,
+)
+
+bifornCringerMoshedPerplexSawder =
+    fn[
+        (glimseGlyphsHazardNoopsTieTie === 0 ?
+            averredBathersBoxroomBuggyNurl
+        :   anodyneCondosMalateOverateRetinol
+        ).prop
+    ]
+
+fn[
+    (glimseGlyphsHazardNoopsTieTie === 0 ?
+        averredBathersBoxroomBuggyNurl
+    :   anodyneCondosMalateOverateRetinol
+    ).prop
+]
+
+bifornCringerMoshedPerplexSawder =
+    fn?.[
+        (glimseGlyphsHazardNoopsTieTie === 0 ?
+            averredBathersBoxroomBuggyNurl
+        :   anodyneCondosMalateOverateRetinol
+        ).prop
+    ]
+
+fn?.[
+    (glimseGlyphsHazardNoopsTieTie === 0 ?
+        averredBathersBoxroomBuggyNurl
+    :   anodyneCondosMalateOverateRetinol
+    ).prop
+]
 
 ================================================================================
 `;
@@ -8380,6 +9426,273 @@ fn?.[
 ================================================================================
 `;
 
+exports[`nested.js - {"experimentalTernaries":true,"semi":false,"tabWidth":4,"filepath":"no-semi.js"} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel"]
+semi: false
+tabWidth: 4
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+let icecream = what == "cone"
+  ? p => !!p ? \`here's your \${p} cone\` : \`just the empty cone for you\`
+  : p => \`here's your \${p} \${what}\`;
+
+const value = condition1
+? value1
+: condition2
+    ? value2
+    : condition3
+        ? value3
+        : value4;
+
+
+const StorybookLoader = ({ match }) => (
+  match.params.storyId === "button"
+    ? <ButtonStorybook />
+    : match.params.storyId === "color"
+    ? <ColorBook />
+    : match.params.storyId === "typography"
+    ? <TypographyBook />
+    : match.params.storyId === "loading"
+    ? <LoaderStorybook />
+    : match.params.storyId === "deal-list"
+    ? <DealListStory />
+    : (
+      <Message>
+        <Title>{'Missing story book'}</Title>
+        <Content>
+          <BackButton/>
+        </Content>
+      </Message>
+    )
+)
+
+const message =
+    i % 3 === 0 && i % 5 === 0 ?
+        'fizzbuzz'
+    : i % 3 === 0 ?
+        'fizz'
+    : i % 5 === 0 ?
+        'buzz'
+    :
+        String(i)
+
+const paymentMessage = state == 'success'
+  ? 'Payment completed successfully'
+
+: state == 'processing'
+  ? 'Payment processing'
+
+: state == 'invalid_cvc'
+  ? 'There was an issue with your CVC number'
+
+: state == 'invalid_expiry'
+  ? 'Expiry must be sometime in the past.'
+
+  : 'There was an issue with the payment.  Please contact support.'
+
+const paymentMessage2 = state == 'success'
+  ? 1 //'Payment completed successfully'
+
+: state == 'processing'
+  ? 2 //'Payment processing'
+
+: state == 'invalid_cvc'
+  ? 3 //'There was an issue with your CVC number'
+
+: true //state == 'invalid_expiry'
+  ? 4 //'Expiry must be sometime in the past.'
+
+  : 5 // 'There was an issue with the payment.  Please contact support.'
+
+const foo = <div className={'match-achievement-medal-type type' + (medals[0].record ? '-record' : (medals[0].unique ? '-unique' : medals[0].type))}>
+	{medals[0].record ? (
+		i18n('Record')
+	) : medals[0].unique ? (
+		i18n('Unique')
+	) : medals[0].type === 0 ? (
+		i18n('Silver')
+	) : medals[0].type === 1 ? (
+		i18n('Gold')
+	) : medals[0].type === 2 ? (
+		i18n('Platinum')
+	) : (
+		i18n('Theme')
+	)}
+</div>
+
+a
+    ? literalline
+    : {
+      123: 12
+    }
+    ? line
+    : softline
+
+const config = {
+    onFailure: onFailure !== undefined ? onFailure :   (
+      error => {
+          notify(
+              typeof error === 'string' ?
+                  error
+              : error.message || 'ra.notification.http_error',
+              'warning',
+              {
+                  _:
+                      typeof error === 'string' ? error
+                      : error && error.message ? error.message
+                      : undefined,
+              }
+          );
+          refresh();
+      }
+    )
+}
+
+showNotification(
+    typeof error === 'string' ? error :   error.message || body,
+    level || 'warning',
+    {
+        messageArgs,
+        undoable: false,
+    }
+)
+
+const result = children && !isEmptyChildren(children)
+  ? children
+  : props.match
+    ? component
+      ? React.createElement(component, props)
+      : render
+        ? render(props)
+        : null
+    : null;
+
+=====================================output=====================================
+let icecream =
+    what == "cone" ?
+        (p) => (!!p ? \`here's your \${p} cone\` : \`just the empty cone for you\`)
+    :   (p) => \`here's your \${p} \${what}\`
+
+const value =
+    condition1 ? value1
+    : condition2 ? value2
+    : condition3 ? value3
+    : value4
+
+const StorybookLoader = ({ match }) =>
+    match.params.storyId === "button" ? <ButtonStorybook />
+    : match.params.storyId === "color" ? <ColorBook />
+    : match.params.storyId === "typography" ? <TypographyBook />
+    : match.params.storyId === "loading" ? <LoaderStorybook />
+    : match.params.storyId === "deal-list" ? <DealListStory />
+    : <Message>
+            <Title>{"Missing story book"}</Title>
+            <Content>
+                <BackButton />
+            </Content>
+        </Message>
+
+const message =
+    i % 3 === 0 && i % 5 === 0 ? "fizzbuzz"
+    : i % 3 === 0 ? "fizz"
+    : i % 5 === 0 ? "buzz"
+    : String(i)
+
+const paymentMessage =
+    state == "success" ? "Payment completed successfully"
+    : state == "processing" ? "Payment processing"
+    : state == "invalid_cvc" ? "There was an issue with your CVC number"
+    : state == "invalid_expiry" ? "Expiry must be sometime in the past."
+    : "There was an issue with the payment.  Please contact support."
+
+const paymentMessage2 =
+    state == "success" ?
+        1 //'Payment completed successfully'
+    : state == "processing" ?
+        2 //'Payment processing'
+    : state == "invalid_cvc" ?
+        3 //'There was an issue with your CVC number'
+    : (
+        true //state == 'invalid_expiry'
+    ) ?
+        4 //'Expiry must be sometime in the past.'
+    :   5 // 'There was an issue with the payment.  Please contact support.'
+
+const foo = (
+    <div
+        className={
+            "match-achievement-medal-type type" +
+            (medals[0].record ? "-record"
+            : medals[0].unique ? "-unique"
+            : medals[0].type)
+        }
+    >
+        {medals[0].record ?
+            i18n("Record")
+        : medals[0].unique ?
+            i18n("Unique")
+        : medals[0].type === 0 ?
+            i18n("Silver")
+        : medals[0].type === 1 ?
+            i18n("Gold")
+        : medals[0].type === 2 ?
+            i18n("Platinum")
+        :   i18n("Theme")}
+    </div>
+)
+
+;a ? literalline
+: (
+    {
+        123: 12,
+    }
+) ?
+    line
+:   softline
+
+const config = {
+    onFailure:
+        onFailure !== undefined ? onFailure : (
+            (error) => {
+                notify(
+                    typeof error === "string" ? error : (
+                        error.message || "ra.notification.http_error"
+                    ),
+                    "warning",
+                    {
+                        _:
+                            typeof error === "string" ? error
+                            : error && error.message ? error.message
+                            : undefined,
+                    },
+                )
+                refresh()
+            }
+        ),
+}
+
+showNotification(
+    typeof error === "string" ? error : error.message || body,
+    level || "warning",
+    {
+        messageArgs,
+        undoable: false,
+    },
+)
+
+const result =
+    children && !isEmptyChildren(children) ? children
+    : props.match ?
+        component ? React.createElement(component, props)
+        : render ? render(props)
+        : null
+    :   null
+
+================================================================================
+`;
+
 exports[`nested.js - {"experimentalTernaries":true,"tabWidth":4} format 1`] = `
 ====================================options=====================================
 experimentalTernaries: true
@@ -10584,6 +11897,92 @@ const result =
 ================================================================================
 `;
 
+exports[`nested-in-condition.js - {"experimentalTernaries":true,"semi":false,"tabWidth":4,"filepath":"no-semi.js"} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel"]
+semi: false
+tabWidth: 4
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+$var = ($number % 10 >= 2 && ($number % 100 < 10 || $number % 100 >= 20)
+? kochabCooieGameOnOboleUnweave
+: annularCooeedSplicesWalksWayWay)
+  ? anodyneCondosMalateOverateRetinol
+  : averredBathersBoxroomBuggyNurl;
+
+const value = (bifornCringerMoshedPerplexSawder
+? askTrovenaBeenaDependsRowans
+: glimseGlyphsHazardNoopsTieTie)
+  ? true
+    ? true
+    : false
+  : true
+  ? true
+  : false;
+
+(bifornCringerMoshedPerplexSawder ? (
+  askTrovenaBeenaDependsRowans
+) : (
+  glimseGlyphsHazardNoopsTieTie
+)) ? (
+  <Element>
+    <Sub />
+    <Sub />
+    <Sub />
+    <Sub />
+    <Sub />
+    <Sub />
+  </Element>
+) : (
+  <Element2>
+    <Sub />
+    <Sub />
+    <Sub />
+  </Element2>
+);
+
+=====================================output=====================================
+$var =
+    (
+        $number % 10 >= 2 && ($number % 100 < 10 || $number % 100 >= 20) ?
+            kochabCooieGameOnOboleUnweave
+        :   annularCooeedSplicesWalksWayWay
+    ) ?
+        anodyneCondosMalateOverateRetinol
+    :   averredBathersBoxroomBuggyNurl
+
+const value =
+    (
+        bifornCringerMoshedPerplexSawder ? askTrovenaBeenaDependsRowans
+        :   glimseGlyphsHazardNoopsTieTie
+    ) ?
+        true ? true
+        :   false
+    : true ? true
+    : false
+
+;(
+    bifornCringerMoshedPerplexSawder ? askTrovenaBeenaDependsRowans
+    :   glimseGlyphsHazardNoopsTieTie
+) ?
+    <Element>
+        <Sub />
+        <Sub />
+        <Sub />
+        <Sub />
+        <Sub />
+        <Sub />
+    </Element>
+:   <Element2>
+        <Sub />
+        <Sub />
+        <Sub />
+    </Element2>
+
+================================================================================
+`;
+
 exports[`nested-in-condition.js - {"experimentalTernaries":true,"tabWidth":4} format 1`] = `
 ====================================options=====================================
 experimentalTernaries: true
@@ -11276,6 +12675,352 @@ const value = (
 ================================================================================
 `;
 
+exports[`no-semi.js - {"experimentalTernaries":true,"semi":false,"tabWidth":4,"filepath":"no-semi.js"} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel"]
+semi: false
+tabWidth: 4
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// https://github.com/prettier/prettier/issues/18965
+// no-semi + experimental-ternaries: leading semicolon must be preserved when
+// the ternary condition wraps in parens (ifBreak) to avoid ASI hazard.
+
+let o = 1;
+(
+    1 ||
+    12345678901234567890123456789012345678901234567890123456789012345678901234567890
+) ?
+    2
+:   3
+
+=====================================output=====================================
+// https://github.com/prettier/prettier/issues/18965
+// no-semi + experimental-ternaries: leading semicolon must be preserved when
+// the ternary condition wraps in parens (ifBreak) to avoid ASI hazard.
+
+let o = 1
+;(
+    1 ||
+    12345678901234567890123456789012345678901234567890123456789012345678901234567890
+) ?
+    2
+:   3
+
+================================================================================
+`;
+
+exports[`no-semi.js - {"experimentalTernaries":true,"tabWidth":4} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "flow", "typescript"]
+tabWidth: 4
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// https://github.com/prettier/prettier/issues/18965
+// no-semi + experimental-ternaries: leading semicolon must be preserved when
+// the ternary condition wraps in parens (ifBreak) to avoid ASI hazard.
+
+let o = 1;
+(
+    1 ||
+    12345678901234567890123456789012345678901234567890123456789012345678901234567890
+) ?
+    2
+:   3
+
+=====================================output=====================================
+// https://github.com/prettier/prettier/issues/18965
+// no-semi + experimental-ternaries: leading semicolon must be preserved when
+// the ternary condition wraps in parens (ifBreak) to avoid ASI hazard.
+
+let o = 1;
+(
+    1 ||
+    12345678901234567890123456789012345678901234567890123456789012345678901234567890
+) ?
+    2
+:   3;
+
+================================================================================
+`;
+
+exports[`no-semi.js - {"experimentalTernaries":true,"useTabs":true,"tabWidth":4} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "flow", "typescript"]
+tabWidth: 4
+useTabs: true
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// https://github.com/prettier/prettier/issues/18965
+// no-semi + experimental-ternaries: leading semicolon must be preserved when
+// the ternary condition wraps in parens (ifBreak) to avoid ASI hazard.
+
+let o = 1;
+(
+    1 ||
+    12345678901234567890123456789012345678901234567890123456789012345678901234567890
+) ?
+    2
+:   3
+
+=====================================output=====================================
+// https://github.com/prettier/prettier/issues/18965
+// no-semi + experimental-ternaries: leading semicolon must be preserved when
+// the ternary condition wraps in parens (ifBreak) to avoid ASI hazard.
+
+let o = 1;
+(
+	1 ||
+	12345678901234567890123456789012345678901234567890123456789012345678901234567890
+) ?
+	2
+:	3;
+
+================================================================================
+`;
+
+exports[`no-semi.js - {"experimentalTernaries":true,"useTabs":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "flow", "typescript"]
+useTabs: true
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// https://github.com/prettier/prettier/issues/18965
+// no-semi + experimental-ternaries: leading semicolon must be preserved when
+// the ternary condition wraps in parens (ifBreak) to avoid ASI hazard.
+
+let o = 1;
+(
+    1 ||
+    12345678901234567890123456789012345678901234567890123456789012345678901234567890
+) ?
+    2
+:   3
+
+=====================================output=====================================
+// https://github.com/prettier/prettier/issues/18965
+// no-semi + experimental-ternaries: leading semicolon must be preserved when
+// the ternary condition wraps in parens (ifBreak) to avoid ASI hazard.
+
+let o = 1;
+(
+	1 ||
+	12345678901234567890123456789012345678901234567890123456789012345678901234567890
+) ?
+	2
+:	3;
+
+================================================================================
+`;
+
+exports[`no-semi.js - {"experimentalTernaries":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// https://github.com/prettier/prettier/issues/18965
+// no-semi + experimental-ternaries: leading semicolon must be preserved when
+// the ternary condition wraps in parens (ifBreak) to avoid ASI hazard.
+
+let o = 1;
+(
+    1 ||
+    12345678901234567890123456789012345678901234567890123456789012345678901234567890
+) ?
+    2
+:   3
+
+=====================================output=====================================
+// https://github.com/prettier/prettier/issues/18965
+// no-semi + experimental-ternaries: leading semicolon must be preserved when
+// the ternary condition wraps in parens (ifBreak) to avoid ASI hazard.
+
+let o = 1;
+(
+  1 ||
+  12345678901234567890123456789012345678901234567890123456789012345678901234567890
+) ?
+  2
+: 3;
+
+================================================================================
+`;
+
+exports[`no-semi.js - {"tabWidth":4} format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+tabWidth: 4
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// https://github.com/prettier/prettier/issues/18965
+// no-semi + experimental-ternaries: leading semicolon must be preserved when
+// the ternary condition wraps in parens (ifBreak) to avoid ASI hazard.
+
+let o = 1;
+(
+    1 ||
+    12345678901234567890123456789012345678901234567890123456789012345678901234567890
+) ?
+    2
+:   3
+
+=====================================output=====================================
+// https://github.com/prettier/prettier/issues/18965
+// no-semi + experimental-ternaries: leading semicolon must be preserved when
+// the ternary condition wraps in parens (ifBreak) to avoid ASI hazard.
+
+let o = 1;
+1 ||
+12345678901234567890123456789012345678901234567890123456789012345678901234567890
+    ? 2
+    : 3;
+
+================================================================================
+`;
+
+exports[`no-semi.js - {"useTabs":true,"tabWidth":4} format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+tabWidth: 4
+useTabs: true
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// https://github.com/prettier/prettier/issues/18965
+// no-semi + experimental-ternaries: leading semicolon must be preserved when
+// the ternary condition wraps in parens (ifBreak) to avoid ASI hazard.
+
+let o = 1;
+(
+    1 ||
+    12345678901234567890123456789012345678901234567890123456789012345678901234567890
+) ?
+    2
+:   3
+
+=====================================output=====================================
+// https://github.com/prettier/prettier/issues/18965
+// no-semi + experimental-ternaries: leading semicolon must be preserved when
+// the ternary condition wraps in parens (ifBreak) to avoid ASI hazard.
+
+let o = 1;
+1 ||
+12345678901234567890123456789012345678901234567890123456789012345678901234567890
+	? 2
+	: 3;
+
+================================================================================
+`;
+
+exports[`no-semi.js - {"useTabs":true} format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+useTabs: true
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// https://github.com/prettier/prettier/issues/18965
+// no-semi + experimental-ternaries: leading semicolon must be preserved when
+// the ternary condition wraps in parens (ifBreak) to avoid ASI hazard.
+
+let o = 1;
+(
+    1 ||
+    12345678901234567890123456789012345678901234567890123456789012345678901234567890
+) ?
+    2
+:   3
+
+=====================================output=====================================
+// https://github.com/prettier/prettier/issues/18965
+// no-semi + experimental-ternaries: leading semicolon must be preserved when
+// the ternary condition wraps in parens (ifBreak) to avoid ASI hazard.
+
+let o = 1;
+1 ||
+12345678901234567890123456789012345678901234567890123456789012345678901234567890
+	? 2
+	: 3;
+
+================================================================================
+`;
+
+exports[`no-semi.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// https://github.com/prettier/prettier/issues/18965
+// no-semi + experimental-ternaries: leading semicolon must be preserved when
+// the ternary condition wraps in parens (ifBreak) to avoid ASI hazard.
+
+let o = 1;
+(
+    1 ||
+    12345678901234567890123456789012345678901234567890123456789012345678901234567890
+) ?
+    2
+:   3
+
+=====================================output=====================================
+// https://github.com/prettier/prettier/issues/18965
+// no-semi + experimental-ternaries: leading semicolon must be preserved when
+// the ternary condition wraps in parens (ifBreak) to avoid ASI hazard.
+
+let o = 1;
+1 ||
+12345678901234567890123456789012345678901234567890123456789012345678901234567890
+  ? 2
+  : 3;
+
+================================================================================
+`;
+
+exports[`parenthesis.js - {"experimentalTernaries":true,"semi":false,"tabWidth":4,"filepath":"no-semi.js"} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel"]
+semi: false
+tabWidth: 4
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+debug ? this.state.isVisible ? "partially visible" : "hidden" : null;
+debug ? this.state.isVisible && somethingComplex ? "partially visible" : "hidden" : null;
+
+a => a ? () => {a} : () => {a}
+a => a ? a : a
+a => a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a
+
+=====================================output=====================================
+;debug ?
+    this.state.isVisible ?
+        "partially visible"
+    :   "hidden"
+:   null
+;debug ?
+    this.state.isVisible && somethingComplex ?
+        "partially visible"
+    :   "hidden"
+:   null
+
+;(a) =>
+    a ?
+        () => {
+            a
+        }
+    :   () => {
+            a
+        }
+;(a) => (a ? a : a)
+;(a) =>
+    a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a
+
+================================================================================
+`;
+
 exports[`parenthesis.js - {"experimentalTernaries":true,"tabWidth":4} format 1`] = `
 ====================================options=====================================
 experimentalTernaries: true
@@ -11580,6 +13325,72 @@ debug
 (a) => (a ? a : a);
 (a) =>
   a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a;
+
+================================================================================
+`;
+
+exports[`test.js - {"experimentalTernaries":true,"semi":false,"tabWidth":4,"filepath":"no-semi.js"} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel"]
+semi: false
+tabWidth: 4
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+const obj0 = conditionIsTruthy ? shortThing : otherShortThing
+
+const obj1 = conditionIsTruthy ? { some: 'long', object: 'with', lots: 'of', stuff } : shortThing
+
+const obj2 = conditionIsTruthy ? shortThing : { some: 'long', object: 'with', lots: 'of', stuff }
+
+const obj3 = conditionIsTruthy ? { some: 'eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger', object: 'with', lots: 'of', stuff } : shortThing
+
+const obj4 = conditionIsTruthy ? shortThing : { some: 'eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger', object: 'with', lots: 'of', stuff }
+
+const obj5 = conditionIsTruthy ? { some: 'long', object: 'with', lots: 'of', stuff } : { some: 'eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger', object: 'with', lots: 'of', stuff }
+
+=====================================output=====================================
+const obj0 = conditionIsTruthy ? shortThing : otherShortThing
+
+const obj1 =
+    conditionIsTruthy ?
+        { some: "long", object: "with", lots: "of", stuff }
+    :   shortThing
+
+const obj2 =
+    conditionIsTruthy ? shortThing : (
+        { some: "long", object: "with", lots: "of", stuff }
+    )
+
+const obj3 =
+    conditionIsTruthy ?
+        {
+            some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
+            object: "with",
+            lots: "of",
+            stuff,
+        }
+    :   shortThing
+
+const obj4 =
+    conditionIsTruthy ? shortThing : (
+        {
+            some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
+            object: "with",
+            lots: "of",
+            stuff,
+        }
+    )
+
+const obj5 =
+    conditionIsTruthy ?
+        { some: "long", object: "with", lots: "of", stuff }
+    :   {
+            some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
+            object: "with",
+            lots: "of",
+            stuff,
+        }
 
 ================================================================================
 `;

--- a/tests/format/js/ternaries/format.test.js
+++ b/tests/format/js/ternaries/format.test.js
@@ -22,3 +22,9 @@ runFormatTest(import.meta, ["babel", "flow", "typescript"], {
   useTabs: true,
   tabWidth: 4,
 });
+runFormatTest(import.meta, ["babel"], {
+  experimentalTernaries: true,
+  semi: false,
+  tabWidth: 4,
+  filepath: "no-semi.js",
+});

--- a/tests/format/js/ternaries/no-semi.js
+++ b/tests/format/js/ternaries/no-semi.js
@@ -1,0 +1,11 @@
+// https://github.com/prettier/prettier/issues/18965
+// no-semi + experimental-ternaries: leading semicolon must be preserved when
+// the ternary condition wraps in parens (ifBreak) to avoid ASI hazard.
+
+let o = 1;
+(
+    1 ||
+    12345678901234567890123456789012345678901234567890123456789012345678901234567890
+) ?
+    2
+:   3


### PR DESCRIPTION
## Summary

Closes #18965

When `semi: false` and `experimentalTernaries: true` are both active, a `ConditionalExpression` at statement level fails to get a leading semicolon, producing broken output like:

```js
// Input
let o = 1;
(1 || veryLongCondition) ? 2 : 3

// Broken output (ASI failure — treats `1` as a function)
let o = 1
(
    1 ||
    veryLongCondition
) ?
    2
:   3

// Expected output
let o = 1
;(
    1 ||
    veryLongCondition
) ?
    2
:   3
```

**Root cause:** `experimentalTernaries` wraps the ternary test with `ifBreak("(")` at the document level (not the AST level). `expressionNeedsAsiProtection` only inspects AST node types, so it doesn't see this `(` and skips adding the protective semicolon.

**Fix:** Add a `ConditionalExpression` case to `expressionNeedsAsiProtection` that returns `true` when `options.experimentalTernaries` is enabled, since the test will be wrapped in `(` on break.

## Test plan

- [x] Added `tests/format/js/ternaries/no-semi.js` fixture with the exact repro from the issue
- [x] Added `runFormatTest` run with `experimentalTernaries: true, semi: false, tabWidth: 4`
- [x] Snapshot shows `;(` correctly in the output
- [x] All 1232 existing tests continue to pass