### PR TITLE
Freeze builtin doc IR singletons and options maps

### DIFF
--- a/src/common/common-options.evaluate.js
+++ b/src/common/common-options.evaluate.js
@@ -1,7 +1,7 @@
 const CATEGORY_COMMON = "Common";
 
 // format based on https://github.com/prettier/prettier/blob/main/src/main/core-options.evaluate.js
-const options = {
+const options = Object.freeze({
   bracketSpacing: {
     category: CATEGORY_COMMON,
     type: "boolean",
@@ -65,6 +65,6 @@ const options = {
     default: false,
     description: "Enforce single attribute per line in HTML, Vue and JSX.",
   },
-};
+});
 
 export default options;

--- a/src/document/builders/break-parent.js
+++ b/src/document/builders/break-parent.js
@@ -5,6 +5,6 @@ import { DOC_TYPE_BREAK_PARENT } from "./types.js";
 */
 
 /** @typedef {BreakParent} */
-const breakParent = { type: DOC_TYPE_BREAK_PARENT };
+const breakParent = Object.freeze({ type: DOC_TYPE_BREAK_PARENT });
 
 export { breakParent };

--- a/src/document/builders/cursor.js
+++ b/src/document/builders/cursor.js
@@ -5,6 +5,6 @@ import { DOC_TYPE_CURSOR } from "./types.js";
 */
 
 /** @type {Cursor} */
-const cursor = { type: DOC_TYPE_CURSOR };
+const cursor = Object.freeze({ type: DOC_TYPE_CURSOR });
 
 export { cursor };

--- a/src/document/builders/line-suffix-boundary.js
+++ b/src/document/builders/line-suffix-boundary.js
@@ -5,6 +5,6 @@ import { DOC_TYPE_LINE_SUFFIX_BOUNDARY } from "./types.js";
 */
 
 /** @typedef {LineSuffixBoundary} */
-const lineSuffixBoundary = { type: DOC_TYPE_LINE_SUFFIX_BOUNDARY };
+const lineSuffixBoundary = Object.freeze({ type: DOC_TYPE_LINE_SUFFIX_BOUNDARY });
 
 export { lineSuffixBoundary };

--- a/src/document/builders/line.js
+++ b/src/document/builders/line.js
@@ -18,21 +18,21 @@ import { DOC_TYPE_LINE } from "./types.js";
 */
 
 /** @type {Line} */
-const line = { type: DOC_TYPE_LINE };
+const line = Object.freeze({ type: DOC_TYPE_LINE });
 /** @type {SoftLine} */
-const softline = { type: DOC_TYPE_LINE, soft: true };
+const softline = Object.freeze({ type: DOC_TYPE_LINE, soft: true });
 /** @type {HardlineWithoutBreakParent} */
-const hardlineWithoutBreakParent = { type: DOC_TYPE_LINE, hard: true };
+const hardlineWithoutBreakParent = Object.freeze({ type: DOC_TYPE_LINE, hard: true });
 /** @type {HardLine} */
-const hardline = [hardlineWithoutBreakParent, breakParent];
+const hardline = Object.freeze([hardlineWithoutBreakParent, breakParent]);
 /** @type {LiterallineWithoutBreakParent} */
-const literallineWithoutBreakParent = {
+const literallineWithoutBreakParent = Object.freeze({
   type: DOC_TYPE_LINE,
   hard: true,
   literal: true,
-};
+});
 /** @type {Literalline} */
-const literalline = [literallineWithoutBreakParent, breakParent];
+const literalline = Object.freeze([literallineWithoutBreakParent, breakParent]);
 
 export {
   hardline,

--- a/src/document/builders/trim.js
+++ b/src/document/builders/trim.js
@@ -5,6 +5,6 @@ import { DOC_TYPE_TRIM } from "./types.js";
 */
 
 /** @typedef {Trim} */
-const trim = { type: DOC_TYPE_TRIM };
+const trim = Object.freeze({ type: DOC_TYPE_TRIM });
 
 export { trim };

--- a/src/main/core-options.evaluate.js
+++ b/src/main/core-options.evaluate.js
@@ -43,7 +43,7 @@ import {
  */
 
 /** @type {{ [name: string]: OptionInfo }} */
-const options = {
+const options = Object.freeze({
   checkIgnorePragma: {
     category: CATEGORY_SPECIAL,
     type: "boolean",
@@ -219,6 +219,6 @@ const options = {
       },
     ],
   },
-};
+});
 
 export default options;

--- a/tests/integration/__tests__/doc-builders.js
+++ b/tests/integration/__tests__/doc-builders.js
@@ -1,16 +1,25 @@
 import prettier from "../../config/prettier-entry.js";
+import commonOptions from "../../../src/common/common-options.evaluate.js";
+import coreOptions from "../../../src/main/core-options.evaluate.js";
+
 const {
-  join,
-  hardline,
-  literalline,
-  group,
-  fill,
-  line,
-  lineSuffix,
+  align,
   breakParent,
+  cursor,
+  fill,
+  group,
+  hardline,
+  hardlineWithoutBreakParent,
   ifBreak,
   indent,
-  align,
+  join,
+  line,
+  lineSuffix,
+  lineSuffixBoundary,
+  literalline,
+  literallineWithoutBreakParent,
+  softline,
+  trim,
 } = prettier.doc.builders;
 
 describe("doc builders", () => {
@@ -72,5 +81,25 @@ describe("doc builders", () => {
     ],
   ])("%s", (_, doc, expected) => {
     expect(doc).toStrictEqual(expected);
+  });
+
+  test.each([
+    ["breakParent", breakParent],
+    ["cursor", cursor],
+    ["hardline", hardline],
+    ["hardlineWithoutBreakParent", hardlineWithoutBreakParent],
+    ["line", line],
+    ["lineSuffixBoundary", lineSuffixBoundary],
+    ["literalline", literalline],
+    ["literallineWithoutBreakParent", literallineWithoutBreakParent],
+    ["softline", softline],
+    ["trim", trim],
+  ])("freezes built-in %s docs", (_, doc) => {
+    expect(Object.isFrozen(doc)).toBe(true);
+  });
+
+  test("freezes built-in options maps", () => {
+    expect(Object.isFrozen(coreOptions)).toBe(true);
+    expect(Object.isFrozen(commonOptions)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- freeze the shared builtin doc IR singleton values exposed by Prettier
- freeze the top-level builtin options maps used for support info
- add an integration test that verifies these builtin objects stay frozen

Fixes #10182

## Validation
- `corepack yarn prettier tests/integration/__tests__/doc-builders.js --check`
- `corepack yarn test tests/integration/__tests__/doc-builders.js tests/integration/__tests__/doc-printer.js tests/integration/__tests__/doc-trim.js tests/integration/__tests__/line-suffix-boundary.js --runInBand`