### PR TITLE
Avoid semicolon in shell trampoline shebangs

### DIFF
--- a/changelog_unreleased/javascript/19194.md
+++ b/changelog_unreleased/javascript/19194.md
@@ -1,6 +1,6 @@
 #### Preserve shell trampoline shebang semicolons (#19194 by @sjh9714)
 
-Prettier no longer inserts a semicolon before the `//; exec` shell comment in multiline shebang trampoline scripts.
+Prettier no longer inserts a semicolon before the `//; exec` shell comment in multiline shebang trampoline scripts. It also preserves required leading semicolons on the following statement when they are needed for ASI protection.
 
 <!-- prettier-ignore -->
 ```jsx

--- a/changelog_unreleased/javascript/19194.md
+++ b/changelog_unreleased/javascript/19194.md
@@ -1,0 +1,21 @@
+#### Preserve shell trampoline shebang semicolons (#19194 by @sjh9714)
+
+Prettier no longer inserts a semicolon before the `//; exec` shell comment in multiline shebang trampoline scripts.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+const ten = 10;
+
+// Prettier stable
+#!/bin/sh
+":"; //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+const ten = 10;
+
+// Prettier main
+#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+const ten = 10;
+```

--- a/src/language-js/print/estree.js
+++ b/src/language-js/print/estree.js
@@ -7,6 +7,7 @@ import {
 } from "../../document/index.js";
 import { printDanglingComments } from "../../main/comments/print.js";
 import UnexpectedNodeError from "../../utilities/unexpected-node-error.js";
+import { isShellShebangDirective } from "../semicolon/semicolon.js";
 import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
 import { isMeaningfulEmptyStatement } from "../utilities/is-meaningful-empty-statement.js";
 import { isMethod } from "../utilities/is-method.js";
@@ -222,7 +223,10 @@ function printEstree(path, options, print, args) {
     case "Super":
       return "super";
     case "Directive":
-      return [print("value"), printSemicolon(options)];
+      return [
+        print("value"),
+        isShellShebangDirective(path, options) ? "" : printSemicolon(options),
+      ];
     case "UnaryExpression": {
       const parts = [node.operator];
 

--- a/src/language-js/print/expression-statement.js
+++ b/src/language-js/print/expression-statement.js
@@ -50,8 +50,10 @@ function shouldPrintSemicolon(path, options) {
 function printExpressionStatement(path, options, print) {
   /** @type {Doc[]} */
   const parts = [print("expression")];
+  const shouldPrintLeadingSemicolon =
+    shouldExpressionStatementPrintLeadingSemicolon(path, options);
 
-  if (shouldExpressionStatementPrintLeadingSemicolon(path, options)) {
+  if (shouldPrintLeadingSemicolon) {
     if (shouldExpressionStatementPrintOwnComments(path, options)) {
       const { node } = path;
       const typeCastComment = getComments(node, CommentCheckFlags.Leading).at(
@@ -63,13 +65,25 @@ function printExpressionStatement(path, options, print) {
         filter: (comment) => comment === typeCastComment,
       });
 
-      return printComments(path, [";", typeCastCommentDoc, ...parts], options, {
-        filter: (comment) => comment !== typeCastComment,
-      });
+      return printComments(
+        path,
+        [
+          ";",
+          typeCastCommentDoc,
+          ...parts,
+          shouldPrintSemicolon(path, options) ? ";" : "",
+        ],
+        options,
+        {
+          filter: (comment) => comment !== typeCastComment,
+        },
+      );
     }
 
     parts.unshift(";");
-  } else if (shouldPrintSemicolon(path, options)) {
+  }
+
+  if (shouldPrintSemicolon(path, options)) {
     parts.push(";");
   }
 

--- a/src/language-js/print/expression-statement.js
+++ b/src/language-js/print/expression-statement.js
@@ -3,6 +3,7 @@ import {
   printLeadingComments,
 } from "../../main/comments/print.js";
 import {
+  isShellShebangDirective,
   isSingleHtmlEventHandlerExpressionStatement,
   isSingleJsxExpressionStatementInMarkdown,
   isSingleVueEventBindingExpressionStatement,
@@ -34,6 +35,7 @@ function shouldPrintSemicolon(path, options) {
   }
 
   if (
+    isShellShebangDirective(path, options) ||
     // Do not append semicolon after the only JSX element in a program
     isSingleJsxExpressionStatementInMarkdown(path, options) ||
     // Do not append semicolon after the only HTML event binding expression in a program

--- a/src/language-js/semicolon/semicolon.js
+++ b/src/language-js/semicolon/semicolon.js
@@ -1,3 +1,4 @@
+import { locEnd } from "../location/index.js";
 import needsParentheses from "../parentheses/needs-parentheses.js";
 import { shouldPrintParamsWithoutParens } from "../print/function.js";
 import {
@@ -5,6 +6,32 @@ import {
   hasNakedLeftSide,
 } from "../utilities/left-side.js";
 import { isJsxElement } from "../utilities/node-types.js";
+
+function isShellShebangDirective(path, options) {
+  const { node, parent } = path;
+
+  if (
+    !options.originalText.startsWith("#!") ||
+    parent.type !== "Program" ||
+    path.index !== 0 ||
+    !(
+      (path.key === "directives" && node.type === "Directive") ||
+      (path.key === "body" &&
+        node.type === "ExpressionStatement" &&
+        typeof node.directive === "string")
+    )
+  ) {
+    return false;
+  }
+
+  const directiveEnd = locEnd(node);
+  const lineEnd = options.originalText.indexOf("\n", directiveEnd);
+
+  return (
+    lineEnd !== -1 &&
+    /^\s*\/\/;/.test(options.originalText.slice(directiveEnd, lineEnd))
+  );
+}
 
 function shouldExpressionStatementPrintLeadingSemicolon(path, options) {
   if (options.semi) {
@@ -128,6 +155,7 @@ function isSingleVueEventBindingExpressionStatement(path, options) {
 }
 
 export {
+  isShellShebangDirective,
   isSingleHtmlEventHandlerExpressionStatement,
   isSingleJsxExpressionStatementInMarkdown,
   isSingleVueEventBindingExpressionStatement,

--- a/src/language-js/semicolon/semicolon.js
+++ b/src/language-js/semicolon/semicolon.js
@@ -7,23 +7,14 @@ import {
 } from "../utilities/left-side.js";
 import { isJsxElement } from "../utilities/node-types.js";
 
-function isShellShebangDirective(path, options) {
-  const { node, parent } = path;
+function isDirectiveNode(node) {
+  return (
+    node.type === "Directive" ||
+    (node.type === "ExpressionStatement" && typeof node.directive === "string")
+  );
+}
 
-  if (
-    !options.originalText.startsWith("#!") ||
-    parent.type !== "Program" ||
-    path.index !== 0 ||
-    !(
-      (path.key === "directives" && node.type === "Directive") ||
-      (path.key === "body" &&
-        node.type === "ExpressionStatement" &&
-        typeof node.directive === "string")
-    )
-  ) {
-    return false;
-  }
-
+function hasShellShebangDirectiveComment(node, options) {
   const directiveEnd = locEnd(node);
   const lineEnd = options.originalText.indexOf("\n", directiveEnd);
 
@@ -33,8 +24,47 @@ function isShellShebangDirective(path, options) {
   );
 }
 
+function isShellShebangDirective(path, options) {
+  const { node, parent } = path;
+
+  if (
+    !options.originalText.startsWith("#!") ||
+    parent.type !== "Program" ||
+    path.index !== 0 ||
+    !(
+      (path.key === "directives" || path.key === "body") &&
+      isDirectiveNode(node)
+    )
+  ) {
+    return false;
+  }
+
+  return hasShellShebangDirectiveComment(node, options);
+}
+
+function isAfterShellShebangDirective(path, options) {
+  if (
+    !options.originalText.startsWith("#!") ||
+    path.key !== "body" ||
+    path.parent.type !== "Program"
+  ) {
+    return false;
+  }
+
+  const previousNode =
+    path.index === 0
+      ? path.parent.directives?.at(-1)
+      : path.parent.body[path.index - 1];
+
+  return (
+    previousNode &&
+    isDirectiveNode(previousNode) &&
+    hasShellShebangDirectiveComment(previousNode, options)
+  );
+}
+
 function shouldExpressionStatementPrintLeadingSemicolon(path, options) {
-  if (options.semi) {
+  if (options.semi && !isAfterShellShebangDirective(path, options)) {
     return false;
   }
 

--- a/tests/format/js/shebang/format.test.js
+++ b/tests/format/js/shebang/format.test.js
@@ -10,6 +10,16 @@ runFormatTest(
         name: "Empty file with shebang",
         code: "#!/usr/bin/env node\n",
       },
+      {
+        name: "Shell trampoline shebang",
+        code: `#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+const ten = 10;`,
+        output: `#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+const ten = 10;
+`,
+      },
     ],
   },
   ["babel", "flow", "typescript"],

