### PR TITLE
Add tests for Flow readonly variance with reserved-word properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "get-east-asian-width": "1.4.0",
     "get-stdin": "9.0.0",
     "graphql": "16.13.2",
-    "hermes-parser": "0.35.0",
+    "hermes-parser": "0.36.0",
     "html-element-attributes": "3.5.0",
     "html-ua-styles": "0.3.1",
     "ignore": "7.0.5",

--- a/tests/format/flow/variance/__snapshots__/format.test.js.snap
+++ b/tests/format/flow/variance/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`variance.js format 1`] = `
 ====================================options=====================================
-parsers: ["flow"]
+parsers: ["flow", "hermes"]
                                                       printWidth: 80 (default) |
 =====================================input======================================
 class Route {
@@ -24,6 +24,13 @@ type ReadonlyInterface = interface {
       readonly   prop:   string
 };
 
+type ReadonlyReservedWords = {
+  readonly   with:   string,
+  readonly   default?:   string,
+  readonly   enum:   number,
+  readonly   new:   boolean,
+};
+
 =====================================output=====================================
 class Route {
   static +param: T;
@@ -42,6 +49,13 @@ type ReadonlyTuple = [readonly label: number];
 
 type ReadonlyInterface = interface {
   readonly prop: string,
+};
+
+type ReadonlyReservedWords = {
+  readonly with: string,
+  readonly default?: string,
+  readonly enum: number,
+  readonly new: boolean,
 };
 
 ================================================================================

--- a/tests/format/flow/variance/format.test.js
+++ b/tests/format/flow/variance/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ["flow"]);
+runFormatTest(import.meta, ["flow", "hermes"]);

--- a/tests/format/flow/variance/variance.js
+++ b/tests/format/flow/variance/variance.js
@@ -16,3 +16,10 @@ type ReadonlyTuple = [  readonly   label:   number  ];
 type ReadonlyInterface = interface {
       readonly   prop:   string
 };
+
+type ReadonlyReservedWords = {
+  readonly   with:   string,
+  readonly   default?:   string,
+  readonly   enum:   number,
+  readonly   new:   boolean,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5584,19 +5584,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hermes-estree@npm:0.35.0":
-  version: 0.35.0
-  resolution: "hermes-estree@npm:0.35.0"
-  checksum: 10/d10283d0189ab2270ecae08632ed4f15eb79f206add4960d198aa6efd5686e1c92ed37c17a020c730281e46ff2f56661f3d787bdfb1692218c1495b329049747
+"hermes-estree@npm:0.36.0":
+  version: 0.36.0
+  resolution: "hermes-estree@npm:0.36.0"
+  checksum: 10/76f3fec9700a8ccb299cf53be22cd9038caf3bfba711370dd24f276444c1ed3c38c27fedd3097f6d9cccaa4dfaa4d02de0f8f02e208ab3fb00c97f8845b8aac5
   languageName: node
   linkType: hard
 
-"hermes-parser@npm:0.35.0":
-  version: 0.35.0
-  resolution: "hermes-parser@npm:0.35.0"
+"hermes-parser@npm:0.36.0":
+  version: 0.36.0
+  resolution: "hermes-parser@npm:0.36.0"
   dependencies:
-    hermes-estree: "npm:0.35.0"
-  checksum: 10/62be25fa41b708db21c4db9153b0d60cfbf9bd4645f1712eb559b3be8c191266b5b381df60fbbc45416799f73c2361eb69a81eead21dc5159fe2ea72f946d5f7
+    hermes-estree: "npm:0.36.0"
+  checksum: 10/81150c00bd8da17187f421a75e6e427187465386681427024f3dc51de996c44cee18fb062d95254028aa1f4ffcdbe7cbdeda50e6edece5c378c9f909067f5bae
   languageName: node
   linkType: hard
 
@@ -8646,7 +8646,7 @@ __metadata:
     gfm-test-suite: "npm:0.0.2"
     globals: "npm:17.4.0"
     graphql: "npm:16.13.2"
-    hermes-parser: "npm:0.35.0"
+    hermes-parser: "npm:0.36.0"
     html-element-attributes: "npm:3.5.0"
     html-ua-styles: "npm:0.3.1"
     ignore: "npm:7.0.5"


### PR DESCRIPTION
## Description

Add formatting tests for `readonly` modifier before reserved-word property names in Flow object types (`with`, `default`, `enum`, `new`). Also add hermes parser to the variance test suite — hermes-parser 0.36.0 added support for `readonly` before reserved-word property names.

Depends on #19096.

## Checklist

- [x] I've added tests to confirm my change works.
- [x] (If changing the API or CLI) I've documented the changes I've made (in the `docs/` directory).
- [x] (If the change is user-facing) I've added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I've read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).