### PR TITLE
Avoid extra semicolon before TypeScript call signatures

### DIFF
--- a/changelog_unreleased/typescript/19139.md
+++ b/changelog_unreleased/typescript/19139.md
@@ -1,0 +1,22 @@
+#### Avoid extra semicolon before TypeScript call signatures after function-type properties (#19139 by @MapleQiAN)
+
+<!-- prettier-ignore -->
+```ts
+// Input
+export interface MyInterface {
+  method: (value: string) => Promise<string>
+  (value: string): Promise<string>
+}
+
+// Prettier stable
+export interface MyInterface {
+  method: (value: string) => Promise<string>;
+  (value: string): Promise<string>
+}
+
+// Prettier main
+export interface MyInterface {
+  method: (value: string) => Promise<string>
+  (value: string): Promise<string>
+}
+```

--- a/src/language-js/print/class-body.js
+++ b/src/language-js/print/class-body.js
@@ -323,7 +323,7 @@ function shouldPrintSemicolonAfterInterfaceProperty(
 
   switch (nextNode.type) {
     case "TSCallSignatureDeclaration":
-      return true;
+      return node.typeAnnotation?.typeAnnotation.type !== "TSFunctionType";
   }
 
   return false;

--- a/tests/format/typescript/interface/no-semi/18858.ts
+++ b/tests/format/typescript/interface/no-semi/18858.ts
@@ -1,0 +1,11 @@
+export interface MyInterface {
+  someMethod: (a: number) => Promise<number>
+  anotherMethod: (a: string) => Promise<string>
+  (a: string): Promise<string>
+}
+
+type MyType = {
+  someMethod: (a: number) => Promise<number>
+  anotherMethod: (a: string) => Promise<string>
+  (a: string): Promise<string>
+}

--- a/tests/format/typescript/interface/no-semi/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/interface/no-semi/__snapshots__/format.test.js.snap
@@ -185,3 +185,37 @@ type H3 = { foo: X; <T>(): T }
 
 ================================================================================
 `;
+
+exports[`18858.ts - {"semi":false} format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+export interface MyInterface {
+  someMethod: (a: number) => Promise<number>
+  anotherMethod: (a: string) => Promise<string>
+  (a: string): Promise<string>
+}
+
+type MyType = {
+  someMethod: (a: number) => Promise<number>
+  anotherMethod: (a: string) => Promise<string>
+  (a: string): Promise<string>
+}
+
+=====================================output=====================================
+export interface MyInterface {
+  someMethod: (a: number) => Promise<number>
+  anotherMethod: (a: string) => Promise<string>
+  (a: string): Promise<string>
+}
+
+type MyType = {
+  someMethod: (a: number) => Promise<number>
+  anotherMethod: (a: string) => Promise<string>
+  (a: string): Promise<string>
+}
+
+================================================================================
+`;


### PR DESCRIPTION
## Description

Fixes #18858.

This keeps `--no-semi` output from adding a semicolon between a TypeScript property signature with a function type and the following call signature. The existing semicolon behavior is preserved for ambiguous cases where omitting the semicolon would merge a property and call signature into a method signature.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
