### PR TITLE
fix(cli): print check summary when using --check with stdin

### DIFF
--- a/changelog_unreleased/cli/19247.md
+++ b/changelog_unreleased/cli/19247.md
@@ -1,0 +1,16 @@
+#### Print check summary when using `--check` with stdin (#19247 by @xfocus3)
+
+Using `--check` with stdin previously printed only a bare `(stdin)`. It now prints the same `Checking formatting...` header and summary line as when checking files.
+
+<!-- prettier-ignore -->
+```console
+// Prettier stable
+$ echo 'const x=1' | prettier --check --stdin-filepath foo.js
+(stdin)
+
+// Prettier main
+$ echo 'const x=1' | prettier --check --stdin-filepath foo.js
+Checking formatting...
+(stdin)
+[warn] Code style issues found in the above file. Run Prettier with --write to fix.
+```

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -94,9 +94,10 @@ async function listDifferent(context, input, options, filename) {
     }
   } catch (error) {
     context.logger.error(error.message);
+    return { error: true };
   }
 
-  return true;
+  return { error: false };
 }
 
 async function format(context, input, opt) {
@@ -249,7 +250,27 @@ async function formatStdin(context) {
       filepath: absoluteFilepath,
     };
 
-    if (await listDifferent(context, input, options, "(stdin)")) {
+    if (context.argv.check || context.argv.listDifferent) {
+      if (context.argv.check) {
+        context.logger.log("Checking formatting...");
+      }
+
+      const { error } = await listDifferent(context, input, options, "(stdin)");
+
+      // `listDifferent` sets `process.exitCode` to 1 when the input isn't
+      // already formatted. For `--check`, print the same summary as when
+      // checking files so the output isn't just a bare `(stdin)`. Skip the
+      // summary when an error (e.g. no inferable parser) was already reported.
+      if (context.argv.check && !error) {
+        if (process.exitCode === 1) {
+          context.logger.warn(
+            "Code style issues found in the above file. Run Prettier with --write to fix.",
+          );
+        } else {
+          context.logger.log("All matched files use Prettier code style!");
+        }
+      }
+
       return;
     }
 

--- a/tests/integration/__tests__/__snapshots__/check.js.snap
+++ b/tests/integration/__tests__/__snapshots__/check.js.snap
@@ -28,6 +28,12 @@ exports[`--checks works in CI just as in a non-TTY mode  2`] = `
 }
 `;
 
+exports[`checks already-formatted stdin with --check  1`] = `
+{
+  "write": [],
+}
+`;
+
 exports[`checks stdin with --check  1`] = `
 {
   "write": [],

--- a/tests/integration/__tests__/check.js
+++ b/tests/integration/__tests__/check.js
@@ -2,8 +2,9 @@ describe("checks stdin with --check", () => {
   runCli("cli/with-shebang", ["--check", "--parser", "babel"], {
     input: "0",
   }).test({
-    stdout: "(stdin)",
-    stderr: "",
+    stdout: "Checking formatting...\n(stdin)",
+    stderr:
+      "[warn] Code style issues found in the above file. Run Prettier with --write to fix.",
     status: "non-zero",
   });
 });
@@ -12,9 +13,21 @@ describe("checks stdin with -c (alias for --check)", () => {
   runCli("cli/with-shebang", ["-c", "--parser", "babel"], {
     input: "0",
   }).test({
-    stdout: "(stdin)",
-    stderr: "",
+    stdout: "Checking formatting...\n(stdin)",
+    stderr:
+      "[warn] Code style issues found in the above file. Run Prettier with --write to fix.",
     status: "non-zero",
+  });
+});
+
+describe("checks already-formatted stdin with --check", () => {
+  runCli("cli/with-shebang", ["--check", "--parser", "babel"], {
+    input: "0;\n",
+  }).test({
+    stdout:
+      "Checking formatting...\nAll matched files use Prettier code style!",
+    stderr: "",
+    status: 0,
   });
 });
 

--- a/tests/integration/__tests__/infer-parser.js
+++ b/tests/integration/__tests__/infer-parser.js
@@ -18,7 +18,7 @@ describe("stdin no path and no parser", () => {
       input: "foo",
     }).test({
       status: 0,
-      stdout: "",
+      stdout: "Checking formatting...",
       write: [],
     });
   });
@@ -50,7 +50,7 @@ describe("stdin with unknown path and no parser", () => {
       input: "foo",
     }).test({
       status: 0,
-      stdout: "",
+      stdout: "Checking formatting...",
       write: [],
     });
   });


### PR DESCRIPTION
## Description

Closes #9150.

Running `--check` with stdin only printed a bare `(stdin)`, instead of the human-readable output produced when checking files:

```console
$ echo 'const x=1' | prettier --check --stdin-filepath foo.js
(stdin)
```

A maintainer confirmed in the issue that supporting this makes sense:

> `--check` wasn't meant to be used with `--stdin-filepath`, but it makes sense to use them together in use cases like yours. Feel free to send a PR implementing this.

### Fix

`formatStdin` now prints the same `Checking formatting...` header and summary line that `formatFiles` prints, so the output is consistent:

```console
# not formatted (exit 1)
$ echo 'const x=1' | prettier --check --stdin-filepath foo.js
Checking formatting...
(stdin)
[warn] Code style issues found in the above file. Run Prettier with --write to fix.

# already formatted (exit 0)
$ echo 'const x = 1;' | prettier --check --stdin-filepath foo.js
Checking formatting...
All matched files use Prettier code style!
```

Notes:
- Exit codes are unchanged (1 when not formatted, 0 when formatted).
- `--list-different` is intentionally left to print only the file name (`(stdin)`), matching its file behavior.
- When no parser can be inferred, the existing error is still reported and no misleading "all files formatted" summary is printed.

## Test plan

- Updated `tests/integration/__tests__/check.js` to assert the new output and added a case for already-formatted stdin.
- Updated two `infer-parser.js` cases that now also print the `Checking formatting...` header (consistent with checking files).
- Full integration suite passes (75 suites, 536 tests). `eslint` and `lint:prettier` pass.
