### PR TITLE
Use Error.prototype.cause in createError

### DIFF
--- a/src/common/parser-create-error.js
+++ b/src/common/parser-create-error.js
@@ -1,6 +1,4 @@
 function createError(message, options) {
-  // TODO: Use `Error.prototype.cause` when we drop support for Node.js<18.7.0
-
   // Construct an error similar to the ones thrown by Babel.
   const error = new SyntaxError(
     message +
@@ -9,6 +7,7 @@ function createError(message, options) {
       ":" +
       options.loc.start.column +
       ")",
+    { cause: options.cause },
   );
 
   return Object.assign(error, options);


### PR DESCRIPTION
The minimum supported Node.js version was raised to >=20 (which
has supported `Error.prototype.cause` since 16.9.0), so the TODO
blocking this change no longer applies.

Pass `{ cause: options.cause }` to the `SyntaxError` constructor
directly instead of relying solely on `Object.assign` to attach the
cause. This uses the standard error-chaining mechanism, which is
properly recognised by runtimes and debugging tools.