### PR TITLE
[Markdown] Keep GFM alert markers on their own line

### DIFF
--- a/changelog_unreleased/markdown/19105.md
+++ b/changelog_unreleased/markdown/19105.md
@@ -8,7 +8,7 @@ Prettier no longer merges a GitHub-flavored Markdown alert marker with the follo
 > [!TIP]
 > Keep the alert marker on its own line.
 
-<!-- Prettier stable -->
+<!-- Prettier stable (--prose-wrap=always) -->
 > [!TIP] Keep the alert marker on its own line.
 
 <!-- Prettier main -->

--- a/changelog_unreleased/markdown/19105.md
+++ b/changelog_unreleased/markdown/19105.md
@@ -1,0 +1,17 @@
+#### Keep GFM alert blockquote markers on their own line (#19105 by @cyphercodes)
+
+Prettier no longer merges a GitHub-flavored Markdown alert marker with the following text when `proseWrap` is `always`.
+
+<!-- prettier-ignore -->
+```md
+<!-- Input -->
+> [!TIP]
+> Keep the alert marker on its own line.
+
+<!-- Prettier stable -->
+> [!TIP] Keep the alert marker on its own line.
+
+<!-- Prettier main -->
+> [!TIP]
+> Keep the alert marker on its own line.
+```

--- a/src/language-markdown/print/paragraph.js
+++ b/src/language-markdown/print/paragraph.js
@@ -1,8 +1,10 @@
 import {
   DOC_TYPE_ARRAY,
   DOC_TYPE_FILL,
+  DOC_TYPE_STRING,
   fill,
   getDocType,
+  hardline,
 } from "../../document/index.js";
 
 /**
@@ -17,8 +19,90 @@ import {
  * @returns {Doc}
  */
 function printParagraph(path, options, print) {
+  if (isGfmAlertBlockquoteHeader(path, options)) {
+    return printGfmAlertBlockquoteHeader(path, print);
+  }
+
   const parts = path.map(print, "children");
   return flattenFill(parts);
+}
+
+const gfmAlertMarkerRegex = /^\[!(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]$/iu;
+
+function isGfmAlertBlockquoteHeader(path, options) {
+  if (options.proseWrap !== "always") {
+    return false;
+  }
+
+  const { node, parent, index } = path;
+  if (parent?.type !== "blockquote" || index !== 0) {
+    return false;
+  }
+
+  const firstChild = node.children[0];
+  if (firstChild?.type !== "sentence") {
+    return false;
+  }
+
+  const [marker, whitespace] = firstChild.children;
+  return (
+    marker?.type === "word" &&
+    gfmAlertMarkerRegex.test(marker.value) &&
+    whitespace?.type === "whitespace" &&
+    whitespace.value === "\n" &&
+    (firstChild.children.length > 2 || node.children.length > 1)
+  );
+}
+
+/**
+ * @param {AstPath} path
+ * @param {*} print
+ * @returns {Doc}
+ */
+function printGfmAlertBlockquoteHeader(path, print) {
+  const [firstChild] = path.node.children;
+  const [marker] = firstChild.children;
+  const parts = [];
+
+  path.each(() => {
+    const { index } = path;
+    parts.push(
+      index === 0 ? printSentenceWithoutGfmAlertHeader(path, print) : print(),
+    );
+  }, "children");
+
+  return [marker.value, hardline, flattenFill(parts)];
+}
+
+/**
+ * @param {AstPath} path
+ * @param {*} print
+ * @returns {Doc}
+ */
+function printSentenceWithoutGfmAlertHeader(path, print) {
+  /** @type {Doc[]} */
+  const parts = [""];
+
+  path.each(() => {
+    if (path.index < 2) {
+      return;
+    }
+
+    const { node } = path;
+    const doc = print();
+    switch (node.type) {
+      case "whitespace":
+        if (getDocType(doc) !== DOC_TYPE_STRING) {
+          parts.push(doc, "");
+          break;
+        }
+      // fallthrough
+      default:
+        parts.push([parts.pop(), doc]);
+    }
+  }, "children");
+
+  return fill(parts);
 }
 
 /**

--- a/tests/format/markdown/blockquote/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/blockquote/__snapshots__/format.test.js.snap
@@ -167,6 +167,85 @@ proseWrap: "preserve"
 ================================================================================
 `;
 
+exports[`gfm-alert.md - {"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+proseWrap: "always"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+> [!TIP]
+> Keep the alert marker on its own line so GitHub renders this blockquote as an alert.
+
+> [!IMPORTANT]
+> Alert content can still wrap when the text is long enough to exceed the configured print width for prose wrapping.
+
+> [!TIP] This is not an alert header because the marker is followed by content on the same line.
+
+=====================================output=====================================
+> [!TIP]
+> Keep the alert marker on its own line so GitHub renders this blockquote as an
+> alert.
+
+> [!IMPORTANT]
+> Alert content can still wrap when the text is long enough to exceed the
+> configured print width for prose wrapping.
+
+> [!TIP] This is not an alert header because the marker is followed by content
+> on the same line.
+
+================================================================================
+`;
+
+exports[`gfm-alert.md - {"proseWrap":"never"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+proseWrap: "never"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+> [!TIP]
+> Keep the alert marker on its own line so GitHub renders this blockquote as an alert.
+
+> [!IMPORTANT]
+> Alert content can still wrap when the text is long enough to exceed the configured print width for prose wrapping.
+
+> [!TIP] This is not an alert header because the marker is followed by content on the same line.
+
+=====================================output=====================================
+> [!TIP] Keep the alert marker on its own line so GitHub renders this blockquote as an alert.
+
+> [!IMPORTANT] Alert content can still wrap when the text is long enough to exceed the configured print width for prose wrapping.
+
+> [!TIP] This is not an alert header because the marker is followed by content on the same line.
+
+================================================================================
+`;
+
+exports[`gfm-alert.md - {"proseWrap":"preserve"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+proseWrap: "preserve"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+> [!TIP]
+> Keep the alert marker on its own line so GitHub renders this blockquote as an alert.
+
+> [!IMPORTANT]
+> Alert content can still wrap when the text is long enough to exceed the configured print width for prose wrapping.
+
+> [!TIP] This is not an alert header because the marker is followed by content on the same line.
+
+=====================================output=====================================
+> [!TIP]
+> Keep the alert marker on its own line so GitHub renders this blockquote as an alert.
+
+> [!IMPORTANT]
+> Alert content can still wrap when the text is long enough to exceed the configured print width for prose wrapping.
+
+> [!TIP] This is not an alert header because the marker is followed by content on the same line.
+
+================================================================================
+`;
+
 exports[`ignore-code.md - {"proseWrap":"always"} format 1`] = `
 ====================================options=====================================
 parsers: ["markdown"]
@@ -817,7 +896,8 @@ proseWrap: "always"
 > proseWrap to \`never\`
 
 =====================================output=====================================
-> [!NOTE] \`DOOM\`
+> [!NOTE]
+> \`DOOM\`
 
 > _b_
 >

--- a/tests/format/markdown/blockquote/gfm-alert.md
+++ b/tests/format/markdown/blockquote/gfm-alert.md
@@ -1,0 +1,7 @@
+> [!TIP]
+> Keep the alert marker on its own line so GitHub renders this blockquote as an alert.
+
+> [!IMPORTANT]
+> Alert content can still wrap when the text is long enough to exceed the configured print width for prose wrapping.
+
+> [!TIP] This is not an alert header because the marker is followed by content on the same line.


### PR DESCRIPTION
## Description

Fixes #19067.

Keeps GFM alert blockquote markers such as `> [!TIP]` on their own line when Markdown is formatted with `proseWrap: "always"`, while still wrapping the alert body normally.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory). (Not applicable.)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).