### PR TITLE
Add `jsxWrapParens` option to control paren-wrapping of multiline JSX

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -138,6 +138,37 @@ Use single quotes instead of double quotes in JSX.
 | ------- | -------------------- | ------------------------ |
 | `false` | `--jsx-single-quote` | `jsxSingleQuote: <bool>` |
 
+## JSX Wrap Parens
+
+Control whether multiline JSX is wrapped in parentheses in positions where the parentheses are not syntactically required (for example, after `return`/`throw`, in arrow function bodies, and in assignments). The wrapping parentheses add an extra level of indentation:
+
+<!-- prettier-ignore -->
+```jsx
+// "always"
+return (
+  <>
+    <SomeElement />
+    <SomeOtherElement />
+  </>
+);
+
+// "never"
+return <>
+  <SomeElement />
+  <SomeOtherElement />
+</>;
+```
+
+Valid options:
+
+- `"always"` - Always wrap multiline JSX in parentheses.
+- `"never"` - Never add parentheses around multiline JSX where they are not required.
+- `"preserve"` - Keep parentheses around multiline JSX only if the original code had them.
+
+| Default    | CLI Override                                                      | API Override                                                     |
+| ---------- | ----------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `"always"` | <code>--jsx-wrap-parens \<always&#124;never&#124;preserve></code> | <code>jsxWrapParens: "\<always&#124;never&#124;preserve>"</code> |
+
 ## Trailing Commas
 
 _Default value changed from `es5` to `all` in v3.0.0_

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -333,6 +333,11 @@ export interface RequiredOptions extends doc.printer.Options {
    */
   jsxSingleQuote: boolean;
   /**
+   * How to wrap multiline JSX in parentheses where they are not required.
+   * @default "always"
+   */
+  jsxWrapParens: "always" | "never" | "preserve";
+  /**
    * Print trailing commas wherever possible.
    * @default "all"
    */

--- a/src/language-js/options.js
+++ b/src/language-js/options.js
@@ -69,6 +69,29 @@ const options = {
     default: false,
     description: "Use single quotes in JSX.",
   },
+  jsxWrapParens: {
+    category: CATEGORY_JAVASCRIPT,
+    type: "choice",
+    default: "always",
+    description:
+      "How to wrap multiline JSX in parentheses where they are not syntactically required.",
+    choices: [
+      {
+        value: "always",
+        description: "Always wrap multiline JSX in parentheses.",
+      },
+      {
+        value: "never",
+        description:
+          "Never add parentheses around multiline JSX where they are not required.",
+      },
+      {
+        value: "preserve",
+        description:
+          "Keep parentheses around multiline JSX only if the original code had them.",
+      },
+    ],
+  },
   quoteProps: {
     category: CATEGORY_JAVASCRIPT,
     type: "choice",

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -18,8 +18,12 @@ import {
   printComments,
   printDanglingComments,
 } from "../../main/comments/print.js";
+import getNextNonSpaceNonCommentCharacter from "../../utilities/get-next-non-space-non-comment-character.js";
 import { getPreferredQuote } from "../../utilities/get-preferred-quote.js";
+import hasNewline from "../../utilities/has-newline.js";
+import { skipWhitespace } from "../../utilities/skip.js";
 import UnexpectedNodeError from "../../utilities/unexpected-node-error.js";
+import { locEnd, locStart } from "../location/index.js";
 import needsParentheses from "../parentheses/needs-parentheses.js";
 import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
 import { createTypeCheckFunction } from "../utilities/create-type-check-function.js";
@@ -484,15 +488,73 @@ const isNoWrapParent = createTypeCheckFunction([
   "JsExpressionRoot",
   "MatchExpressionCase",
 ]);
+
+// Detect whether the JSX node was wrapped in parentheses in the original
+// source, parser-independently (some parsers, e.g. `typescript` and `flow`,
+// don't retain `node.extra.parenthesized`). Requires a `(` immediately before
+// and a matching `)` immediately after the node so that parentheses around an
+// enclosing expression (e.g. `(<a /> && <b />)`) aren't misattributed to an
+// operand.
+function isParenthesizedInOriginalText(node, options) {
+  const { originalText } = options;
+  const precedingCharIndex = skipWhitespace(originalText, locStart(node) - 1, {
+    backwards: true,
+  });
+  return (
+    precedingCharIndex !== false &&
+    originalText[precedingCharIndex] === "(" &&
+    getNextNonSpaceNonCommentCharacter(originalText, locEnd(node)) === ")"
+  );
+}
+
+// Stripping the optional parens around the element is unsafe when it carries
+// certain comments:
+//   - A leading comment: a `//` can't share a line with the `<` open tag, so
+//     unwrapping would force ASI after `return` and change semantics.
+//   - A trailing block comment on the element's own line (no newline before
+//     it): it prints inline, before the statement's semicolon, and would hop
+//     to after the semicolon on the next pass — i.e. not idempotent. Trailing
+//     line comments and own-line comments print as line suffixes (past the
+//     semicolon) and unwrap cleanly.
+function elementHasParenForcingComment(node, options) {
+  return (
+    hasComment(node, CommentCheckFlags.Leading) ||
+    hasComment(
+      node,
+      CommentCheckFlags.Trailing | CommentCheckFlags.Block,
+      (comment) =>
+        !hasNewline(options.originalText, locStart(comment), {
+          backwards: true,
+        }),
+    )
+  );
+}
+
 function maybeWrapJsxElementInParens(path, elem, options) {
-  const { parent } = path;
+  const { node, parent } = path;
 
   if (isNoWrapParent(parent)) {
     return elem;
   }
 
-  const shouldBreak = shouldBreakJsxElement(path);
   const needsParens = needsParentheses(path, options);
+  const { jsxWrapParens } = options;
+
+  // Optional parens only; never suppress syntactically required parens, and
+  // keep them when a comment makes unwrapping unsafe (see helper above).
+  // "never" always skips the wrapping; "preserve" skips it unless the source
+  // had parens around this element.
+  if (
+    !needsParens &&
+    !elementHasParenForcingComment(node, options) &&
+    (jsxWrapParens === "never" ||
+      (jsxWrapParens === "preserve" &&
+        !isParenthesizedInOriginalText(node, options)))
+  ) {
+    return elem;
+  }
+
+  const shouldBreak = shouldBreakJsxElement(path);
 
   return group(
     [

--- a/tests/format/jsx/wrap-parens/__snapshots__/format.test.js.snap
+++ b/tests/format/jsx/wrap-parens/__snapshots__/format.test.js.snap
@@ -1,0 +1,865 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`comments.js - {"jsxWrapParens":"never"} format 1`] = `
+====================================options=====================================
+jsxWrapParens: "never"
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// A leading comment keeps the wrapping parens even under "never"/"preserve":
+// a \`//\` can't share a line with the \`<\` open tag, so unwrapping would force
+// ASI after \`return\` and change semantics.
+
+function leadingLineComment() {
+  return (
+    // leading
+    <>
+      <A />
+    </>
+  );
+}
+
+function leadingBlockComment() {
+  return (
+    /* leading */
+    <>
+      <A />
+    </>
+  );
+}
+
+// A trailing block comment on the element's own line prints inline (before the
+// statement's semicolon), so the parens are kept to stay idempotent.
+function trailingSameLineBlockComment() {
+  return (
+    <>
+      <A />
+    </> /* trailing */
+  );
+}
+
+// Trailing line comments and own-line comments print as line suffixes (past
+// the semicolon) and unwrap cleanly.
+function trailingLineComment() {
+  return (
+    <>
+      <A />
+    </> // trailing
+  );
+}
+
+function trailingOwnLineBlockComment() {
+  return (
+    <>
+      <A />
+    </>
+    /* trailing */
+  );
+}
+
+// Comments inside the tag (attributes, names, values) or in the children attach
+// to descendant nodes, so they don't block stripping the optional parens.
+function attributeComment() {
+  return (
+    <div
+      // attr
+      className="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    >
+      <A />
+    </div>
+  );
+}
+
+function childComment() {
+  return (
+    <>
+      {/* child */}
+      <A />
+    </>
+  );
+}
+
+=====================================output=====================================
+// A leading comment keeps the wrapping parens even under "never"/"preserve":
+// a \`//\` can't share a line with the \`<\` open tag, so unwrapping would force
+// ASI after \`return\` and change semantics.
+
+function leadingLineComment() {
+  return (
+    // leading
+    <>
+      <A />
+    </>
+  );
+}
+
+function leadingBlockComment() {
+  return (
+    /* leading */
+    <>
+      <A />
+    </>
+  );
+}
+
+// A trailing block comment on the element's own line prints inline (before the
+// statement's semicolon), so the parens are kept to stay idempotent.
+function trailingSameLineBlockComment() {
+  return (
+    <>
+      <A />
+    </> /* trailing */
+  );
+}
+
+// Trailing line comments and own-line comments print as line suffixes (past
+// the semicolon) and unwrap cleanly.
+function trailingLineComment() {
+  return <>
+    <A />
+  </>; // trailing
+}
+
+function trailingOwnLineBlockComment() {
+  return <>
+    <A />
+  </>;
+  /* trailing */
+}
+
+// Comments inside the tag (attributes, names, values) or in the children attach
+// to descendant nodes, so they don't block stripping the optional parens.
+function attributeComment() {
+  return <div
+    // attr
+    className="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  >
+    <A />
+  </div>;
+}
+
+function childComment() {
+  return <>
+    {/* child */}
+    <A />
+  </>;
+}
+
+================================================================================
+`;
+
+exports[`comments.js - {"jsxWrapParens":"preserve"} format 1`] = `
+====================================options=====================================
+jsxWrapParens: "preserve"
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// A leading comment keeps the wrapping parens even under "never"/"preserve":
+// a \`//\` can't share a line with the \`<\` open tag, so unwrapping would force
+// ASI after \`return\` and change semantics.
+
+function leadingLineComment() {
+  return (
+    // leading
+    <>
+      <A />
+    </>
+  );
+}
+
+function leadingBlockComment() {
+  return (
+    /* leading */
+    <>
+      <A />
+    </>
+  );
+}
+
+// A trailing block comment on the element's own line prints inline (before the
+// statement's semicolon), so the parens are kept to stay idempotent.
+function trailingSameLineBlockComment() {
+  return (
+    <>
+      <A />
+    </> /* trailing */
+  );
+}
+
+// Trailing line comments and own-line comments print as line suffixes (past
+// the semicolon) and unwrap cleanly.
+function trailingLineComment() {
+  return (
+    <>
+      <A />
+    </> // trailing
+  );
+}
+
+function trailingOwnLineBlockComment() {
+  return (
+    <>
+      <A />
+    </>
+    /* trailing */
+  );
+}
+
+// Comments inside the tag (attributes, names, values) or in the children attach
+// to descendant nodes, so they don't block stripping the optional parens.
+function attributeComment() {
+  return (
+    <div
+      // attr
+      className="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    >
+      <A />
+    </div>
+  );
+}
+
+function childComment() {
+  return (
+    <>
+      {/* child */}
+      <A />
+    </>
+  );
+}
+
+=====================================output=====================================
+// A leading comment keeps the wrapping parens even under "never"/"preserve":
+// a \`//\` can't share a line with the \`<\` open tag, so unwrapping would force
+// ASI after \`return\` and change semantics.
+
+function leadingLineComment() {
+  return (
+    // leading
+    <>
+      <A />
+    </>
+  );
+}
+
+function leadingBlockComment() {
+  return (
+    /* leading */
+    <>
+      <A />
+    </>
+  );
+}
+
+// A trailing block comment on the element's own line prints inline (before the
+// statement's semicolon), so the parens are kept to stay idempotent.
+function trailingSameLineBlockComment() {
+  return (
+    <>
+      <A />
+    </> /* trailing */
+  );
+}
+
+// Trailing line comments and own-line comments print as line suffixes (past
+// the semicolon) and unwrap cleanly.
+function trailingLineComment() {
+  return (
+    <>
+      <A />
+    </> // trailing
+  );
+}
+
+function trailingOwnLineBlockComment() {
+  return (
+    <>
+      <A />
+    </>
+    /* trailing */
+  );
+}
+
+// Comments inside the tag (attributes, names, values) or in the children attach
+// to descendant nodes, so they don't block stripping the optional parens.
+function attributeComment() {
+  return (
+    <div
+      // attr
+      className="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    >
+      <A />
+    </div>
+  );
+}
+
+function childComment() {
+  return (
+    <>
+      {/* child */}
+      <A />
+    </>
+  );
+}
+
+================================================================================
+`;
+
+exports[`comments.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// A leading comment keeps the wrapping parens even under "never"/"preserve":
+// a \`//\` can't share a line with the \`<\` open tag, so unwrapping would force
+// ASI after \`return\` and change semantics.
+
+function leadingLineComment() {
+  return (
+    // leading
+    <>
+      <A />
+    </>
+  );
+}
+
+function leadingBlockComment() {
+  return (
+    /* leading */
+    <>
+      <A />
+    </>
+  );
+}
+
+// A trailing block comment on the element's own line prints inline (before the
+// statement's semicolon), so the parens are kept to stay idempotent.
+function trailingSameLineBlockComment() {
+  return (
+    <>
+      <A />
+    </> /* trailing */
+  );
+}
+
+// Trailing line comments and own-line comments print as line suffixes (past
+// the semicolon) and unwrap cleanly.
+function trailingLineComment() {
+  return (
+    <>
+      <A />
+    </> // trailing
+  );
+}
+
+function trailingOwnLineBlockComment() {
+  return (
+    <>
+      <A />
+    </>
+    /* trailing */
+  );
+}
+
+// Comments inside the tag (attributes, names, values) or in the children attach
+// to descendant nodes, so they don't block stripping the optional parens.
+function attributeComment() {
+  return (
+    <div
+      // attr
+      className="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    >
+      <A />
+    </div>
+  );
+}
+
+function childComment() {
+  return (
+    <>
+      {/* child */}
+      <A />
+    </>
+  );
+}
+
+=====================================output=====================================
+// A leading comment keeps the wrapping parens even under "never"/"preserve":
+// a \`//\` can't share a line with the \`<\` open tag, so unwrapping would force
+// ASI after \`return\` and change semantics.
+
+function leadingLineComment() {
+  return (
+    // leading
+    <>
+      <A />
+    </>
+  );
+}
+
+function leadingBlockComment() {
+  return (
+    /* leading */
+    <>
+      <A />
+    </>
+  );
+}
+
+// A trailing block comment on the element's own line prints inline (before the
+// statement's semicolon), so the parens are kept to stay idempotent.
+function trailingSameLineBlockComment() {
+  return (
+    <>
+      <A />
+    </> /* trailing */
+  );
+}
+
+// Trailing line comments and own-line comments print as line suffixes (past
+// the semicolon) and unwrap cleanly.
+function trailingLineComment() {
+  return (
+    <>
+      <A />
+    </> // trailing
+  );
+}
+
+function trailingOwnLineBlockComment() {
+  return (
+    <>
+      <A />
+    </>
+    /* trailing */
+  );
+}
+
+// Comments inside the tag (attributes, names, values) or in the children attach
+// to descendant nodes, so they don't block stripping the optional parens.
+function attributeComment() {
+  return (
+    <div
+      // attr
+      className="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    >
+      <A />
+    </div>
+  );
+}
+
+function childComment() {
+  return (
+    <>
+      {/* child */}
+      <A />
+    </>
+  );
+}
+
+================================================================================
+`;
+
+exports[`wrap-parens.js - {"jsxWrapParens":"never"} format 1`] = `
+====================================options=====================================
+jsxWrapParens: "never"
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+function bareReturn() {
+  return <>
+    <SomeElement />
+    <SomeOtherElement />
+  </>;
+}
+
+function parenReturn() {
+  return (
+    <>
+      <SomeElement />
+      <SomeOtherElement />
+    </>
+  );
+}
+
+function bareReturnElement() {
+  return <div>
+    <SomeElement />
+    <SomeOtherElement />
+  </div>;
+}
+
+function throwJsx() {
+  throw <div>
+    <SomeElement />
+    <SomeOtherElement />
+  </div>;
+}
+
+const bareArrow = () => <>
+  <SomeElement />
+  <SomeOtherElement />
+</>;
+
+const parenArrow = () => (
+  <>
+    <SomeElement />
+    <SomeOtherElement />
+  </>
+);
+
+const bareAssign = <>
+  <SomeElement />
+  <SomeOtherElement />
+</>;
+
+const parenAssign = (
+  <>
+    <SomeElement />
+    <SomeOtherElement />
+  </>
+);
+
+// Parens are syntactically required here and must be kept regardless of option.
+const mapped = (
+  <div>
+    <SomeElement />
+    <SomeOtherElement />
+  </div>
+).map((x) => x);
+
+=====================================output=====================================
+function bareReturn() {
+  return <>
+    <SomeElement />
+    <SomeOtherElement />
+  </>;
+}
+
+function parenReturn() {
+  return <>
+    <SomeElement />
+    <SomeOtherElement />
+  </>;
+}
+
+function bareReturnElement() {
+  return <div>
+    <SomeElement />
+    <SomeOtherElement />
+  </div>;
+}
+
+function throwJsx() {
+  throw <div>
+    <SomeElement />
+    <SomeOtherElement />
+  </div>;
+}
+
+const bareArrow = () => <>
+  <SomeElement />
+  <SomeOtherElement />
+</>;
+
+const parenArrow = () => <>
+  <SomeElement />
+  <SomeOtherElement />
+</>;
+
+const bareAssign = <>
+  <SomeElement />
+  <SomeOtherElement />
+</>;
+
+const parenAssign = <>
+  <SomeElement />
+  <SomeOtherElement />
+</>;
+
+// Parens are syntactically required here and must be kept regardless of option.
+const mapped = (
+  <div>
+    <SomeElement />
+    <SomeOtherElement />
+  </div>
+).map((x) => x);
+
+================================================================================
+`;
+
+exports[`wrap-parens.js - {"jsxWrapParens":"preserve"} format 1`] = `
+====================================options=====================================
+jsxWrapParens: "preserve"
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+function bareReturn() {
+  return <>
+    <SomeElement />
+    <SomeOtherElement />
+  </>;
+}
+
+function parenReturn() {
+  return (
+    <>
+      <SomeElement />
+      <SomeOtherElement />
+    </>
+  );
+}
+
+function bareReturnElement() {
+  return <div>
+    <SomeElement />
+    <SomeOtherElement />
+  </div>;
+}
+
+function throwJsx() {
+  throw <div>
+    <SomeElement />
+    <SomeOtherElement />
+  </div>;
+}
+
+const bareArrow = () => <>
+  <SomeElement />
+  <SomeOtherElement />
+</>;
+
+const parenArrow = () => (
+  <>
+    <SomeElement />
+    <SomeOtherElement />
+  </>
+);
+
+const bareAssign = <>
+  <SomeElement />
+  <SomeOtherElement />
+</>;
+
+const parenAssign = (
+  <>
+    <SomeElement />
+    <SomeOtherElement />
+  </>
+);
+
+// Parens are syntactically required here and must be kept regardless of option.
+const mapped = (
+  <div>
+    <SomeElement />
+    <SomeOtherElement />
+  </div>
+).map((x) => x);
+
+=====================================output=====================================
+function bareReturn() {
+  return <>
+    <SomeElement />
+    <SomeOtherElement />
+  </>;
+}
+
+function parenReturn() {
+  return (
+    <>
+      <SomeElement />
+      <SomeOtherElement />
+    </>
+  );
+}
+
+function bareReturnElement() {
+  return <div>
+    <SomeElement />
+    <SomeOtherElement />
+  </div>;
+}
+
+function throwJsx() {
+  throw <div>
+    <SomeElement />
+    <SomeOtherElement />
+  </div>;
+}
+
+const bareArrow = () => <>
+  <SomeElement />
+  <SomeOtherElement />
+</>;
+
+const parenArrow = () => (
+  <>
+    <SomeElement />
+    <SomeOtherElement />
+  </>
+);
+
+const bareAssign = <>
+  <SomeElement />
+  <SomeOtherElement />
+</>;
+
+const parenAssign = (
+  <>
+    <SomeElement />
+    <SomeOtherElement />
+  </>
+);
+
+// Parens are syntactically required here and must be kept regardless of option.
+const mapped = (
+  <div>
+    <SomeElement />
+    <SomeOtherElement />
+  </div>
+).map((x) => x);
+
+================================================================================
+`;
+
+exports[`wrap-parens.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+function bareReturn() {
+  return <>
+    <SomeElement />
+    <SomeOtherElement />
+  </>;
+}
+
+function parenReturn() {
+  return (
+    <>
+      <SomeElement />
+      <SomeOtherElement />
+    </>
+  );
+}
+
+function bareReturnElement() {
+  return <div>
+    <SomeElement />
+    <SomeOtherElement />
+  </div>;
+}
+
+function throwJsx() {
+  throw <div>
+    <SomeElement />
+    <SomeOtherElement />
+  </div>;
+}
+
+const bareArrow = () => <>
+  <SomeElement />
+  <SomeOtherElement />
+</>;
+
+const parenArrow = () => (
+  <>
+    <SomeElement />
+    <SomeOtherElement />
+  </>
+);
+
+const bareAssign = <>
+  <SomeElement />
+  <SomeOtherElement />
+</>;
+
+const parenAssign = (
+  <>
+    <SomeElement />
+    <SomeOtherElement />
+  </>
+);
+
+// Parens are syntactically required here and must be kept regardless of option.
+const mapped = (
+  <div>
+    <SomeElement />
+    <SomeOtherElement />
+  </div>
+).map((x) => x);
+
+=====================================output=====================================
+function bareReturn() {
+  return (
+    <>
+      <SomeElement />
+      <SomeOtherElement />
+    </>
+  );
+}
+
+function parenReturn() {
+  return (
+    <>
+      <SomeElement />
+      <SomeOtherElement />
+    </>
+  );
+}
+
+function bareReturnElement() {
+  return (
+    <div>
+      <SomeElement />
+      <SomeOtherElement />
+    </div>
+  );
+}
+
+function throwJsx() {
+  throw (
+    <div>
+      <SomeElement />
+      <SomeOtherElement />
+    </div>
+  );
+}
+
+const bareArrow = () => (
+  <>
+    <SomeElement />
+    <SomeOtherElement />
+  </>
+);
+
+const parenArrow = () => (
+  <>
+    <SomeElement />
+    <SomeOtherElement />
+  </>
+);
+
+const bareAssign = (
+  <>
+    <SomeElement />
+    <SomeOtherElement />
+  </>
+);
+
+const parenAssign = (
+  <>
+    <SomeElement />
+    <SomeOtherElement />
+  </>
+);
+
+// Parens are syntactically required here and must be kept regardless of option.
+const mapped = (
+  <div>
+    <SomeElement />
+    <SomeOtherElement />
+  </div>
+).map((x) => x);
+
+================================================================================
+`;

--- a/tests/format/jsx/wrap-parens/comments.js
+++ b/tests/format/jsx/wrap-parens/comments.js
@@ -1,0 +1,72 @@
+// A leading comment keeps the wrapping parens even under "never"/"preserve":
+// a `//` can't share a line with the `<` open tag, so unwrapping would force
+// ASI after `return` and change semantics.
+
+function leadingLineComment() {
+  return (
+    // leading
+    <>
+      <A />
+    </>
+  );
+}
+
+function leadingBlockComment() {
+  return (
+    /* leading */
+    <>
+      <A />
+    </>
+  );
+}
+
+// A trailing block comment on the element's own line prints inline (before the
+// statement's semicolon), so the parens are kept to stay idempotent.
+function trailingSameLineBlockComment() {
+  return (
+    <>
+      <A />
+    </> /* trailing */
+  );
+}
+
+// Trailing line comments and own-line comments print as line suffixes (past
+// the semicolon) and unwrap cleanly.
+function trailingLineComment() {
+  return (
+    <>
+      <A />
+    </> // trailing
+  );
+}
+
+function trailingOwnLineBlockComment() {
+  return (
+    <>
+      <A />
+    </>
+    /* trailing */
+  );
+}
+
+// Comments inside the tag (attributes, names, values) or in the children attach
+// to descendant nodes, so they don't block stripping the optional parens.
+function attributeComment() {
+  return (
+    <div
+      // attr
+      className="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    >
+      <A />
+    </div>
+  );
+}
+
+function childComment() {
+  return (
+    <>
+      {/* child */}
+      <A />
+    </>
+  );
+}

--- a/tests/format/jsx/wrap-parens/format.test.js
+++ b/tests/format/jsx/wrap-parens/format.test.js
@@ -1,0 +1,7 @@
+runFormatTest(import.meta, ["babel", "flow", "typescript"]);
+runFormatTest(import.meta, ["babel", "flow", "typescript"], {
+  jsxWrapParens: "never",
+});
+runFormatTest(import.meta, ["babel", "flow", "typescript"], {
+  jsxWrapParens: "preserve",
+});

--- a/tests/format/jsx/wrap-parens/wrap-parens.js
+++ b/tests/format/jsx/wrap-parens/wrap-parens.js
@@ -1,0 +1,61 @@
+function bareReturn() {
+  return <>
+    <SomeElement />
+    <SomeOtherElement />
+  </>;
+}
+
+function parenReturn() {
+  return (
+    <>
+      <SomeElement />
+      <SomeOtherElement />
+    </>
+  );
+}
+
+function bareReturnElement() {
+  return <div>
+    <SomeElement />
+    <SomeOtherElement />
+  </div>;
+}
+
+function throwJsx() {
+  throw <div>
+    <SomeElement />
+    <SomeOtherElement />
+  </div>;
+}
+
+const bareArrow = () => <>
+  <SomeElement />
+  <SomeOtherElement />
+</>;
+
+const parenArrow = () => (
+  <>
+    <SomeElement />
+    <SomeOtherElement />
+  </>
+);
+
+const bareAssign = <>
+  <SomeElement />
+  <SomeOtherElement />
+</>;
+
+const parenAssign = (
+  <>
+    <SomeElement />
+    <SomeOtherElement />
+  </>
+);
+
+// Parens are syntactically required here and must be kept regardless of option.
+const mapped = (
+  <div>
+    <SomeElement />
+    <SomeOtherElement />
+  </div>
+).map((x) => x);

--- a/tests/integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests/integration/__tests__/__snapshots__/early-exit.js.snap
@@ -63,6 +63,9 @@ Format options:
                            Defaults to css.
   --jsx-single-quote       Use single quotes in JSX.
                            Defaults to false.
+  --jsx-wrap-parens <always|never|preserve>
+                           How to wrap multiline JSX in parentheses where they are not syntactically required.
+                           Defaults to always.
   --object-wrap <preserve|collapse>
                            How to wrap object literals.
                            Defaults to preserve.
@@ -239,6 +242,9 @@ Format options:
                            Defaults to css.
   --jsx-single-quote       Use single quotes in JSX.
                            Defaults to false.
+  --jsx-wrap-parens <always|never|preserve>
+                           How to wrap multiline JSX in parentheses where they are not syntactically required.
+                           Defaults to always.
   --object-wrap <preserve|collapse>
                            How to wrap object literals.
                            Defaults to preserve.

--- a/tests/integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests/integration/__tests__/__snapshots__/help-options.js.snap
@@ -330,6 +330,24 @@ Default: false",
 }
 `;
 
+exports[`show detailed usage with --help jsx-wrap-parens  1`] = `
+{
+  "stderr": "",
+  "stdout": "--jsx-wrap-parens <always|never|preserve>
+
+  How to wrap multiline JSX in parentheses where they are not syntactically required.
+
+Valid options:
+
+  always     Always wrap multiline JSX in parentheses.
+  never      Never add parentheses around multiline JSX where they are not required.
+  preserve   Keep parentheses around multiline JSX only if the original code had them.
+
+Default: always",
+  "write": [],
+}
+`;
+
 exports[`show detailed usage with --help list-different  1`] = `
 {
   "stderr": "",

--- a/tests/integration/__tests__/__snapshots__/schema.js.snap
+++ b/tests/integration/__tests__/__snapshots__/schema.js.snap
@@ -156,6 +156,30 @@ exports[`schema 1`] = `
           "description": "Use single quotes in JSX.",
           "type": "boolean",
         },
+        "jsxWrapParens": {
+          "default": "always",
+          "description": "How to wrap multiline JSX in parentheses where they are not syntactically required.",
+          "oneOf": [
+            {
+              "description": "Always wrap multiline JSX in parentheses.",
+              "enum": [
+                "always",
+              ],
+            },
+            {
+              "description": "Never add parentheses around multiline JSX where they are not required.",
+              "enum": [
+                "never",
+              ],
+            },
+            {
+              "description": "Keep parentheses around multiline JSX only if the original code had them.",
+              "enum": [
+                "preserve",
+              ],
+            },
+          ],
+        },
         "objectWrap": {
           "default": "preserve",
           "description": "How to wrap object literals.",

--- a/tests/integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests/integration/__tests__/__snapshots__/support-info.js.snap
@@ -170,6 +170,15 @@ exports[`API getSupportInfo() 1`] = `
       "default": false,
       "type": "boolean",
     },
+    "jsxWrapParens": {
+      "choices": [
+        "always",
+        "never",
+        "preserve",
+      ],
+      "default": "always",
+      "type": "choice",
+    },
     "objectWrap": {
       "choices": [
         "preserve",
@@ -954,6 +963,28 @@ exports[`CLI --support-info  1`] = `
       "name": "jsxSingleQuote",
       "pluginDefaults": {},
       "type": "boolean"
+    },
+    {
+      "category": "JavaScript",
+      "choices": [
+        {
+          "description": "Always wrap multiline JSX in parentheses.",
+          "value": "always"
+        },
+        {
+          "description": "Never add parentheses around multiline JSX where they are not required.",
+          "value": "never"
+        },
+        {
+          "description": "Keep parentheses around multiline JSX only if the original code had them.",
+          "value": "preserve"
+        }
+      ],
+      "default": "always",
+      "description": "How to wrap multiline JSX in parentheses where they are not syntactically required.",
+      "name": "jsxWrapParens",
+      "pluginDefaults": {},
+      "type": "choice"
     },
     {
       "category": "Common",


### PR DESCRIPTION
Adds a `jsxWrapParens` option for JavaScript/JSX, controlling whether multiline JSX is wrapped in parentheses in positions where they are not syntactically required (return/throw, arrow bodies, assignments, etc). The default keeps output unchanged.

- `always`: current behavior.
- `never`: never add the optional parens; print JSX inline without the extra indentation level.
- `preserve`: keep the parens only if the source already had them.

Includes option declaration, TypeScript type, docs, and fixtures covering the option variants and all comment shapes.

Should fix #18298

Diff was generated with assistance from Claude Code, so review carefully. Let me know if I can clean anything up.