### PR TITLE
Add support for `writeonly` Flow variance modifier

### DIFF
--- a/changelog_unreleased/flow/19099.md
+++ b/changelog_unreleased/flow/19099.md
@@ -1,4 +1,4 @@
-#### Add support for `writeonly` variance modifier (#XXXX by @marcoww6)
+#### Add support for `writeonly` variance modifier (#19099 by @marcoww6)
 
 <!-- prettier-ignore -->
 ```jsx

--- a/changelog_unreleased/flow/XXXX.md
+++ b/changelog_unreleased/flow/XXXX.md
@@ -1,0 +1,13 @@
+#### Add support for `writeonly` variance modifier (#XXXX by @marcoww6)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+type T = {writeonly foo: string};
+
+// Prettier stable
+// SyntaxError
+
+// Prettier main
+type T = { writeonly foo: string };
+```

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "get-east-asian-width": "1.4.0",
     "get-stdin": "9.0.0",
     "graphql": "16.13.2",
-    "hermes-parser": "0.35.0",
+    "hermes-parser": "0.36.0",
     "html-element-attributes": "3.5.0",
     "html-ua-styles": "0.3.1",
     "ignore": "7.0.5",

--- a/src/language-js/print/flow.js
+++ b/src/language-js/print/flow.js
@@ -218,7 +218,12 @@ function printFlow(path, options, print, args) {
       return ["?", print("typeAnnotation")];
     case "Variance": {
       const { kind } = node;
-      assert.ok(kind === "plus" || kind === "minus" || kind === "readonly");
+      assert.ok(
+        kind === "plus" ||
+          kind === "minus" ||
+          kind === "readonly" ||
+          kind === "writeonly",
+      );
       return kind === "plus" ? "+" : kind === "minus" ? "-" : `${kind} `;
     }
     case "KeyofTypeAnnotation":

--- a/src/language-js/print/flow.js
+++ b/src/language-js/print/flow.js
@@ -222,7 +222,9 @@ function printFlow(path, options, print, args) {
         kind === "plus" ||
           kind === "minus" ||
           kind === "readonly" ||
-          kind === "writeonly",
+          kind === "writeonly" ||
+          kind === "in" ||
+          kind === "out",
       );
       return kind === "plus" ? "+" : kind === "minus" ? "-" : `${kind} `;
     }

