### PR TITLE
Fix return comment placement in member chains

### DIFF
--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -21,6 +21,7 @@ import { isTypeCastComment } from "../utilities/is-type-cast-comment.js";
 import {
   isArrayType,
   isBinaryCastExpression,
+  isCallExpression,
   isCallLikeExpression,
   isCallOrNewExpression,
   isConditionalType,
@@ -191,13 +192,31 @@ function handleMemberExpressionComments({
 }) {
   if (
     isMemberExpression(enclosingNode) &&
-    followingNode?.type === "Identifier"
+    followingNode === enclosingNode.object &&
+    isCallExpression(followingNode)
+  ) {
+    addLeadingComment(getLeftMostNodeInMemberCallChain(followingNode), comment);
+    return true;
+  }
+
+  if (
+    isMemberExpression(enclosingNode) &&
+    followingNode?.type === "Identifier" &&
+    followingNode !== enclosingNode.object
   ) {
     addLeadingComment(enclosingNode, comment);
     return true;
   }
 
   return false;
+}
+
+function getLeftMostNodeInMemberCallChain(node) {
+  while (isCallExpression(node) || isMemberExpression(node)) {
+    node = isCallExpression(node) ? node.callee : node.object;
+  }
+
+  return node;
 }
 
 function handleNestedConditionalExpressionComments({

--- a/tests/format/js/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/js/comments/__snapshots__/format.test.js.snap
@@ -5695,9 +5695,9 @@ function memberOutside() {
 
 function memberInAndOutWithCalls() {
   return (
+    // Reason for a
     aFunction
-      .b// Reason for a
-      ()
+      .b()
       .c.d()
   )
 }
@@ -6062,9 +6062,9 @@ function memberOutside() {
 
 function memberInAndOutWithCalls() {
   return (
+    // Reason for a
     aFunction
-      .b// Reason for a
-      ()
+      .b()
       .c.d()
   );
 }


### PR DESCRIPTION
## Summary

Fixes comment attachment for return expressions where a comment belongs to the start of a member/call chain. The previous output could leave the comment between a property and its call parentheses, for example after `.b` and before `()`. This places the comment before the left-most expression in the chain instead.

## Test

- `corepack.cmd yarn jest tests/format/js/comments --runInBand`