### PR TITLE
Fix unstable comment in arrow function with sequence expression body

### DIFF
--- a/changelog_unreleased/javascript/19241.md
+++ b/changelog_unreleased/javascript/19241.md
@@ -1,0 +1,13 @@
+#### Fix unstable comment in arrow function with sequence expression body (#19241 by @itsybitsybootsy)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+() => (a, b, c /* abc */);
+
+// Prettier stable
+() => (a, b, c) /* abc */;
+
+// Prettier main
+() => (a, b, c /* abc */);
+```

--- a/changelog_unreleased/javascript/19253.md
+++ b/changelog_unreleased/javascript/19253.md
@@ -1,4 +1,4 @@
-#### Fix unstable comment in arrow function with sequence expression body (#19241 by @itsybitsybootsy)
+#### Fix unstable comment in arrow function with sequence expression body (#19253 by @itsybitsybootsy)
 
 <!-- prettier-ignore -->
 ```jsx

--- a/changelog_unreleased/javascript/19253.md
+++ b/changelog_unreleased/javascript/19253.md
@@ -3,11 +3,11 @@
 <!-- prettier-ignore -->
 ```jsx
 // Input
-() => (a, b, c /* abc */);
+const fn = () => (a, b, c /* abc */);
 
 // Prettier stable
-() => (a, b, c) /* abc */;
+const fn = () => (a, b, c) /* abc */;
 
 // Prettier main
-() => (a, b, c /* abc */);
+const fn = () => (a, b, c /* abc */);
 ```

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -112,6 +112,7 @@ function handleEndOfLineComment(context) {
     handleLastBinaryOperatorOperand,
     handleTSMappedTypeComments,
     handleArrowExpressionComments,
+    handleArrowBodySequenceExpressionTrailingComment,
     handlePropertySignatureComments,
     handleBinaryCastExpressionComment,
   ].some((fn) => fn(context));
@@ -134,6 +135,7 @@ function handleRemainingComment(context) {
     handleCommentAfterArrowParams,
     handleFunctionNameComments,
     handleTSFunctionTrailingComments,
+    handleArrowBodySequenceExpressionTrailingComment,
     handleBinaryCastExpressionComment,
   ].some((fn) => fn(context));
 }
@@ -1068,6 +1070,31 @@ function handleArrowExpressionComments({
     return true;
   }
 
+  return false;
+}
+
+// A trailing comment inside the parentheses around a `SequenceExpression`
+// arrow body would otherwise attach to the `SequenceExpression` itself.
+// The AST node does not include those parentheses, so the comment then
+// prints outside them and drifts further on each reformat (#18776, #14702).
+// Re-attach to the last sequence element so it stays inside the parens.
+function handleArrowBodySequenceExpressionTrailingComment({
+  comment,
+  enclosingNode,
+  precedingNode,
+  followingNode,
+  text,
+}) {
+  if (
+    !followingNode &&
+    enclosingNode?.type === "ArrowFunctionExpression" &&
+    precedingNode?.type === "SequenceExpression" &&
+    enclosingNode.body === precedingNode &&
+    getNextNonSpaceNonCommentCharacter(text, locEnd(comment)) === ")"
+  ) {
+    addTrailingComment(precedingNode.expressions.at(-1), comment);
+    return true;
+  }
   return false;
 }
 

--- a/tests/config/format-test/failed-format-tests.js
+++ b/tests/config/format-test/failed-format-tests.js
@@ -33,7 +33,6 @@ const unstableTests = new Map(
     "typescript/call/callee-comments.ts",
     "js/arrows/arrow-chain-with-trailing-comments.js",
     "typescript/as/comments/18160.ts",
-    "js/arrows/issue-14702.js",
   ].map((fixture) => {
     const [file, isUnstable = () => true] = Array.isArray(fixture)
       ? fixture

--- a/tests/format/js/arrows/__snapshots__/format.test.js.snap
+++ b/tests/format/js/arrows/__snapshots__/format.test.js.snap
@@ -4469,7 +4469,7 @@ parsers: ["babel", "typescript"]
 a = () => (1, 2, 3 /* abc */);
 
 =====================================output=====================================
-a = () => (1, 2, 3) /* abc */;
+a = () => (1, 2, 3 /* abc */);
 
 ================================================================================
 `;
@@ -4483,7 +4483,7 @@ parsers: ["babel", "typescript"]
 a = () => (1, 2, 3 /* abc */);
 
 =====================================output=====================================
-a = () => (1, 2, 3) /* abc */;
+a = () => (1, 2, 3 /* abc */);
 
 ================================================================================
 `;
@@ -4738,6 +4738,58 @@ a =
     id;
 
 a = () => /** @param {string} id */ id => id;
+
+================================================================================
+`;
+
+exports[`issue-18776.js - {"arrowParens":"always"} format 1`] = `
+====================================options=====================================
+arrowParens: "always"
+parsers: ["babel", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+() => (a, b, c /* abc */);
+
+let multilineCase = (someParameter) => (
+  someVeryLongExpressionName,
+  anotherVeryLongExpressionName,
+  yetAnotherVeryLongExpressionName /* abc */
+);
+
+=====================================output=====================================
+() => (a, b, c /* abc */);
+
+let multilineCase = (someParameter) => (
+  someVeryLongExpressionName,
+  anotherVeryLongExpressionName,
+  yetAnotherVeryLongExpressionName /* abc */
+);
+
+================================================================================
+`;
+
+exports[`issue-18776.js - {"arrowParens":"avoid"} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+parsers: ["babel", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+() => (a, b, c /* abc */);
+
+let multilineCase = (someParameter) => (
+  someVeryLongExpressionName,
+  anotherVeryLongExpressionName,
+  yetAnotherVeryLongExpressionName /* abc */
+);
+
+=====================================output=====================================
+() => (a, b, c /* abc */);
+
+let multilineCase = someParameter => (
+  someVeryLongExpressionName,
+  anotherVeryLongExpressionName,
+  yetAnotherVeryLongExpressionName /* abc */
+);
 
 ================================================================================
 `;

--- a/tests/format/js/arrows/issue-18776.js
+++ b/tests/format/js/arrows/issue-18776.js
@@ -1,0 +1,7 @@
+() => (a, b, c /* abc */);
+
+let multilineCase = (someParameter) => (
+  someVeryLongExpressionName,
+  anotherVeryLongExpressionName,
+  yetAnotherVeryLongExpressionName /* abc */
+);


### PR DESCRIPTION
## Description

Fixes #18776.

A trailing block comment inside the parens around an arrow function's `SequenceExpression` body ended up outside the parens and moved further right on each reformat:

```jsx
// Input
() => (a, b, c /* abc */);

// Stable
() => (a, b, c) /* abc */;

// Second pass
() => (a, b, c); /* abc */
```

Fix attaches the trailing comment to the last sequence element, gated on `enclosingNode.type === "ArrowFunctionExpression"` with `enclosingNode.body === precedingNode`.

`tests/format/js/arrows/issue-14702.js` is the same bug. snapshot updated, removed from `unstableTests`.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [x] _N/A, no API or CLI changes._ (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).