### PR TITLE
fix: invalidate cache entry when format fails

### DIFF
--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -392,6 +392,11 @@ async function formatFiles(context) {
         numberOfFilesWithError += 1;
       }
 
+      // Invalidate cache entry when format fails (e.g. parse error),
+      // otherwise the file-entry-cache may still consider this file
+      // as unchanged on the next run, causing it to be cached as valid.
+      formatResultsCache?.removeFormatResultsCache(filename);
+
       continue;
     }
 


### PR DESCRIPTION
## Problem

When  is used, files with syntax errors can be incorrectly cached as valid on subsequent runs.

**Repro:**
1. Format a valid file with  (cached as valid)
2. Overwrite the file with invalid syntax
3. First  run: reports the syntax error
4. Second  run: reports success (wrong!)

**Root cause:** In , when format fails (e.g. parse error), the  block uses  to skip to the next file. This skips the cache invalidation logic at the end of the loop (L452-455), leaving the file-entry-cache in an inconsistent state.

## Fix

Call  in the catch block before , ensuring the cache entry is invalidated when format fails.

Fixes #19085