### PR TITLE
Add tests for Flow readonly variance with reserved-word properties

### DIFF
--- a/tests/format/flow/variance/__snapshots__/format.test.js.snap
+++ b/tests/format/flow/variance/__snapshots__/format.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`variance.js format 1`] = `
 ====================================options=====================================
-parsers: ["flow"]
+parsers: ["flow", "hermes"]
                                                       printWidth: 80 (default) |
 =====================================input======================================
 class Route {
@@ -24,6 +24,13 @@ type ReadonlyInterface = interface {
       readonly   prop:   string
 };
 
+type ReadonlyReservedWords = {
+  readonly   with:   string,
+  readonly   default?:   string,
+  readonly   enum:   number,
+  readonly   new:   boolean,
+};
+
 =====================================output=====================================
 class Route {
   static +param: T;
@@ -42,6 +49,13 @@ type ReadonlyTuple = [readonly label: number];
 
 type ReadonlyInterface = interface {
   readonly prop: string,
+};
+
+type ReadonlyReservedWords = {
+  readonly with: string,
+  readonly default?: string,
+  readonly enum: number,
+  readonly new: boolean,
 };
 
 ================================================================================

--- a/tests/format/flow/variance/format.test.js
+++ b/tests/format/flow/variance/format.test.js
@@ -1,1 +1,1 @@
-runFormatTest(import.meta, ["flow"]);
+runFormatTest(import.meta, ["flow", "hermes"]);

--- a/tests/format/flow/variance/variance.js
+++ b/tests/format/flow/variance/variance.js
@@ -16,3 +16,10 @@ type ReadonlyTuple = [  readonly   label:   number  ];
 type ReadonlyInterface = interface {
       readonly   prop:   string
 };
+
+type ReadonlyReservedWords = {
+  readonly   with:   string,
+  readonly   default?:   string,
+  readonly   enum:   number,
+  readonly   new:   boolean,
+};


### PR DESCRIPTION
## Description

Add formatting tests for `readonly` modifier before reserved-word property names in Flow object types (`with`, `default`, `enum`, `new`). Also add hermes parser to the variance test suite — hermes-parser 0.36.0 added support for `readonly` before reserved-word property names.

Depends on #19096.

## Checklist

- [x] I've added tests to confirm my change works.
- [x] (If changing the API or CLI) I've documented the changes I've made (in the `docs/` directory).
- [x] (If the change is user-facing) I've added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I've read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).