### PR TITLE
docs: add docusaurus-plugin-copy-page-button

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -277,7 +277,7 @@ const config = {
       },
     },
 
-  plugins: [llmsTxtPlugin],
+  plugins: [llmsTxtPlugin, "docusaurus-plugin-copy-page-button"],
 
   markdown: {
     hooks: {

--- a/website/package.json
+++ b/website/package.json
@@ -31,7 +31,7 @@
     "clipboard": "2.0.11",
     "clsx": "2.1.1",
     "cm6-graphql": "0.2.1",
-    "docusaurus-plugin-copy-page-button": "0.4.3",
+    "docusaurus-plugin-copy-page-button": "0.5.1",
     "github-buttons": "2.31.1",
     "graphql": "16.13.2",
     "lz-string": "1.5.0",

--- a/website/package.json
+++ b/website/package.json
@@ -31,6 +31,7 @@
     "clipboard": "2.0.11",
     "clsx": "2.1.1",
     "cm6-graphql": "0.2.1",
+    "docusaurus-plugin-copy-page-button": "^0.4.2",
     "github-buttons": "2.31.1",
     "graphql": "16.13.2",
     "lz-string": "1.5.0",

--- a/website/package.json
+++ b/website/package.json
@@ -31,7 +31,7 @@
     "clipboard": "2.0.11",
     "clsx": "2.1.1",
     "cm6-graphql": "0.2.1",
-    "docusaurus-plugin-copy-page-button": "^0.4.2",
+    "docusaurus-plugin-copy-page-button": "0.4.3",
     "github-buttons": "2.31.1",
     "graphql": "16.13.2",
     "lz-string": "1.5.0",

--- a/website/vite.config.mjs
+++ b/website/vite.config.mjs
@@ -9,7 +9,10 @@ const IS_CI = Boolean(process.env.CI);
 const OUT_DIRECTORY = "./static/playground/";
 const cdnDependencies = {
   file: new URL("./package.json", import.meta.url),
-  exclude: new Set(["@docusaurus/preset-classic"]),
+  exclude: new Set([
+    "@docusaurus/preset-classic",
+    "docusaurus-plugin-copy-page-button",
+  ]),
   overrideDependencies: new Map([
     // We don't need deps from `vue`
     ["vue", []],

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -7044,13 +7044,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"docusaurus-plugin-copy-page-button@npm:0.4.3":
-  version: 0.4.3
-  resolution: "docusaurus-plugin-copy-page-button@npm:0.4.3"
+"docusaurus-plugin-copy-page-button@npm:0.5.1":
+  version: 0.5.1
+  resolution: "docusaurus-plugin-copy-page-button@npm:0.5.1"
   peerDependencies:
     "@docusaurus/core": ^3.0.0
     react: ^18.0.0 || ^19.0.0
-  checksum: 10/4b87e5e0fd4cc4b11643e7799c60e976dfbee13c223b50f739ba1ee58037c13c57df762edcdbe2227ea3aa66ce893a78158d09fcc4681aa5571c88ff1201c79c
+  checksum: 10/efab016c1513019376ee866bc4c2db2b97b12138c5d209b3feaf635d98830a20d3956e00a5a7a611aa0b76de8e96dfd1e194c074b81e456585a2fea6aca06ab3
   languageName: node
   linkType: hard
 
@@ -12854,7 +12854,7 @@ __metadata:
     clsx: "npm:2.1.1"
     cm6-graphql: "npm:0.2.1"
     concurrently: "npm:9.2.1"
-    docusaurus-plugin-copy-page-button: "npm:0.4.3"
+    docusaurus-plugin-copy-page-button: "npm:0.5.1"
     github-buttons: "npm:2.31.1"
     graphql: "npm:16.13.2"
     lz-string: "npm:1.5.0"

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -7044,13 +7044,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"docusaurus-plugin-copy-page-button@npm:^0.4.2":
-  version: 0.4.2
-  resolution: "docusaurus-plugin-copy-page-button@npm:0.4.2"
+"docusaurus-plugin-copy-page-button@npm:0.4.3":
+  version: 0.4.3
+  resolution: "docusaurus-plugin-copy-page-button@npm:0.4.3"
   peerDependencies:
     "@docusaurus/core": ^3.0.0
     react: ^18.0.0 || ^19.0.0
-  checksum: 10/e591ff132932e4e2ba028f8b221309a6146d618c005c3fd985e3dffe6f435468d6b88d3ac91f717e46762524451ffc8cef75e1fd6de7ea4692488a3123ebc08b
+  checksum: 10/4b87e5e0fd4cc4b11643e7799c60e976dfbee13c223b50f739ba1ee58037c13c57df762edcdbe2227ea3aa66ce893a78158d09fcc4681aa5571c88ff1201c79c
   languageName: node
   linkType: hard
 
@@ -12854,7 +12854,7 @@ __metadata:
     clsx: "npm:2.1.1"
     cm6-graphql: "npm:0.2.1"
     concurrently: "npm:9.2.1"
-    docusaurus-plugin-copy-page-button: "npm:^0.4.2"
+    docusaurus-plugin-copy-page-button: "npm:0.4.3"
     github-buttons: "npm:2.31.1"
     graphql: "npm:16.13.2"
     lz-string: "npm:1.5.0"

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -7044,6 +7044,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"docusaurus-plugin-copy-page-button@npm:^0.4.2":
+  version: 0.4.2
+  resolution: "docusaurus-plugin-copy-page-button@npm:0.4.2"
+  peerDependencies:
+    "@docusaurus/core": ^3.0.0
+    react: ^18.0.0 || ^19.0.0
+  checksum: 10/e591ff132932e4e2ba028f8b221309a6146d618c005c3fd985e3dffe6f435468d6b88d3ac91f717e46762524451ffc8cef75e1fd6de7ea4692488a3123ebc08b
+  languageName: node
+  linkType: hard
+
 "dom-converter@npm:^0.2.0":
   version: 0.2.0
   resolution: "dom-converter@npm:0.2.0"
@@ -12844,6 +12854,7 @@ __metadata:
     clsx: "npm:2.1.1"
     cm6-graphql: "npm:0.2.1"
     concurrently: "npm:9.2.1"
+    docusaurus-plugin-copy-page-button: "npm:^0.4.2"
     github-buttons: "npm:2.31.1"
     graphql: "npm:16.13.2"
     lz-string: "npm:1.5.0"


### PR DESCRIPTION
## What this adds

A "Copy page" button in the docs sidebar that exports the current Prettier docs page as clean markdown, with one-click "Open in ChatGPT", "Open in Claude", and "Open in Gemini" actions.

## Why for Prettier

Prettier already ships an `llms-txt-plugin` for whole-site AI discovery. This plugin is the complementary front-end piece — single-page handoff. When a developer is reading [Configuration File](https://prettier.io/docs/configuration) or an options page and wants to ask Claude "explain `arrowParens: avoid` and what it does to my codebase," the plugin gives them a clean markdown copy in one click, instead of selecting around the sidebar.

The two plugins serve different surfaces:
- **llms.txt** — AI tools discovering the whole site
- **This plugin** — a developer with a specific docs page handing it to an AI

Already shipping on Ethereum execution-apis, Sui (Mysten Labs), Walrus, Seal, SuiNS, Monad, Flare, Kaia, Nillion, Chronicle, and Cardano docs. Listed in the [official Docusaurus community plugins](https://docusaurus.io/community/resources#plugins).

## Changes

- Adds `docusaurus-plugin-copy-page-button` to `dependencies` in `website/package.json` (^0.4.2, alphabetical)
- Appends the plugin string to the existing `plugins` array in `website/docusaurus.config.js`, next to `llmsTxtPlugin`

The button auto-injects into the table-of-contents sidebar. No further config required, theme-aware, mobile-friendly, ~5kb client.

## Links

- Live demo: https://portdeveloper.github.io/copy-page-button-showcase/
- Plugin repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button

Happy to revert or adjust if this doesn't fit the project's direction.