### PR TITLE
Remove `esm-utils` from scripts

### DIFF
--- a/scripts/build/builders/javascript-module.js
+++ b/scripts/build/builders/javascript-module.js
@@ -1,8 +1,8 @@
+import { createRequire } from "node:module";
 import path from "node:path";
 import url from "node:url";
 import browserslistToEsbuild from "browserslist-to-esbuild";
 import esbuild from "esbuild";
-import createEsmUtils from "esm-utils";
 import projectPackageJson from "../../../package.json" with { type: "json" };
 import {
   PRODUCTION_MINIMAL_NODE_JS_VERSION,
@@ -20,7 +20,7 @@ import esbuildPluginVisualizer from "../esbuild-plugins/visualizer.js";
 import transform from "../transform/index.js";
 import { getPackageFile } from "../utilities.js";
 
-const { require, resolve: importMetaResolve } = createEsmUtils(import.meta);
+const require = createRequire(import.meta.url);
 
 const universalTarget = browserslistToEsbuild(projectPackageJson.browserslist);
 const getRelativePath = (from, to) => {
@@ -44,7 +44,7 @@ function getEsbuildOptions({ packageConfig, file, cliOptions, buildOptions }) {
     We already replaced line end to `\n` before calling it
     */
     {
-      module: url.fileURLToPath(importMetaResolve("jest-docblock")),
+      module: url.fileURLToPath(import.meta.resolve("jest-docblock")),
       path: require.resolve("jest-docblock"),
     },
     {

--- a/scripts/build/packages/prettier.js
+++ b/scripts/build/packages/prettier.js
@@ -826,6 +826,4 @@ packageConfig.modules.push(
   }),
 );
 
-console.log(packageConfig);
-
 export default packageConfig;

--- a/scripts/build/packages/prettier.js
+++ b/scripts/build/packages/prettier.js
@@ -1,6 +1,6 @@
+import { createRequire } from "node:module";
 import path from "node:path";
 import url from "node:url";
-import createEsmUtils from "esm-utils";
 import { outdent } from "outdent";
 import { DIST_DIR, PROJECT_ROOT } from "../../utilities/index.js";
 import { createJavascriptModuleBuilder } from "../builders/javascript-module.js";
@@ -15,13 +15,9 @@ import {
 } from "./config-helpers.js";
 import { generatePackageJson } from "./prettier-package-json.js";
 
-const {
-  require,
-  dirname,
-  resolve: importMetaResolve,
-} = createEsmUtils(import.meta);
+const require = createRequire(import.meta.url);
 const resolveEsmModulePath = (specifier) =>
-  url.fileURLToPath(importMetaResolve(specifier));
+  url.fileURLToPath(import.meta.resolve(specifier));
 
 const extensions = {
   esm: ".mjs",
@@ -73,7 +69,7 @@ const mainModule = {
         // `parse-json` uses old version of `@babel/code-frame`
         // Remove this when `parse-json` supports @babel/code-frame v8
         {
-          module: require.resolve("parse-json"),
+          module: resolveEsmModulePath("parse-json"),
           process(text) {
             text = text.replace(
               "return {line: Number(line), column: Number(column)}",
@@ -92,11 +88,11 @@ const mainModule = {
           replacement: "export default { parse };",
         },
         {
-          module: require.resolve("@babel/code-frame"),
+          module: resolveEsmModulePath("@babel/code-frame"),
           process(text) {
             text = text.replace(
               "from 'node:util'",
-              `from ${JSON.stringify(path.join(dirname, "../shims/node-util.js"))}`,
+              `from ${JSON.stringify(path.join(import.meta.dirname, "../shims/node-util.js"))}`,
             );
             return text;
           },
@@ -114,7 +110,7 @@ const mainModule = {
         // Smaller size
         {
           module: getPackageFile("picocolors/picocolors.browser.js"),
-          path: path.join(dirname, "../shims/colors.js"),
+          path: path.join(import.meta.dirname, "../shims/colors.js"),
         },
       ],
     }),
@@ -440,7 +436,7 @@ const pluginFiles = [
       // Only needed if `range`/`loc` in parse options is `false`
       {
         module: getPackageFile("debug/src/browser.js"),
-        path: path.join(dirname, "../shims/debug.js"),
+        path: path.join(import.meta.dirname, "../shims/debug.js"),
       },
       {
         module: require.resolve("ts-api-utils"),
@@ -829,5 +825,7 @@ packageConfig.modules.push(
     packageDisplayName: "Prettier",
   }),
 );
+
+console.log(packageConfig);
 
 export default packageConfig;

--- a/scripts/draft-blog-post.js
+++ b/scripts/draft-blog-post.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
-import createEsmUtils from "esm-utils";
 import fg from "fast-glob";
 import semver from "semver";
 import {
@@ -13,8 +13,8 @@ import {
   replaceVersions,
 } from "./utilities/changelog.js";
 
-const { __dirname, require } = createEsmUtils(import.meta);
-const blogDir = path.join(__dirname, "../website/blog");
+const require = createRequire(import.meta.url);
+const blogDir = path.join(import.meta.dirname, "../website/blog");
 const introTemplateFile = new URL(
   "BLOG_POST_INTRO_TEMPLATE.md",
   changelogUnreleasedDirectory,


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