--- a/tests/config/format-test/verify-fixtures.js
+++ b/tests/config/format-test/verify-fixtures.js
@@ -24,7 +24,7 @@ const categoryParsers = new Map([
   [
     "flow",
     {
-      parsers: ["flow", "babel-flow"],
+      parsers: ["flow", "babel-flow", "hermes"],
       verifyParsers: [
         "flow",
         "babel-flow",

--- a/tests/format/flow/in-out-variance/__snapshots__/format.test.js.snap
+++ b/tests/format/flow/in-out-variance/__snapshots__/format.test.js.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`in-out-variance.js format 1`] = `
+====================================options=====================================
+parsers: ["hermes"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+type Contravariant<  in   T  > = T;
+
+type Covariant<  out   T  > = T;
+
+type Mixed<  in   T,   out   U  > = T;
+
+type InNamedIn<  in   in  > = void;
+
+type OutNamedOut<  out   out  > = void;
+
+type InWithBound<  in   T:   number  > = T;
+
+type OutWithDefault<  out   T  =   string  > = T;
+
+=====================================output=====================================
+type Contravariant<in T> = T;
+
+type Covariant<out T> = T;
+
+type Mixed<in T, out U> = T;
+
+type InNamedIn<in in> = void;
+
+type OutNamedOut<out out> = void;
+
+type InWithBound<in T: number> = T;
+
+type OutWithDefault<out T = string> = T;
+
+================================================================================
+`;

--- a/tests/format/flow/in-out-variance/format.test.js
+++ b/tests/format/flow/in-out-variance/format.test.js
@@ -1,0 +1,1 @@
+runFormatTest(import.meta, ["hermes"]);

--- a/tests/format/flow/in-out-variance/in-out-variance.js
+++ b/tests/format/flow/in-out-variance/in-out-variance.js
@@ -1,0 +1,13 @@
+type Contravariant<  in   T  > = T;
+
+type Covariant<  out   T  > = T;
+
+type Mixed<  in   T,   out   U  > = T;
+
+type InNamedIn<  in   in  > = void;
+
+type OutNamedOut<  out   out  > = void;
+
+type InWithBound<  in   T:   number  > = T;
+
+type OutWithDefault<  out   T  =   string  > = T;

--- a/tests/format/flow/writeonly/__snapshots__/format.test.js.snap
+++ b/tests/format/flow/writeonly/__snapshots__/format.test.js.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`writeonly.js format 1`] = `
+====================================options=====================================
+parsers: ["hermes"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+type WriteonlyObj = {
+    writeonly   foo:   string,
+  writeonly [string]:   unknown
+};
+
+type WriteonlyReservedWords = {
+  writeonly   with:   string,
+  writeonly   default?:   string,
+};
+
+=====================================output=====================================
+type WriteonlyObj = {
+  writeonly foo: string,
+  writeonly [string]: unknown,
+};
+
+type WriteonlyReservedWords = {
+  writeonly with: string,
+  writeonly default?: string,
+};
+
+================================================================================
+`;

--- a/tests/format/flow/writeonly/format.test.js
+++ b/tests/format/flow/writeonly/format.test.js
@@ -1,0 +1,1 @@
+runFormatTest(import.meta, ["hermes"]);

--- a/tests/format/flow/writeonly/writeonly.js
+++ b/tests/format/flow/writeonly/writeonly.js
@@ -1,0 +1,9 @@
+type WriteonlyObj = {
+    writeonly   foo:   string,
+  writeonly [string]:   unknown
+};
+
+type WriteonlyReservedWords = {
+  writeonly   with:   string,
+  writeonly   default?:   string,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5584,19 +5584,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hermes-estree@npm:0.35.0":
-  version: 0.35.0
-  resolution: "hermes-estree@npm:0.35.0"
-  checksum: 10/d10283d0189ab2270ecae08632ed4f15eb79f206add4960d198aa6efd5686e1c92ed37c17a020c730281e46ff2f56661f3d787bdfb1692218c1495b329049747
+"hermes-estree@npm:0.36.0":
+  version: 0.36.0
+  resolution: "hermes-estree@npm:0.36.0"
+  checksum: 10/76f3fec9700a8ccb299cf53be22cd9038caf3bfba711370dd24f276444c1ed3c38c27fedd3097f6d9cccaa4dfaa4d02de0f8f02e208ab3fb00c97f8845b8aac5
   languageName: node
   linkType: hard
 
-"hermes-parser@npm:0.35.0":
-  version: 0.35.0
-  resolution: "hermes-parser@npm:0.35.0"
+"hermes-parser@npm:0.36.0":
+  version: 0.36.0
+  resolution: "hermes-parser@npm:0.36.0"
   dependencies:
-    hermes-estree: "npm:0.35.0"
-  checksum: 10/62be25fa41b708db21c4db9153b0d60cfbf9bd4645f1712eb559b3be8c191266b5b381df60fbbc45416799f73c2361eb69a81eead21dc5159fe2ea72f946d5f7
+    hermes-estree: "npm:0.36.0"
+  checksum: 10/81150c00bd8da17187f421a75e6e427187465386681427024f3dc51de996c44cee18fb062d95254028aa1f4ffcdbe7cbdeda50e6edece5c378c9f909067f5bae
   languageName: node
   linkType: hard
 
@@ -8646,7 +8646,7 @@ __metadata:
     gfm-test-suite: "npm:0.0.2"
     globals: "npm:17.4.0"
     graphql: "npm:16.13.2"
-    hermes-parser: "npm:0.35.0"
+    hermes-parser: "npm:0.36.0"
     html-element-attributes: "npm:3.5.0"
     html-ua-styles: "npm:0.3.1"
     ignore: "npm:7.0.5"


### PR DESCRIPTION
## Description

Add support for the `writeonly` variance modifier on Flow object type properties and indexers. This is a new syntax feature in hermes-parser 0.36.0.

```js
type T = { writeonly foo: string };
type T = { writeonly [string]: unknown };
```

Depends on #19096.

## Checklist

- [x] I've added tests to confirm my change works.
- [x] (If changing the API or CLI) I've documented the changes I've made (in the `docs/` directory).
- [x] (If the change is user-facing) I've added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I've read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).