### PR TITLE
Fix misplaced return comments in member chains

### DIFF
--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -21,6 +21,7 @@ import { isTypeCastComment } from "../utilities/is-type-cast-comment.js";
 import {
   isArrayType,
   isBinaryCastExpression,
+  isCallExpression,
   isCallLikeExpression,
   isCallOrNewExpression,
   isConditionalType,
@@ -191,13 +192,31 @@ function handleMemberExpressionComments({
 }) {
   if (
     isMemberExpression(enclosingNode) &&
-    followingNode?.type === "Identifier"
+    followingNode === enclosingNode.object &&
+    isCallExpression(followingNode)
+  ) {
+    addLeadingComment(getLeftMostNodeInMemberCallChain(followingNode), comment);
+    return true;
+  }
+
+  if (
+    isMemberExpression(enclosingNode) &&
+    followingNode?.type === "Identifier" &&
+    followingNode !== enclosingNode.object
   ) {
     addLeadingComment(enclosingNode, comment);
     return true;
   }
 
   return false;
+}
+
+function getLeftMostNodeInMemberCallChain(node) {
+  while (isCallExpression(node) || isMemberExpression(node)) {
+    node = isCallExpression(node) ? node.callee : node.object;
+  }
+
+  return node;
 }
 
 function handleNestedConditionalExpressionComments({

--- a/tests/format/js/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/js/comments/__snapshots__/format.test.js.snap
@@ -5695,9 +5695,9 @@ function memberOutside() {
 
 function memberInAndOutWithCalls() {
   return (
+    // Reason for a
     aFunction
-      .b// Reason for a
-      ()
+      .b()
       .c.d()
   )
 }
@@ -6062,9 +6062,9 @@ function memberOutside() {
 
 function memberInAndOutWithCalls() {
   return (
+    // Reason for a
     aFunction
-      .b// Reason for a
-      ()
+      .b()
       .c.d()
   );
 }


### PR DESCRIPTION
## Summary
- keep own-line comments at the start of parenthesized return member/call chains
- avoid printing those comments between a member name and its call parentheses
- update the JS comments format snapshots

Fixes #18843
DevLoot bounty: https://devloot.xyz/bounty/9

## Tests
- `corepack yarn jest tests/format/js/comments/format.test.js --runInBand`
- `corepack yarn eslint src/language-js/comments/handle-comments.js --format stylish`
- `corepack yarn prettier src/language-js/comments/handle-comments.js --check`
- `git diff --check`