### PR TITLE
Warn when an explicitly specified file is in an ignored directory

### DIFF
--- a/changelog_unreleased/cli/19242.md
+++ b/changelog_unreleased/cli/19242.md
@@ -1,0 +1,17 @@
+#### Warn when an explicitly specified file is in an ignored directory (#19242 by @xfocus3)
+
+When a file inside an ignored directory (such as `node_modules`) was passed explicitly on the
+CLI, Prettier silently skipped it, often leaving a confusing `No matching files` error. Prettier
+now reports the ignored path, and points to `--with-node-modules` when the path is inside
+`node_modules`.
+
+<!-- prettier-ignore -->
+```console
+# Prettier stable
+$ prettier node_modules/vue/dist/vue.global.prod.js
+[error] No matching files. Patterns: node_modules/vue/dist/vue.global.prod.js
+
+# Prettier main
+$ prettier node_modules/vue/dist/vue.global.prod.js
+[error] Explicitly specified pattern "node_modules/vue/dist/vue.global.prod.js" is ignored. Use the `--with-node-modules` flag to format files inside the `node_modules` directory.
+```

--- a/src/cli/expand-patterns.js
+++ b/src/cli/expand-patterns.js
@@ -65,6 +65,23 @@ async function* expandPatternsInternal(context) {
     const absolutePath = path.resolve(pattern);
 
     if (directoryIgnorer.shouldIgnore(absolutePath)) {
+      if (context.argv.errorOnUnmatchedPattern !== false) {
+        const isInNodeModules = path
+          .relative(cwd, absolutePath)
+          .split(path.sep)
+          .includes("node_modules");
+        yield {
+          error:
+            `Explicitly specified pattern "${pattern}" is ignored.` +
+            (isInNodeModules && context.argv.withNodeModules !== true
+              ? " Use the `--with-node-modules` flag to format files inside the `node_modules` directory."
+              : ""),
+        };
+      } else {
+        context.logger.debug(
+          `Skipping pattern "${pattern}", as it is inside an ignored directory.`,
+        );
+      }
       continue;
     }
 

--- a/tests/integration/__tests__/__snapshots__/with-node-modules.js.snap
+++ b/tests/integration/__tests__/__snapshots__/with-node-modules.js.snap
@@ -33,7 +33,8 @@ regular-module.js",
 
 exports[`ignores node_modules by default for file list  1`] = `
 {
-  "stderr": "",
+  "stderr": "[error] Explicitly specified pattern "node_modules/node-module.js" is ignored. Use the \`--with-node-modules\` flag to format files inside the \`node_modules\` directory.
+[error] Explicitly specified pattern "nested/node_modules/node-module.js" is ignored. Use the \`--with-node-modules\` flag to format files inside the \`node_modules\` directory.",
   "stdout": "not_node_modules/file.js
 regular-module.js",
   "write": [],

--- a/tests/integration/__tests__/with-node-modules.js
+++ b/tests/integration/__tests__/with-node-modules.js
@@ -28,7 +28,7 @@ describe("ignores node_modules by default for file list", () => {
     "regular-module.js",
     "-l",
   ]).test({
-    status: 1,
+    status: 2,
   });
 });
 


### PR DESCRIPTION
## Description

Fixes #15700.

When a file path inside an ignored directory (such as `node_modules`) is passed explicitly on the CLI, Prettier silently skips it. Because no entry is yielded, the user often ends up with a confusing generic `No matching files` error and no indication that the file was ignored.

This change makes an explicitly specified pattern that resolves into an ignored directory produce a clear error, and when the path is inside `node_modules` the message also points to the `--with-node-modules` flag.

### Before

```console
$ prettier node_modules/vue/dist/vue.global.prod.js
[error] No matching files. Patterns: node_modules/vue/dist/vue.global.prod.js
```

### After

```console
$ prettier node_modules/vue/dist/vue.global.prod.js
[error] Explicitly specified pattern "node_modules/vue/dist/vue.global.prod.js" is ignored. Use the `--with-node-modules` flag to format files inside the `node_modules` directory.
```

This is consistent with how Prettier already reports other explicitly specified but unusable paths (symbolic links, files excluded by negative glob patterns): the message is logged via `logger.error` and the process exits with code 2, while other files passed in the same invocation are still formatted.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory). — No documented option changes; this only improves diagnostics for explicitly passed ignored paths.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the contributing guidelines.
