### PR TITLE
Preserve blank lines between JSX attributes

### DIFF
--- a/changelog_unreleased/javascript/19161.md
+++ b/changelog_unreleased/javascript/19161.md
@@ -5,24 +5,33 @@ Prettier now keeps one existing blank line between JSX attributes, consistent wi
 <!-- prettier-ignore -->
 ```jsx
 // Input
-<Component
-  first={1}
+<Button
+  type="submit"
+  variant="primary"
+  size="large"
 
 
 
-  second={2}
+  disabled={isSubmitting}
+  onClick={handleSubmit}
 />;
 
 // Prettier stable
-<Component
-  first={1}
-  second={2}
+<Button
+  type="submit"
+  variant="primary"
+  size="large"
+  disabled={isSubmitting}
+  onClick={handleSubmit}
 />;
 
 // Prettier main
-<Component
-  first={1}
+<Button
+  type="submit"
+  variant="primary"
+  size="large"
 
-  second={2}
+  disabled={isSubmitting}
+  onClick={handleSubmit}
 />;
 ```

--- a/changelog_unreleased/javascript/19161.md
+++ b/changelog_unreleased/javascript/19161.md
@@ -1,0 +1,28 @@
+#### Preserve blank lines between JSX attributes (#19161 by @Poliklot)
+
+Prettier now keeps one existing blank line between JSX attributes, consistent with how it preserves blank lines in many other places. Multiple blank lines are still collapsed to one.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+<Component
+  first={1}
+
+
+
+  second={2}
+/>;
+
+// Prettier stable
+<Component
+  first={1}
+  second={2}
+/>;
+
+// Prettier main
+<Component
+  first={1}
+
+  second={2}
+/>;
+```

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -19,14 +19,13 @@ import {
   printDanglingComments,
 } from "../../main/comments/print.js";
 import { getPreferredQuote } from "../../utilities/get-preferred-quote.js";
-import skipNewline from "../../utilities/skip-newline.js";
 import UnexpectedNodeError from "../../utilities/unexpected-node-error.js";
-import { locEnd, locStart } from "../location/index.js";
 import needsParentheses from "../parentheses/needs-parentheses.js";
 import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
 import { createTypeCheckFunction } from "../utilities/create-type-check-function.js";
 import { getRaw } from "../utilities/get-raw.js";
 import { isMeaningfulJsxText } from "../utilities/is-meaningful-jsx-text.js";
+import { isNextLineEmpty } from "../utilities/is-next-line-empty.js";
 import { jsxWhitespace } from "../utilities/jsx-whitespace.js";
 import {
   isArrayExpression,
@@ -567,34 +566,6 @@ function printJsxAttribute(path, options, print) {
   return parts;
 }
 
-function isNextJsxAttributeOnEmptyLine(text, previousAttribute, nextAttribute) {
-  let index = locEnd(previousAttribute);
-  const end = locStart(nextAttribute);
-  let newlineCount = 0;
-
-  while (index < end) {
-    if (text.charAt(index) === " " || text.charAt(index) === "\t") {
-      index++;
-      continue;
-    }
-
-    const nextIndex = skipNewline(text, index);
-    if (nextIndex !== false && nextIndex !== index) {
-      newlineCount++;
-      if (newlineCount > 1) {
-        return true;
-      }
-
-      index = nextIndex;
-      continue;
-    }
-
-    return false;
-  }
-
-  return false;
-}
-
 function printJsxExpressionContainer(path, options, print) {
   const { node } = path;
 
@@ -684,14 +655,10 @@ function printJsxOpeningElement(path, options, print) {
       print("typeArguments"),
       indent(
         path.map(
-          ({ isFirst, previous, node: attribute }) => [
+          ({ isFirst, previous }) => [
             isFirst
               ? attributeLine
-              : isNextJsxAttributeOnEmptyLine(
-                    options.originalText,
-                    previous,
-                    attribute,
-                  )
+              : isNextLineEmpty(previous, options)
                 ? [hardline, hardline]
                 : attributeLine,
             print(),

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -19,7 +19,9 @@ import {
   printDanglingComments,
 } from "../../main/comments/print.js";
 import { getPreferredQuote } from "../../utilities/get-preferred-quote.js";
+import skipNewline from "../../utilities/skip-newline.js";
 import UnexpectedNodeError from "../../utilities/unexpected-node-error.js";
+import { locEnd, locStart } from "../location/index.js";
 import needsParentheses from "../parentheses/needs-parentheses.js";
 import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
 import { createTypeCheckFunction } from "../utilities/create-type-check-function.js";
@@ -565,6 +567,34 @@ function printJsxAttribute(path, options, print) {
   return parts;
 }
 
+function isNextJsxAttributeOnEmptyLine(text, previousAttribute, nextAttribute) {
+  let index = locEnd(previousAttribute);
+  const end = locStart(nextAttribute);
+  let newlineCount = 0;
+
+  while (index < end) {
+    if (text.charAt(index) === " " || text.charAt(index) === "\t") {
+      index++;
+      continue;
+    }
+
+    const nextIndex = skipNewline(text, index);
+    if (nextIndex !== false && nextIndex !== index) {
+      newlineCount++;
+      if (newlineCount > 1) {
+        return true;
+      }
+
+      index = nextIndex;
+      continue;
+    }
+
+    return false;
+  }
+
+  return false;
+}
+
 function printJsxExpressionContainer(path, options, print) {
   const { node } = path;
 
@@ -652,7 +682,23 @@ function printJsxOpeningElement(path, options, print) {
       "<",
       print("name"),
       print("typeArguments"),
-      indent(path.map(() => [attributeLine, print()], "attributes")),
+      indent(
+        path.map(
+          ({ isFirst, previous, node: attribute }) => [
+            isFirst
+              ? attributeLine
+              : isNextJsxAttributeOnEmptyLine(
+                    options.originalText,
+                    previous,
+                    attribute,
+                  )
+                ? [hardline, hardline]
+                : attributeLine,
+            print(),
+          ],
+          "attributes",
+        ),
+      ),
       ...printEndOfOpeningTag(node, options, nameHasComments),
     ],
     { shouldBreak },

--- a/tests/format/jsx/attribute-blank-lines/__snapshots__/format.test.js.snap
+++ b/tests/format/jsx/attribute-blank-lines/__snapshots__/format.test.js.snap
@@ -1,0 +1,171 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`attribute-blank-lines.js - {"singleAttributePerLine":true} format 1`] = `
+====================================options=====================================
+parsers: ["flow", "babel", "typescript"]
+singleAttributePerLine: true
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+const basic = (
+  <Component
+    first={1}
+
+    second={2}
+    third={3}
+  />
+);
+
+const multipleBlankLines = (
+  <Component
+    first={1}
+
+
+
+    second={2}
+  />
+);
+
+const spreadAttributes = (
+  <Component
+    first={1}
+
+    {...props}
+
+    second={2}
+  />
+);
+
+const noBlankLines = (
+  <Component
+    first={1}
+    second={2}
+    third={3}
+  />
+);
+
+const inlineAttributes = <Component first={1} second={2} />;
+
+=====================================output=====================================
+const basic = (
+  <Component
+    first={1}
+
+    second={2}
+    third={3}
+  />
+);
+
+const multipleBlankLines = (
+  <Component
+    first={1}
+
+    second={2}
+  />
+);
+
+const spreadAttributes = (
+  <Component
+    first={1}
+
+    {...props}
+
+    second={2}
+  />
+);
+
+const noBlankLines = (
+  <Component
+    first={1}
+    second={2}
+    third={3}
+  />
+);
+
+const inlineAttributes = (
+  <Component
+    first={1}
+    second={2}
+  />
+);
+
+================================================================================
+`;
+
+exports[`attribute-blank-lines.js format 1`] = `
+====================================options=====================================
+parsers: ["flow", "babel", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+const basic = (
+  <Component
+    first={1}
+
+    second={2}
+    third={3}
+  />
+);
+
+const multipleBlankLines = (
+  <Component
+    first={1}
+
+
+
+    second={2}
+  />
+);
+
+const spreadAttributes = (
+  <Component
+    first={1}
+
+    {...props}
+
+    second={2}
+  />
+);
+
+const noBlankLines = (
+  <Component
+    first={1}
+    second={2}
+    third={3}
+  />
+);
+
+const inlineAttributes = <Component first={1} second={2} />;
+
+=====================================output=====================================
+const basic = (
+  <Component
+    first={1}
+
+    second={2}
+    third={3}
+  />
+);
+
+const multipleBlankLines = (
+  <Component
+    first={1}
+
+    second={2}
+  />
+);
+
+const spreadAttributes = (
+  <Component
+    first={1}
+
+    {...props}
+
+    second={2}
+  />
+);
+
+const noBlankLines = <Component first={1} second={2} third={3} />;
+
+const inlineAttributes = <Component first={1} second={2} />;
+
+================================================================================
+`;

--- a/tests/format/jsx/attribute-blank-lines/attribute-blank-lines.js
+++ b/tests/format/jsx/attribute-blank-lines/attribute-blank-lines.js
@@ -1,0 +1,38 @@
+const basic = (
+  <Component
+    first={1}
+
+    second={2}
+    third={3}
+  />
+);
+
+const multipleBlankLines = (
+  <Component
+    first={1}
+
+
+
+    second={2}
+  />
+);
+
+const spreadAttributes = (
+  <Component
+    first={1}
+
+    {...props}
+
+    second={2}
+  />
+);
+
+const noBlankLines = (
+  <Component
+    first={1}
+    second={2}
+    third={3}
+  />
+);
+
+const inlineAttributes = <Component first={1} second={2} />;

--- a/tests/format/jsx/attribute-blank-lines/format.test.js
+++ b/tests/format/jsx/attribute-blank-lines/format.test.js
@@ -1,0 +1,4 @@
+runFormatTest(import.meta, ["flow", "babel", "typescript"]);
+runFormatTest(import.meta, ["flow", "babel", "typescript"], {
+  singleAttributePerLine: true,
+});

--- a/tests/format/jsx/jsx/__snapshots__/format.test.js.snap
+++ b/tests/format/jsx/jsx/__snapshots__/format.test.js.snap
@@ -4988,21 +4988,29 @@ singleQuote: false
 <div
   single="foo"
   single2={"foo"}
+
   double="bar"
   double2={"bar"}
+
   singleDouble='"'
   singleDouble2={'"'}
+
   doubleSingle="'"
   doubleSingle2={"'"}
+
   singleEscaped={"'"}
   singleEscaped2="'"
+
   doubleEscaped={'"'}
   doubleEscaped2='"'
+
   singleBothEscaped={"'\\""}
   singleBothEscaped2="'&quot;"
+
   singleBoth="' &quot;"
   singleBoth2={"' \\""}
   singleBoth3="' ' &quot;"
+
   doubleBoth="&quot; '"
   doubleBoth2={"\\" '"}
   doubleBoth3="&quot; ' '"
@@ -5077,21 +5085,29 @@ singleQuote: false
 <div
   single='foo'
   single2={"foo"}
+
   double='bar'
   double2={"bar"}
+
   singleDouble='"'
   singleDouble2={'"'}
+
   doubleSingle="'"
   doubleSingle2={"'"}
+
   singleEscaped={"'"}
   singleEscaped2="'"
+
   doubleEscaped={'"'}
   doubleEscaped2='"'
+
   singleBothEscaped={"'\\""}
   singleBothEscaped2='&apos;"'
+
   singleBoth='&apos; "'
   singleBoth2={"' \\""}
   singleBoth3="' ' &quot;"
+
   doubleBoth='" &apos;'
   doubleBoth2={"\\" '"}
   doubleBoth3="&quot; ' '"
@@ -5166,21 +5182,29 @@ singleQuote: true
 <div
   single="foo"
   single2={'foo'}
+
   double="bar"
   double2={'bar'}
+
   singleDouble='"'
   singleDouble2={'"'}
+
   doubleSingle="'"
   doubleSingle2={"'"}
+
   singleEscaped={"'"}
   singleEscaped2="'"
+
   doubleEscaped={'"'}
   doubleEscaped2='"'
+
   singleBothEscaped={'\\'"'}
   singleBothEscaped2="'&quot;"
+
   singleBoth="' &quot;"
   singleBoth2={'\\' "'}
   singleBoth3="' ' &quot;"
+
   doubleBoth="&quot; '"
   doubleBoth2={'" \\''}
   doubleBoth3="&quot; ' '"
@@ -5255,21 +5279,29 @@ singleQuote: true
 <div
   single='foo'
   single2={'foo'}
+
   double='bar'
   double2={'bar'}
+
   singleDouble='"'
   singleDouble2={'"'}
+
   doubleSingle="'"
   doubleSingle2={"'"}
+
   singleEscaped={"'"}
   singleEscaped2="'"
+
   doubleEscaped={'"'}
   doubleEscaped2='"'
+
   singleBothEscaped={'\\'"'}
   singleBothEscaped2='&apos;"'
+
   singleBoth='&apos; "'
   singleBoth2={'\\' "'}
   singleBoth3="' ' &quot;"
+
   doubleBoth='" &apos;'
   doubleBoth2={'" \\''}
   doubleBoth3="&quot; ' '"

--- a/tests/format/typescript/tsx/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/tsx/__snapshots__/format.test.js.snap
@@ -1,5 +1,30 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`attribute-blank-lines.tsx format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+const element = (
+  <Component<Props>
+    first={1}
+
+    second={2}
+  />
+);
+
+=====================================output=====================================
+const element = (
+  <Component<Props>
+    first={1}
+
+    second={2}
+  />
+);
+
+================================================================================
+`;
+
 exports[`generic-component.tsx format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/tsx/attribute-blank-lines.tsx
+++ b/tests/format/typescript/tsx/attribute-blank-lines.tsx
@@ -1,0 +1,7 @@
+const element = (
+  <Component<Props>
+    first={1}
+
+    second={2}
+  />
+);


### PR DESCRIPTION
## Description

Preserve existing blank lines between JSX attributes.

Prettier already preserves blank lines in many other places while collapsing multiple blank lines to one. JSX attributes currently lose that grouping entirely. This PR makes JSX attributes consistent with that behavior.

Refs https://github.com/prettier/prettier/discussions/18977

<!-- prettier-ignore -->
```jsx
// Input
<ReactPlayer
  muted

  onTimeUpdate={() => setTime(playerRef.current?.currentTime ?? 0)}

  onLoadedMetadata={hideLoading}
  onLoadedData={hideLoading}
/>;

// Prettier stable
<ReactPlayer
  muted
  onTimeUpdate={() => setTime(playerRef.current?.currentTime ?? 0)}
  onLoadedMetadata={hideLoading}
  onLoadedData={hideLoading}
/>;

// Prettier main
<ReactPlayer
  muted

  onTimeUpdate={() => setTime(playerRef.current?.currentTime ?? 0)}

  onLoadedMetadata={hideLoading}
  onLoadedData={hideLoading}
/>;
```

Multiple blank lines are still collapsed to one.

## Checklist

- [x] I've added tests to confirm my change works.
- [ ] (If changing the API or CLI) I've documented the changes I've made (in the `docs/` directory). N/A — no API or CLI changes.
- [x] (If the change is user-facing) I've added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I've read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
