### PR TITLE
fix(markdown): keep indentation of multi-line inline code in lists

### DIFF
--- a/changelog_unreleased/markdown/19248.md
+++ b/changelog_unreleased/markdown/19248.md
@@ -1,0 +1,21 @@
+#### Keep indentation of multi-line inline code in lists (#19248 by @xfocus3)
+
+With `proseWrap: preserve`, an inline code span containing a newline inside a list item kept its continuation line at column 0, which breaks the list item under CommonMark. The continuation now preserves the list's indentation.
+
+<!-- prettier-ignore -->
+````markdown
+<!-- Input -->
+- Sub-bullet wraps and contains
+  `someInlineCode(arg1, arg2,
+  arg3, arg4)` and continues.
+
+<!-- Prettier stable -->
+- Sub-bullet wraps and contains
+  `someInlineCode(arg1, arg2,
+arg3, arg4)` and continues.
+
+<!-- Prettier main -->
+- Sub-bullet wraps and contains
+  `someInlineCode(arg1, arg2,
+  arg3, arg4)` and continues.
+````

--- a/src/language-markdown/print/mdast.js
+++ b/src/language-markdown/print/mdast.js
@@ -169,7 +169,16 @@ function printMdast(path, options, print) {
         (/^[\n ]/.test(code) && /[\n ]$/.test(code) && /[^\n ]/.test(code))
           ? " "
           : "";
-      return [backtickString, padding, code, padding, backtickString];
+      // When `proseWrap` is `preserve`, the code can contain newlines. Re-apply
+      // the surrounding indentation to continuation lines (via `markAsRoot`)
+      // so they aren't emitted at column 0, which would break the enclosing
+      // list item's continuation. `literalline` is used (rather than
+      // `hardline`) to preserve any significant trailing whitespace in the
+      // code span.
+      const content = code.includes("\n")
+        ? replaceEndOfLine(code, markAsRoot(literalline))
+        : code;
+      return [backtickString, padding, content, padding, backtickString];
     }
     case "wikiLink": {
       let contents;

--- a/tests/format/markdown/inlineCode/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/inlineCode/__snapshots__/format.test.js.snap
@@ -238,6 +238,63 @@ culpa qui officia deserunt mollit anim id est laborum.
 ================================================================================
 `;
 
+exports[`inline-code-newline-in-list.md - {"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+proseWrap: "always"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+- Top-level:
+  - Sub-bullet wraps and contains
+    \`someInlineCode(arg1, arg2,
+    arg3, arg4)\` and continues with more text after the
+    code span closes.
+
+1. Ordered list:
+   1. Nested item with \`code spanning
+      two lines\` inside it.
+
+=====================================output=====================================
+- Top-level:
+  - Sub-bullet wraps and contains \`someInlineCode(arg1, arg2, arg3, arg4)\` and
+    continues with more text after the code span closes.
+
+1. Ordered list:
+   1. Nested item with \`code spanning two lines\` inside it.
+
+================================================================================
+`;
+
+exports[`inline-code-newline-in-list.md - {"proseWrap":"preserve"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+proseWrap: "preserve"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+- Top-level:
+  - Sub-bullet wraps and contains
+    \`someInlineCode(arg1, arg2,
+    arg3, arg4)\` and continues with more text after the
+    code span closes.
+
+1. Ordered list:
+   1. Nested item with \`code spanning
+      two lines\` inside it.
+
+=====================================output=====================================
+- Top-level:
+  - Sub-bullet wraps and contains
+    \`someInlineCode(arg1, arg2,
+    arg3, arg4)\` and continues with more text after the
+    code span closes.
+
+1. Ordered list:
+   1. Nested item with \`code spanning
+      two lines\` inside it.
+
+================================================================================
+`;
+
 exports[`long.md - {"proseWrap":"always"} format 1`] = `
 ====================================options=====================================
 parsers: ["markdown"]

--- a/tests/format/markdown/inlineCode/inline-code-newline-in-list.md
+++ b/tests/format/markdown/inlineCode/inline-code-newline-in-list.md
@@ -1,0 +1,9 @@
+- Top-level:
+  - Sub-bullet wraps and contains
+    `someInlineCode(arg1, arg2,
+    arg3, arg4)` and continues with more text after the
+    code span closes.
+
+1. Ordered list:
+   1. Nested item with `code spanning
+      two lines` inside it.


### PR DESCRIPTION
## Description

Closes #19116.

With `proseWrap: preserve`, an inline code span that contains a newline inside a list item was printed with its continuation line at column 0:

````markdown
<!-- input -->
- Top-level:
  - Sub-bullet wraps and contains
    `someInlineCode(arg1, arg2,
    arg3, arg4)` and continues with more text after the
    code span closes.
````

````markdown
<!-- output before this PR -->
- Top-level:
  - Sub-bullet wraps and contains
    `someInlineCode(arg1, arg2,
arg3, arg4)` and continues with more text after the
    code span closes.
````

The `arg3, arg4)` line drops to column 0. Under CommonMark this terminates the sub-bullet, so following indented content gets re-parsed in a new context — silently corrupting the rendered output. The behavior is idempotent, so `--check` reports clean afterward and CI doesn't catch it.

### Cause

The `inlineCode` printer emitted `node.value` (which can contain `\n` when `proseWrap` is `preserve`) as a flat string. A raw `\n` in the doc isn't re-indented by the printer, so continuation lines land at column 0.

### Fix

Re-apply the surrounding indentation to continuation lines with `markAsRoot`. `literalline` (rather than `hardline`) is used so any significant trailing whitespace inside the code span is preserved — `hardline` would trim it and change the literal code content. The fix only activates when the code contains a newline, so single-line spans are unaffected.

## Test plan

- Added `tests/format/markdown/inlineCode/inline-code-newline-in-list.md` covering bulleted and ordered list continuations.
- Full markdown + mdx suite passes (56 suites, 1519 tests) with no other snapshot changes — confirming existing trailing-whitespace edge cases (`inline-code-multiple-spaces.md`) are unaffected.
- `eslint` and `lint:prettier` pass.
