### PR TITLE
fix: do not modify blockLiteral/blockFolded value for clip/strip chomping

### DIFF
--- a/src/language-yaml/massage-ast/index.js
+++ b/src/language-yaml/massage-ast/index.js
@@ -33,10 +33,7 @@ function massageAstNode(original, cloned /* , parent */) {
           .join("\n");
       }
 
-      // TODO: Fix this
-      if (original.chomping === "clip" || original.chomping === "strip") {
-        cloned.value = original.value.trimEnd();
-      }
+
       break;
   }
 }


### PR DESCRIPTION
## Problem

In src/language-yaml/massage-ast/index.js, the massageAstNode function incorrectly trims trailing whitespace from blockLiteral and blockFolded values when chomping is clip or strip.

This changes the semantic meaning of YAML block scalars. The value property should remain unchanged - the YAML spec defines different chomping modes (clip, strip, keep) that determine how trailing newlines are interpreted, and modifying the value loses this information.

## Fix

Remove the trimEnd() call that was introduced in #18419. The keep chomping case above already correctly handles trailing spaces/tabs on individual lines without modifying the overall value.

Fixes #19256