### PR TITLE
Support directives on directive definitions in GraphQL

### DIFF
--- a/changelog_unreleased/graphql/19171.md
+++ b/changelog_unreleased/graphql/19171.md
@@ -1,0 +1,17 @@
+#### Support directives on directive definitions (#19171 by @YBJ0000)
+
+[Directives on directive definitions](https://github.com/graphql/graphql-js/pull/4521) (and `extend directive` extensions) are now formatted instead of throwing a syntax error.
+
+<!-- prettier-ignore -->
+```gql
+# Input
+directive @a @b on QUERY
+extend directive @a @b
+
+# Prettier stable
+Error: Syntax Error: Expected "on", found "@".
+
+# Prettier main
+directive @a @b on QUERY
+extend directive @a @b
+```

--- a/changelog_unreleased/graphql/19171.md
+++ b/changelog_unreleased/graphql/19171.md
@@ -1,6 +1,6 @@
 #### Support directives on directive definitions (#19171 by @YBJ0000)
 
-[Directives on directive definitions](https://github.com/graphql/graphql-js/pull/4521) (and `extend directive` extensions) are now formatted instead of throwing a syntax error.
+[Directives on directive definitions](https://github.com/graphql/graphql-js/pull/4521) (and `extend directive` extensions) are now supported.
 
 <!-- prettier-ignore -->
 ```gql

--- a/src/language-graphql/parser-graphql.js
+++ b/src/language-graphql/parser-graphql.js
@@ -17,6 +17,7 @@ function parseComments(ast) {
 
 const parseOptions = {
   allowLegacyFragmentVariables: true,
+  experimentalDirectivesOnDirectiveDefinitions: true,
 };
 
 function createParseError(error) {

--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -290,9 +290,18 @@ function genericPrint(path, options, print) {
               ")",
             ])
           : "",
+        printDirectives(path, print, node),
         node.repeatable ? " repeatable" : "",
         " on ",
         ...join(" | ", path.map(print, "locations")),
+      ];
+
+    case "DirectiveExtension":
+      return [
+        "extend directive ",
+        "@",
+        print("name"),
+        printDirectives(path, print, node),
       ];
 
     case "EnumTypeExtension":

--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -290,7 +290,7 @@ function genericPrint(path, options, print) {
               ")",
             ])
           : "",
-        printDirectives(path, print, node),
+        printDirectives(path, print),
         node.repeatable ? " repeatable" : "",
         " on ",
         ...join(" | ", path.map(print, "locations")),
@@ -298,10 +298,9 @@ function genericPrint(path, options, print) {
 
     case "DirectiveExtension":
       return [
-        "extend directive ",
-        "@",
+        "extend directive @",
         print("name"),
-        printDirectives(path, print, node),
+        printDirectives(path, print),
       ];
 
     case "EnumTypeExtension":

--- a/src/language-graphql/visitor-keys.js
+++ b/src/language-graphql/visitor-keys.js
@@ -13,10 +13,4 @@ for (const kind of [
   delete visitorKeys[kind];
 }
 
-// Not supported yet
-visitorKeys.DirectiveDefinition = visitorKeys.DirectiveDefinition.filter(
-  (key) => key !== "directives",
-);
-delete visitorKeys.DirectiveExtension;
-
 export default visitorKeys;

--- a/tests/format/graphql/directive-decl/__snapshots__/format.test.js.snap
+++ b/tests/format/graphql/directive-decl/__snapshots__/format.test.js.snap
@@ -42,3 +42,30 @@ directive @a(as: String = 1) on QUERY
 
 ================================================================================
 `;
+
+exports[`directives-on-directive-definitions.graphql format 1`] = `
+====================================options=====================================
+parsers: ["graphql"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+directive @a @b on QUERY
+directive @a(x: Int)   @b @c on QUERY
+directive @a @b repeatable on QUERY
+directive @a(x: Int) @b repeatable on QUERY | MUTATION
+directive @a @b(reason: "deprecated") on QUERY
+
+extend directive @a @b
+extend directive @a @b @c
+
+=====================================output=====================================
+directive @a @b on QUERY
+directive @a(x: Int) @b @c on QUERY
+directive @a @b repeatable on QUERY
+directive @a(x: Int) @b repeatable on QUERY | MUTATION
+directive @a @b(reason: "deprecated") on QUERY
+
+extend directive @a @b
+extend directive @a @b @c
+
+================================================================================
+`;

--- a/tests/format/graphql/directive-decl/directives-on-directive-definitions.graphql
+++ b/tests/format/graphql/directive-decl/directives-on-directive-definitions.graphql
@@ -1,0 +1,8 @@
+directive @a @b on QUERY
+directive @a(x: Int)   @b @c on QUERY
+directive @a @b repeatable on QUERY
+directive @a(x: Int) @b repeatable on QUERY | MUTATION
+directive @a @b(reason: "deprecated") on QUERY
+
+extend directive @a @b
+extend directive @a @b @c

--- a/tests/unit/__snapshots__/visitor-keys.js.snap
+++ b/tests/unit/__snapshots__/visitor-keys.js.snap
@@ -1294,7 +1294,12 @@ exports[`visitor keys graphql 1`] = `
   "DirectiveDefinition": [
     "arguments",
     "description",
+    "directives",
     "locations",
+    "name",
+  ],
+  "DirectiveExtension": [
+    "directives",
     "name",
   ],
   "Document": [


### PR DESCRIPTION
<!-- Please make sure to read the Pull Request Guidelines:
https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md#pull-request-guidelines -->

**Description**

Fixes #19167.

GraphQL added support for [directives on directive definitions](https://github.com/graphql/graphql-js/pull/4521) (and `extend directive` extensions). The `graphql` dependency was already bumped to a version that can parse this syntax in #19120, but Prettier still threw a syntax error on it.

This PR:

- Enables the `experimentalDirectivesOnDirectiveDefinitions` parser option in the GraphQL parser.
- Stops dropping the `directives` visitor key from `DirectiveDefinition` and stops deleting the `DirectiveExtension` key, so these nodes are traversed correctly.
- Prints directives in `DirectiveDefinition` (between the arguments and `repeatable`, matching `graphql-js`'s own printer) and adds a printer case for `DirectiveExtension`.

<!-- prettier-ignore -->
```gql
# Input
directive @a @b on QUERY
directive @a(x: Int) @b repeatable on QUERY | MUTATION
extend directive @a @b

# Prettier stable
Error: Syntax Error: Expected "on", found "@".

# Prettier main
directive @a @b on QUERY
directive @a(x: Int) @b repeatable on QUERY | MUTATION
extend directive @a @b
```

**Checklist**

- [x] I've read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [x] I've added tests (`tests/format/graphql/directive-decl/directives-on-directive-definitions.graphql`).
- [x] I've added a changelog entry.