### PR TITLE
Add @poliklot/prettier-plugin-handlebars to community plugins

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -213,6 +213,7 @@
         "Pipenv",
         "Pipfile",
         "pnpapi",
+        "poliklot",
         "preorder",
         "prettierx",
         "progid",

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -59,6 +59,7 @@ Strings provided to `plugins` are ultimately passed to [`import()` expression](h
 
 ## Community Plugins
 
+- [`@poliklot/prettier-plugin-handlebars`](https://github.com/Poliklot/prettier-plugin-handlebars) by [**@Poliklot**](https://github.com/Poliklot)
 - [`prettier-plugin-apex`](https://github.com/dangmai/prettier-plugin-apex) by [**@dangmai**](https://github.com/dangmai)
 - [`prettier-plugin-astro`](https://github.com/withastro/prettier-plugin-astro) by [**@withastro contributors**](https://github.com/withastro/prettier-plugin-astro/graphs/contributors)
 - [`prettier-plugin-bigcommerce-stencil`](https://github.com/phoenix128/prettier-plugin-bigcommerce-stencil) by [**@phoenix128**](https://github.com/phoenix128)

--- a/website/versioned_docs/version-stable/plugins.md
+++ b/website/versioned_docs/version-stable/plugins.md
@@ -49,6 +49,7 @@ Strings provided to `plugins` are ultimately passed to [`import()` expression](h
 
 ## Community Plugins
 
+- [`@poliklot/prettier-plugin-handlebars`](https://github.com/Poliklot/prettier-plugin-handlebars) by [**@Poliklot**](https://github.com/Poliklot)
 - [`prettier-plugin-apex`](https://github.com/dangmai/prettier-plugin-apex) by [**@dangmai**](https://github.com/dangmai)
 - [`prettier-plugin-astro`](https://github.com/withastro/prettier-plugin-astro) by [**@withastro contributors**](https://github.com/withastro/prettier-plugin-astro/graphs/contributors)
 - [`prettier-plugin-bigcommerce-stencil`](https://github.com/phoenix128/prettier-plugin-bigcommerce-stencil) by [**@phoenix128**](https://github.com/phoenix128)


### PR DESCRIPTION
## Description

- add `@poliklot/prettier-plugin-handlebars` to the community plugins list
- link to the plugin repository and credit the plugin author
- update both the current docs and the stable versioned docs

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

## Validation

- Tests were not run because this is a documentation list update only.
- A changelog entry was not added because this PR only updates documentation.
