### PR TITLE
fix(mdx): keep line-start inline HTML in paragraphs

### DIFF
--- a/changelog_unreleased/mdx/19137.md
+++ b/changelog_unreleased/mdx/19137.md
@@ -1,0 +1,19 @@
+#### Keep line-start inline HTML in MDX paragraphs (#19137 by @puneetdixit200)
+
+Previously, a standard inline HTML tag that started a continuation line in an MDX paragraph could be parsed as a separate JSX block.
+
+<!-- prettier-ignore -->
+```mdx
+<!-- Input -->
+This paragraph wraps before the inline tag
+<span>inline text</span> and continues.
+
+<!-- Prettier stable -->
+This paragraph wraps before the inline tag
+
+<span>inline text</span> and continues.
+
+<!-- Prettier main -->
+This paragraph wraps before the inline tag
+<span>inline text</span> and continues.
+```

--- a/src/language-markdown/parse/parse-mdx.js
+++ b/src/language-markdown/parse/parse-mdx.js
@@ -1,6 +1,8 @@
+import { htmlTags } from "@prettier/html-tags";
 import footnotes from "remark-footnotes";
 import remarkMath from "remark-math";
 import remarkParse from "remark-parse";
+import htmlBlockElements from "remark-parse/lib/block-elements.js";
 import unified from "unified";
 import { BLOCKS_REGEX, esSyntax } from "./mdx.js";
 import frontMatter from "./unified-plugins/front-matter.js";
@@ -23,6 +25,107 @@ import wikiLink from "./unified-plugins/wiki-link.js";
  * interface InlineCode { children: Array<Sentence> }
  */
 
+const htmlBlockElementSet = new Set(htmlBlockElements);
+const htmlInlineTagSet = new Set(
+  htmlTags.filter((tagName) => !htmlBlockElementSet.has(tagName)),
+);
+const htmlTagNameStartRegex = /^<\/?\s*([a-z][\w:-]*)/iu;
+const inlineHtmlProcessor = unified().use(remarkParse, {
+  commonmark: true,
+  blocks: [],
+});
+
+function startsWithInlineHtmlTag(value) {
+  const match = htmlTagNameStartRegex.exec(value);
+  return Boolean(match && htmlInlineTagSet.has(match[1].toLowerCase()));
+}
+
+function adjustPosition(node, positionStart) {
+  if (node.position) {
+    for (const key of ["start", "end"]) {
+      const point = node.position[key];
+      const { line } = point;
+      point.line += positionStart.line - 1;
+      point.column += line === 1 ? positionStart.column - 1 : 0;
+      if (
+        typeof point.offset === "number" &&
+        typeof positionStart.offset === "number"
+      ) {
+        point.offset += positionStart.offset;
+      }
+    }
+  }
+
+  for (const child of node.children ?? []) {
+    adjustPosition(child, positionStart);
+  }
+
+  return node;
+}
+
+function parseInlineHtmlChildren(value, positionStart) {
+  const [node] = inlineHtmlProcessor.parse(value).children;
+
+  if (!node) {
+    return;
+  }
+
+  adjustPosition(node, positionStart);
+
+  if (node.type === "paragraph") {
+    return node.children;
+  }
+
+  if (node.type === "html") {
+    return [node];
+  }
+}
+
+function mergeLineStartInlineHtmlIntoParagraph() {
+  return (tree) => {
+    const { children } = tree;
+
+    for (let index = 1; index < children.length; index++) {
+      const previous = children[index - 1];
+      const node = children[index];
+
+      if (
+        previous.type !== "paragraph" ||
+        node.type !== "jsx" ||
+        previous.position?.end?.line + 1 !== node.position?.start?.line ||
+        !startsWithInlineHtmlTag(node.value)
+      ) {
+        continue;
+      }
+
+      const inlineChildren = parseInlineHtmlChildren(
+        node.value,
+        node.position.start,
+      );
+
+      if (!inlineChildren) {
+        continue;
+      }
+
+      previous.children.push(
+        {
+          type: "text",
+          value: "\n",
+          position: {
+            start: { ...previous.position.end },
+            end: { ...node.position.start },
+            indent: [1],
+          },
+        },
+        ...inlineChildren,
+      );
+      previous.position.end = node.position.end;
+      children.splice(index, 1);
+      index--;
+    }
+  };
+}
+
 function parseMdx(text) {
   const processor = unified()
     .use(remarkParse, {
@@ -35,6 +138,7 @@ function parseMdx(text) {
     .use(esSyntax)
     .use(liquid)
     .use(htmlToJsx)
+    .use(mergeLineStartInlineHtmlIntoParagraph)
     .use(wikiLink);
   return processor.run(processor.parse(text));
 }

--- a/tests/format/mdx/inline-html/format.test.js
+++ b/tests/format/mdx/inline-html/format.test.js
@@ -1,0 +1,14 @@
+runFormatTest(
+  {
+    importMeta: import.meta,
+    snippets: [
+      {
+        name: "line-start inline html remains in paragraph",
+        code: "This paragraph has enough words before the inline span so Prettier wraps the span\n<span>inline text</span> and keeps the surrounding text together.\n",
+        output:
+          "This paragraph has enough words before the inline span so Prettier wraps the span\n<span>inline text</span> and keeps the surrounding text together.\n",
+      },
+    ],
+  },
+  ["mdx"],
+);


### PR DESCRIPTION
## Description

Fixes #19137.

Prettier currently lets the MDX parser classify a standard inline HTML tag at the start of a continuation line as a separate JSX block. This preserves those standard inline HTML tags as part of the preceding paragraph when there is no blank line separator, while leaving existing MDX JSX block behavior intact.

I used AI assistance while preparing this patch; I reviewed the code and verified the final behavior locally.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory). Not applicable.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

Verification:

- `yarn jest tests/format/mdx --runInBand`
- `FULL_TEST=1 yarn jest tests/format/mdx --runInBand`
- `yarn eslint src/language-markdown/parse/parse-mdx.js tests/format/mdx/inline-html/format.test.js --format friendly`
- `yarn prettier src/language-markdown/parse/parse-mdx.js tests/format/mdx/inline-html/format.test.js changelog_unreleased/mdx/19137.md --check`
- `yarn lint:changelog`
- `yarn lint:format-test`
- `yarn lint:deps`
- `git diff --check`