--- a/tests/format/js/shebang/format.test.js
+++ b/tests/format/js/shebang/format.test.js
@@ -20,6 +20,30 @@ const ten = 10;`,
 const ten = 10;
 `,
       },
+      {
+        name: "Shell trampoline shebang before array expression",
+        code: `#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+
+;[].forEach();`,
+        output: `#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+
+;[].forEach();
+`,
+      },
+      {
+        name: "Shell trampoline shebang before parenthesized call",
+        code: `#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+
+;(() => console.log(1))();`,
+        output: `#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+
+;(() => console.log(1))();
+`,
+      },
     ],
   },
   ["babel", "flow", "typescript"],


### PR DESCRIPTION
## Description

Fixes #7562.

Prettier was adding a semicolon before the trailing shell comment in multiline shebang trampolines like `":" //; exec ...`, which can break shell execution before the file reaches Node/ts-node. This keeps the directive line unchanged only for the shebang-plus-`//;` trampoline pattern, while preserving normal semicolon behavior elsewhere.

Note: I used Codex while preparing this change, and I reviewed the final diff and ran the listed checks locally.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory). Not applicable.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

## Testing

- `yarn jest tests/format/js/shebang --runInBand` (failed before the fix with `":"; //; exec ...`)
- `yarn jest tests/format/js/shebang tests/format/js/no-semi --runInBand`
- `yarn lint:eslint src/language-js/semicolon/semicolon.js src/language-js/print/expression-statement.js src/language-js/print/estree.js tests/format/js/shebang/format.test.js`
- `yarn lint:format-test`
- `yarn lint:changelog`
- `yarn prettier --check src/language-js/semicolon/semicolon.js src/language-js/print/expression-statement.js src/language-js/print/estree.js tests/format/js/shebang/format.test.js`
- `yarn prettier --check changelog_unreleased/javascript/19194.md`
- `git diff --check`