### PR TITLE
fix(scss): don't treat `!default`/`!global` inside strings as flags

### DIFF
--- a/changelog_unreleased/scss/19245.md
+++ b/changelog_unreleased/scss/19245.md
@@ -1,0 +1,21 @@
+#### Don't treat `!default`/`!global` inside strings as declaration flags (#19245 by @xfocus3)
+
+`!default` and `!global` appearing inside a string or function argument are no longer mistaken for Sass declaration flags, so the surrounding value is left untouched.
+
+<!-- prettier-ignore -->
+```scss
+// Input
+$a: "!default";
+$b: unquote("!default");
+$c: url("x!global");
+
+// Prettier stable
+$a: " !default";
+$b: unquote(" !default");
+$c: url("x !global");
+
+// Prettier main
+$a: "!default";
+$b: unquote("!default");
+$c: url("x!global");
+```

--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -22,6 +22,77 @@ import isSCSSNestedPropertyNode from "./utilities/is-scss-nested-property-node.j
 const DEFAULT_SCSS_DIRECTIVE = /(\s*)(!default).*$/;
 const GLOBAL_SCSS_DIRECTIVE = /(\s*)(!global).*$/;
 
+// Detect a trailing SCSS declaration flag (`!default` / `!global`) while
+// ignoring occurrences inside strings or function arguments (e.g.
+// `$a: "!default"` or `$b: unquote("!default")`). A genuine flag is parsed as
+// a top-level `value-word` node whose value matches the directive, optionally
+// followed only by comments.
+//
+// When the value cannot be parsed structurally, falls back to a regex match
+// to preserve the previous behavior. Returns `{ raw, value }` when a flag is
+// found, otherwise `null`.
+function matchTrailingSCSSDirective(value, directive, regex, options) {
+  if (!value.includes(directive)) {
+    return null;
+  }
+
+  const parsed = parseValue(value, options);
+
+  if (parsed.type !== "value-unknown") {
+    const topLevelGroup = parsed.group?.group;
+    if (!topLevelGroup) {
+      return null;
+    }
+
+    // The trailing flag (if any) is the final space-separated word of the
+    // value. For a plain value (e.g. `12px !default`) the words are the groups
+    // of the top-level node. For a comma-separated value (e.g.
+    // `$x, $y !default`) the flag lives in the *last* comma item, which is
+    // itself a group of words.
+    let scope = topLevelGroup;
+    const { groups } = scope;
+    if (groups?.length > 0) {
+      const lastGroup = groups.at(-1);
+      if (lastGroup?.groups) {
+        scope = lastGroup;
+      }
+    }
+
+    const candidateNodes = scope.groups ?? [scope];
+
+    const lastNonCommentIndex = candidateNodes.findLastIndex(
+      (node) => node.type !== "value-comment",
+    );
+    const directiveNode = candidateNodes[lastNonCommentIndex];
+
+    if (
+      directiveNode?.type !== "value-word" ||
+      directiveNode.value !== directive
+    ) {
+      return null;
+    }
+
+    const startIndex =
+      directiveNode.sourceIndex - (directiveNode.raws?.before?.length ?? 0);
+
+    return {
+      raw: value.slice(startIndex),
+      value: value.slice(0, startIndex),
+    };
+  }
+
+  // Could not parse the value structurally; fall back to the regex.
+  const match = value.match(regex);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    raw: match[0],
+    value: value.slice(0, match.index),
+  };
+}
+
 function parseNestedCSS(node, options) {
   if (isObject(node)) {
     delete node.parent;
@@ -163,25 +234,35 @@ function parseNestedCSS(node, options) {
     }
 
     if (value.trim().length > 0) {
-      const defaultSCSSDirectiveIndex = value.match(DEFAULT_SCSS_DIRECTIVE);
+      const defaultSCSSDirective = matchTrailingSCSSDirective(
+        value,
+        "!default",
+        DEFAULT_SCSS_DIRECTIVE,
+        options,
+      );
 
-      if (defaultSCSSDirectiveIndex) {
-        value = value.slice(0, defaultSCSSDirectiveIndex.index);
+      if (defaultSCSSDirective) {
+        value = defaultSCSSDirective.value;
         node.scssDefault = true;
 
-        if (defaultSCSSDirectiveIndex[0].trim() !== "!default") {
-          node.raws.scssDefault = defaultSCSSDirectiveIndex[0];
+        if (defaultSCSSDirective.raw.trim() !== "!default") {
+          node.raws.scssDefault = defaultSCSSDirective.raw;
         }
       }
 
-      const globalSCSSDirectiveIndex = value.match(GLOBAL_SCSS_DIRECTIVE);
+      const globalSCSSDirective = matchTrailingSCSSDirective(
+        value,
+        "!global",
+        GLOBAL_SCSS_DIRECTIVE,
+        options,
+      );
 
-      if (globalSCSSDirectiveIndex) {
-        value = value.slice(0, globalSCSSDirectiveIndex.index);
+      if (globalSCSSDirective) {
+        value = globalSCSSDirective.value;
         node.scssGlobal = true;
 
-        if (globalSCSSDirectiveIndex[0].trim() !== "!global") {
-          node.raws.scssGlobal = globalSCSSDirectiveIndex[0];
+        if (globalSCSSDirective.raw.trim() !== "!global") {
+          node.raws.scssGlobal = globalSCSSDirective.raw;
         }
       }
 

--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -19,8 +19,8 @@ import { hasIgnorePragma, hasPragma } from "./pragma.js";
 import isModuleRuleName from "./utilities/is-module-rule-name.js";
 import isSCSSNestedPropertyNode from "./utilities/is-scss-nested-property-node.js";
 
-const DEFAULT_SCSS_DIRECTIVE = /(\s*)(!default).*$/;
-const GLOBAL_SCSS_DIRECTIVE = /(\s*)(!global).*$/;
+const DEFAULT_SCSS_DIRECTIVE = /(\s*)(!default)\s?$/;
+const GLOBAL_SCSS_DIRECTIVE = /(\s*)(!global)\s?$/;
 
 // Detect a trailing SCSS declaration flag (`!default` / `!global`) while
 // ignoring occurrences inside strings or function arguments (e.g.

--- a/tests/format/scss/flag/19203.scss
+++ b/tests/format/scss/flag/19203.scss
@@ -1,0 +1,6 @@
+$a: "!default";
+$b: unquote("!default");
+$c: url("x!global");
+$d: "!default" !default;
+$e: "x!global" !global;
+$f: map-get($map, "!default") !default;

--- a/tests/format/scss/flag/__snapshots__/format.test.js.snap
+++ b/tests/format/scss/flag/__snapshots__/format.test.js.snap
@@ -83,3 +83,51 @@ $global: "very-long-long-long-long-long-long-long-long-long-long-long-value" !gl
 
 ================================================================================
 `;
+
+exports[`19203.scss - {"trailingComma":"es5"} format 1`] = `
+====================================options=====================================
+parsers: ["scss"]
+trailingComma: "es5"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+$a: "!default";
+$b: unquote("!default");
+$c: url("x!global");
+$d: "!default" !default;
+$e: "x!global" !global;
+$f: map-get($map, "!default") !default;
+
+=====================================output=====================================
+$a: "!default";
+$b: unquote("!default");
+$c: url("x!global");
+$d: "!default" !default;
+$e: "x!global" !global;
+$f: map-get($map, "!default") !default;
+
+================================================================================
+`;
+
+exports[`19203.scss - {"trailingComma":"none"} format 1`] = `
+====================================options=====================================
+parsers: ["scss"]
+trailingComma: "none"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+$a: "!default";
+$b: unquote("!default");
+$c: url("x!global");
+$d: "!default" !default;
+$e: "x!global" !global;
+$f: map-get($map, "!default") !default;
+
+=====================================output=====================================
+$a: "!default";
+$b: unquote("!default");
+$c: url("x!global");
+$d: "!default" !default;
+$e: "x!global" !global;
+$f: map-get($map, "!default") !default;
+
+================================================================================
+`;


### PR DESCRIPTION
## Description

Closes #19203.

When `!default` or `!global` appeared inside a string or function argument in SCSS, Prettier treated it as a Sass declaration flag and split it off the value, injecting a stray space:

```scss
/* input */
$a: "!default";
$b: unquote("!default");
$c: url("x!global");

/* output before this PR */
$a: " !default";
$b: unquote(" !default");
$c: url("x !global");
```

### Cause

The flag was detected with `value.match(/(\s*)(!default).*$/)`, which matches the raw `!default` / `!global` text **anywhere** in the value — including inside strings and `url(...)` / function arguments — and then sliced everything after it off the value.

### Fix

Detect the directive structurally. A genuine trailing flag parses as the final top-level `value-word` node whose value is exactly `!default` / `!global` (optionally followed only by comments). Text inside a string parses as a `value-string`, and text inside a function parses as a `value-func`, so those are correctly left untouched. The comma-separated case (where the flag lives in the last comma item) is handled too. If the value can't be parsed structurally, it falls back to the original regex so existing behavior is preserved.

```scss
/* output after this PR */
$a: "!default";
$b: unquote("!default");
$c: url("x!global");

/* genuine flags still work, including alongside a string value */
$d: "!default" !default;
$e: "x!global" !global;
$f: map-get($map, "!default") !default;
```

## Checklist

- [x] Added a regression fixture (`tests/format/scss/flag/19203.scss`) covering in-string, function-argument, and mixed string-plus-genuine-flag cases.
- [x] `yarn jest tests/format/scss tests/format/css tests/format/less` passes (358/358).
- [x] `yarn eslint src/language-css/parser-postcss.js` passes.
- [x] `yarn lint:prettier` passes.
