### PR TITLE
Add test for await in async component syntax

### DIFF
--- a/tests/format/flow/component/__snapshots__/format.test.js.snap
+++ b/tests/format/flow/component/__snapshots__/format.test.js.snap
@@ -82,6 +82,32 @@ async component MyAsyncComponent(bar: string, baz: number) {
 
 export async component MyExportedAsyncComponent() {}
 
+async component MyAsyncComponentWithAwait() {
+  const   data   =   await   fetchData();
+  return <OtherComponent data={data} />;
+}
+
+async component MyAsyncComponentWithAwaitAndParams(bar:   string,   baz:   number) {
+  const   data   =   await   fetchData(bar,   baz);
+  return <OtherComponent data={data} />;
+}
+
+async component MyAsyncComponentWithAwaitAndRenders(bar: string) renders SomeComponent {
+  const   data   =   await   fetchData(bar);
+  return <OtherComponent data={data} />;
+}
+
+async component MyAsyncComponentWithMultipleAwaits() {
+  const   data   =   await   fetchData();
+  const   processed   =   await   processData(data);
+  return <OtherComponent data={processed} />;
+}
+
+async component MyAsyncComponentWithLongAwait() {
+  const data = await fetchSomeReallllllllllllllllllllllllllllllllllllllyLongFunctionName(argumentOne, argumentTwo, argumentThree);
+  return <OtherComponent data={data} />;
+}
+
 =====================================output=====================================
 component MyComponent() {}
 
@@ -193,6 +219,39 @@ async component MyAsyncComponent(bar: string, baz: number) {
 }
 
 export async component MyExportedAsyncComponent() {}
+
+async component MyAsyncComponentWithAwait() {
+  const data = await fetchData();
+  return <OtherComponent data={data} />;
+}
+
+async component MyAsyncComponentWithAwaitAndParams(bar: string, baz: number) {
+  const data = await fetchData(bar, baz);
+  return <OtherComponent data={data} />;
+}
+
+async component MyAsyncComponentWithAwaitAndRenders(
+  bar: string,
+) renders SomeComponent {
+  const data = await fetchData(bar);
+  return <OtherComponent data={data} />;
+}
+
+async component MyAsyncComponentWithMultipleAwaits() {
+  const data = await fetchData();
+  const processed = await processData(data);
+  return <OtherComponent data={processed} />;
+}
+
+async component MyAsyncComponentWithLongAwait() {
+  const data =
+    await fetchSomeReallllllllllllllllllllllllllllllllllllllyLongFunctionName(
+      argumentOne,
+      argumentTwo,
+      argumentThree,
+    );
+  return <OtherComponent data={data} />;
+}
 
 ================================================================================
 `;

--- a/tests/format/flow/component/component-declaration.js
+++ b/tests/format/flow/component/component-declaration.js
@@ -74,3 +74,29 @@ async component MyAsyncComponent(bar: string, baz: number) {
 }
 
 export async component MyExportedAsyncComponent() {}
+
+async component MyAsyncComponentWithAwait() {
+  const   data   =   await   fetchData();
+  return <OtherComponent data={data} />;
+}
+
+async component MyAsyncComponentWithAwaitAndParams(bar:   string,   baz:   number) {
+  const   data   =   await   fetchData(bar,   baz);
+  return <OtherComponent data={data} />;
+}
+
+async component MyAsyncComponentWithAwaitAndRenders(bar: string) renders SomeComponent {
+  const   data   =   await   fetchData(bar);
+  return <OtherComponent data={data} />;
+}
+
+async component MyAsyncComponentWithMultipleAwaits() {
+  const   data   =   await   fetchData();
+  const   processed   =   await   processData(data);
+  return <OtherComponent data={processed} />;
+}
+
+async component MyAsyncComponentWithLongAwait() {
+  const data = await fetchSomeReallllllllllllllllllllllllllllllllllllllyLongFunctionName(argumentOne, argumentTwo, argumentThree);
+  return <OtherComponent data={data} />;
+}


### PR DESCRIPTION
## Description

`hermes-parser` was updated from 0.36.0 to 0.36.1 in #19122, which added support for `await` expressions inside async Flow component bodies. This PR adds test cases to verify prettier correctly formats this pattern.

Test cases cover:
- Basic `await` with deliberate extra whitespace to verify normalization
- `await` with component parameters
- `await` with `renders` clause
- Multiple sequential `await` expressions
- Long `await` expression that triggers line-breaking

## Checklist

- [x] I've added tests to confirm my change works.
- [ ] (If changing the API or CLI) I've documented the changes I've made (in the `docs/` directory). N/A — no API or CLI changes.
- [ ] (If the change is user-facing) I've added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`. N/A — test-only change, no user-facing formatting difference.
- [x] I've read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).