### PR TITLE
Avoid treating SCSS strings as declaration flags

### DIFF
--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -22,6 +22,69 @@ import isSCSSNestedPropertyNode from "./utilities/is-scss-nested-property-node.j
 const DEFAULT_SCSS_DIRECTIVE = /(\s*)(!default).*$/;
 const GLOBAL_SCSS_DIRECTIVE = /(\s*)(!global).*$/;
 
+function extractTrailingScssDirective(value, directive, options) {
+  if (!value.includes(directive)) {
+    return null;
+  }
+
+  const parsedValue = parseValue(value, options);
+  if (parsedValue.type === "value-unknown") {
+    return;
+  }
+
+  const topLevelGroup = parsedValue.group?.group;
+  const topLevelNodes = topLevelGroup?.groups ?? [topLevelGroup].filter(Boolean);
+
+  if (topLevelNodes.length === 0) {
+    return null;
+  }
+
+  const lastNonCommentIndex = topLevelNodes.findLastIndex(
+    (node) => node.type !== "value-comment",
+  );
+  const directiveNode = topLevelNodes[lastNonCommentIndex];
+
+  if (
+    directiveNode?.type !== "value-word" ||
+    directiveNode.value !== directive ||
+    !topLevelNodes
+      .slice(lastNonCommentIndex + 1)
+      .every((node) => node.type === "value-comment")
+  ) {
+    return null;
+  }
+
+  const startIndex = directiveNode.sourceIndex - directiveNode.raws.before.length;
+  const raw = value.slice(startIndex);
+
+  return {
+    raw,
+    value: value.slice(0, startIndex),
+  };
+}
+
+function extractTrailingScssDirectiveWithFallback(
+  value,
+  directive,
+  regex,
+  options,
+) {
+  const parsedDirective = extractTrailingScssDirective(value, directive, options);
+  if (parsedDirective !== undefined) {
+    return parsedDirective;
+  }
+
+  const match = value.match(regex);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    raw: match[0],
+    value: value.slice(0, match.index),
+  };
+}
+
 function parseNestedCSS(node, options) {
   if (isObject(node)) {
     delete node.parent;
@@ -163,25 +226,37 @@ function parseNestedCSS(node, options) {
     }
 
     if (value.trim().length > 0) {
-      const defaultSCSSDirectiveIndex = value.match(DEFAULT_SCSS_DIRECTIVE);
+      const defaultSCSSDirective =
+        extractTrailingScssDirectiveWithFallback(
+          value,
+          "!default",
+          DEFAULT_SCSS_DIRECTIVE,
+          options,
+        );
 
-      if (defaultSCSSDirectiveIndex) {
-        value = value.slice(0, defaultSCSSDirectiveIndex.index);
+      if (defaultSCSSDirective) {
+        value = defaultSCSSDirective.value;
         node.scssDefault = true;
 
-        if (defaultSCSSDirectiveIndex[0].trim() !== "!default") {
-          node.raws.scssDefault = defaultSCSSDirectiveIndex[0];
+        if (defaultSCSSDirective.raw.trim() !== "!default") {
+          node.raws.scssDefault = defaultSCSSDirective.raw;
         }
       }
 
-      const globalSCSSDirectiveIndex = value.match(GLOBAL_SCSS_DIRECTIVE);
+      const globalSCSSDirective =
+        extractTrailingScssDirectiveWithFallback(
+          value,
+          "!global",
+          GLOBAL_SCSS_DIRECTIVE,
+          options,
+        );
 
-      if (globalSCSSDirectiveIndex) {
-        value = value.slice(0, globalSCSSDirectiveIndex.index);
+      if (globalSCSSDirective) {
+        value = globalSCSSDirective.value;
         node.scssGlobal = true;
 
-        if (globalSCSSDirectiveIndex[0].trim() !== "!global") {
-          node.raws.scssGlobal = globalSCSSDirectiveIndex[0];
+        if (globalSCSSDirective.raw.trim() !== "!global") {
+          node.raws.scssGlobal = globalSCSSDirective.raw;
         }
       }
 

--- a/tests/format/scss/flag/19203.scss
+++ b/tests/format/scss/flag/19203.scss
@@ -1,0 +1,3 @@
+$string-default: "!default";
+$function-default: unquote("!default");
+$url-global: url("x!global");

--- a/tests/format/scss/flag/__snapshots__/format.test.js.snap
+++ b/tests/format/scss/flag/__snapshots__/format.test.js.snap
@@ -83,3 +83,39 @@ $global: "very-long-long-long-long-long-long-long-long-long-long-long-value" !gl
 
 ================================================================================
 `;
+
+exports[`19203.scss - {"trailingComma":"es5"} format 1`] = `
+====================================options=====================================
+parsers: ["scss"]
+trailingComma: "es5"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+$string-default: "!default";
+$function-default: unquote("!default");
+$url-global: url("x!global");
+
+=====================================output=====================================
+$string-default: "!default";
+$function-default: unquote("!default");
+$url-global: url("x!global");
+
+================================================================================
+`;
+
+exports[`19203.scss - {"trailingComma":"none"} format 1`] = `
+====================================options=====================================
+parsers: ["scss"]
+trailingComma: "none"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+$string-default: "!default";
+$function-default: unquote("!default");
+$url-global: url("x!global");
+
+=====================================output=====================================
+$string-default: "!default";
+$function-default: unquote("!default");
+$url-global: url("x!global");
+
+================================================================================
+`;


### PR DESCRIPTION
## Summary
- stop treating top-level `!default` and `!global` inside SCSS strings and function arguments as declaration flags
- keep the existing regex fallback only for values the value parser can't understand
- add regression coverage for string, function, and `url()` cases under `tests/format/scss/flag`

## Why
The directive detection in `parser-postcss.js` was matching raw `!default` / `!global` text before the value was parsed. That meant values like `"!default"`, `unquote("!default")`, and `url("x!global")` were split as if they had trailing Sass flags, which changed the formatted output.

Closes #19203.

## Checks
- `yarn test tests/format/scss/flag -u`
- `./node_modules/.bin/eslint src/language-css/parser-postcss.js`
- direct CLI repro with `node ./bin/prettier.js --parser scss`
