### PR TITLE
fix(api): don't reject array options left unset when they have a default

### DIFF
--- a/changelog_unreleased/api/19246.md
+++ b/changelog_unreleased/api/19246.md
@@ -1,0 +1,15 @@
+#### Don't reject array options left unset when they have a default (#19246 by @xfocus3)
+
+A plugin option declared with `array: true` and a `default` value no longer throws when the option is left unset. Previously it failed with `Invalid <name> value. Expected an array of ..., but received undefined`.
+
+<!-- prettier-ignore -->
+```js
+// Plugin option:
+//   myOption: { type: "path", array: true, default: [{ value: ["x"] }] }
+
+// Prettier stable
+// [error] Invalid myOption value. Expected an array of a string, but received undefined.
+
+// Prettier main
+// (formats successfully; the default is applied)
+```

--- a/src/main/normalize-options.js
+++ b/src/main/normalize-options.js
@@ -206,6 +206,19 @@ function optionInfoToSchema(optionInfo, { isCLI, optionInfos, FlagSchema }) {
     ? vnopts.ArraySchema.create({
         ...(isCLI ? { preprocess: (v) => (Array.isArray(v) ? v : [v]) } : {}),
         ...handlers,
+        // An unset option (`undefined`) should be ignored so its default can be
+        // applied, just like non-array options. `ArraySchema` otherwise treats
+        // `undefined` as an invalid value and its `forward`/`redirect`/
+        // `deprecated` handlers iterate over the value, throwing on `undefined`.
+        // Guard each handler so `undefined` passes through untouched.
+        validate: (value, schema, utils) =>
+          value === undefined || schema.validate(value, utils),
+        forward: (value, schema, utils) =>
+          value === undefined ? undefined : schema.forward(value, utils),
+        redirect: (value, schema, utils) =>
+          value === undefined ? undefined : schema.redirect(value, utils),
+        deprecated: (value, schema, utils) =>
+          value === undefined ? false : schema.deprecated(value, utils),
         // @ts-expect-error
         valueSchema: SchemaConstructor.create(parameters),
       })

--- a/tests/integration/__tests__/plugin-default-options.js
+++ b/tests/integration/__tests__/plugin-default-options.js
@@ -39,3 +39,40 @@ describe("overriding plugin default options should work", () => {
     write: [],
   });
 });
+
+describe("plugin array option with a default value should work (#19012)", () => {
+  runCli(
+    "plugins/array-option-default",
+    [
+      "--stdin-filepath",
+      "example.foo",
+      "--plugin=./plugin.cjs",
+      "--no-editorconfig",
+    ],
+    { input: "hello-world" },
+  ).test({
+    stdout: JSON.stringify({ fooArrayOption: ["default-value"] }),
+    stderr: "",
+    status: 0,
+    write: [],
+  });
+});
+
+describe("overriding plugin array option should work", () => {
+  runCli(
+    "plugins/array-option-default",
+    [
+      "--stdin-filepath",
+      "example.foo",
+      "--plugin=./plugin.cjs",
+      "--no-editorconfig",
+      "--foo-array-option=custom-value",
+    ],
+    { input: "hello-world" },
+  ).test({
+    stdout: JSON.stringify({ fooArrayOption: ["custom-value"] }),
+    stderr: "",
+    status: 0,
+    write: [],
+  });
+});

--- a/tests/integration/plugins/array-option-default/plugin.cjs
+++ b/tests/integration/plugins/array-option-default/plugin.cjs
@@ -1,0 +1,34 @@
+"use strict";
+
+// Regression fixture for #19012: a plugin option with `array: true` and a
+// `default` value must not throw "Expected an array of ..., but received
+// undefined" when the option is left unset.
+module.exports = {
+  languages: [
+    {
+      name: "foo",
+      parsers: ["foo-parser"],
+      extensions: [".foo"],
+    },
+  ],
+  options: {
+    fooArrayOption: {
+      type: "path",
+      array: true,
+      default: [{ value: ["default-value"] }],
+      description: "foo array option",
+    },
+  },
+  parsers: {
+    "foo-parser": {
+      parse: (text) => ({ text }),
+      astFormat: "foo-ast",
+    },
+  },
+  printers: {
+    "foo-ast": {
+      print: (path, options) =>
+        JSON.stringify({ fooArrayOption: options.fooArrayOption }),
+    },
+  },
+};


### PR DESCRIPTION
## Description

Closes #19012.

A plugin option declared with `array: true` **and** a `default` value threw when the option was left unset:

```
[error] Invalid <name> value. Expected an array of a string, but received undefined.
```

(and, once that was bypassed, `[error] value is not iterable`).

### Cause

In `optionInfoToSchema` (`src/main/normalize-options.js`), an `array` option is wrapped in `vnopts.ArraySchema`. Non-array schemas already allow an unset (`undefined`) value to pass through so the default can be applied later (`value === undefined || schema.validate(...)`), but the array wrapper did not:

- `ArraySchema.validate(undefined)` returns `false` → "Expected an array of …, but received undefined".
- `ArraySchema.forward` / `redirect` / `deprecated` iterate the value (`for (const subValue of value)`), so they throw `value is not iterable` on `undefined`.

The default is only filled in *after* normalization, so an option that is referenced while still `undefined` (e.g. set to `undefined` in a config, or passed through by tooling) hit this.

### Fix

Guard the array schema handlers so an `undefined` value passes through untouched, mirroring how non-array options already behave. The option is then dropped during normalization and its default is applied as expected. Explicitly-provided array values are unaffected.

## Test plan

Added regression tests in `tests/integration/__tests__/plugin-default-options.js` using a new fixture plugin (`tests/integration/plugins/array-option-default/`) that declares an `array` option with a default:

- option unset → default is applied (previously threw)
- option provided on the CLI → provided value is used

All existing plugin/config/normalization integration and unit tests pass.
