### PR TITLE
Preserve multiline shebang shell shims

### DIFF
--- a/changelog_unreleased/javascript/7562.md
+++ b/changelog_unreleased/javascript/7562.md
@@ -1,0 +1,19 @@
+#### Preserve multiline shebang shell shims (#7562 by @sarathfrancis90)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+const ten = 10;
+
+// Prettier stable
+#!/bin/sh
+":"; //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+const ten = 10;
+
+// Prettier main
+#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+const ten = 10;
+```

--- a/src/language-js/print/estree.js
+++ b/src/language-js/print/estree.js
@@ -7,6 +7,7 @@ import {
 } from "../../document/index.js";
 import { printDanglingComments } from "../../main/comments/print.js";
 import UnexpectedNodeError from "../../utilities/unexpected-node-error.js";
+import { isMultilineShebangShellShim } from "../semicolon/semicolon.js";
 import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
 import { isMeaningfulEmptyStatement } from "../utilities/is-meaningful-empty-statement.js";
 import { isMethod } from "../utilities/is-method.js";
@@ -222,7 +223,12 @@ function printEstree(path, options, print, args) {
     case "Super":
       return "super";
     case "Directive":
-      return [print("value"), printSemicolon(options)];
+      return [
+        print("value"),
+        isMultilineShebangShellShim(path, options)
+          ? ""
+          : printSemicolon(options),
+      ];
     case "UnaryExpression": {
       const parts = [node.operator];
 

--- a/src/language-js/print/expression-statement.js
+++ b/src/language-js/print/expression-statement.js
@@ -3,6 +3,7 @@ import {
   printLeadingComments,
 } from "../../main/comments/print.js";
 import {
+  isMultilineShebangShellShim,
   isSingleHtmlEventHandlerExpressionStatement,
   isSingleJsxExpressionStatementInMarkdown,
   isSingleVueEventBindingExpressionStatement,
@@ -33,6 +34,10 @@ function shouldPrintSemicolon(path, options) {
     return false;
   }
 
+  if (isMultilineShebangShellShim(path, options)) {
+    return false;
+  }
+
   if (
     // Do not append semicolon after the only JSX element in a program
     isSingleJsxExpressionStatementInMarkdown(path, options) ||
@@ -49,7 +54,10 @@ function printExpressionStatement(path, options, print) {
   /** @type {Doc[]} */
   const parts = [print("expression")];
 
-  if (shouldExpressionStatementPrintLeadingSemicolon(path, options)) {
+  const shouldPrintLeadingSemicolon =
+    shouldExpressionStatementPrintLeadingSemicolon(path, options);
+
+  if (shouldPrintLeadingSemicolon) {
     if (shouldExpressionStatementPrintOwnComments(path, options)) {
       const { node } = path;
       const typeCastComment = getComments(node, CommentCheckFlags.Leading).at(
@@ -67,6 +75,9 @@ function printExpressionStatement(path, options, print) {
     }
 
     parts.unshift(";");
+    if (options.semi) {
+      parts.push(";");
+    }
   } else if (shouldPrintSemicolon(path, options)) {
     parts.push(";");
   }

--- a/src/language-js/semicolon/semicolon.js
+++ b/src/language-js/semicolon/semicolon.js
@@ -1,3 +1,4 @@
+import { locEnd, locStart } from "../location/index.js";
 import needsParentheses from "../parentheses/needs-parentheses.js";
 import { shouldPrintParamsWithoutParens } from "../print/function.js";
 import {
@@ -7,7 +8,10 @@ import {
 import { isJsxElement } from "../utilities/node-types.js";
 
 function shouldExpressionStatementPrintLeadingSemicolon(path, options) {
-  if (options.semi) {
+  if (
+    options.semi &&
+    !isExpressionStatementAfterMultilineShebangShellShim(path, options)
+  ) {
     return false;
   }
 
@@ -37,6 +41,67 @@ function shouldExpressionStatementPrintLeadingSemicolon(path, options) {
   }
 
   return false;
+}
+
+function isMultilineShebangShellShim(path, options) {
+  const { node, parent } = path;
+
+  if (
+    parent?.type !== "Program" ||
+    !options.originalText.startsWith("#!") ||
+    !isColonDirectiveLikeNode(node)
+  ) {
+    return false;
+  }
+
+  const firstLineEnd = options.originalText.indexOf("\n");
+  if (firstLineEnd === -1 || locStart(node) !== firstLineEnd + 1) {
+    return false;
+  }
+
+  const contentEnd = node.__contentEnd ?? locEnd(node.value ?? node.expression);
+  const endOfLine = options.originalText.indexOf("\n", contentEnd);
+  const lineRest = options.originalText.slice(
+    contentEnd,
+    endOfLine === -1 ? undefined : endOfLine,
+  );
+
+  return /^\s*\/\/\s*;/.test(lineRest);
+}
+
+function isColonDirectiveLikeNode(node) {
+  return (
+    (node.type === "Directive" && node.value?.value === ":") ||
+    (node.type === "ExpressionStatement" &&
+      node.directive === ":" &&
+      node.expression.value === ":")
+  );
+}
+
+function isExpressionStatementAfterMultilineShebangShellShim(path, options) {
+  if (
+    path.node.type !== "ExpressionStatement" ||
+    path.parent?.type !== "Program"
+  ) {
+    return false;
+  }
+
+  const previousStatement = path.previous;
+  if (previousStatement) {
+    return isMultilineShebangShellShim(
+      { node: previousStatement, parent: path.parent },
+      options,
+    );
+  }
+
+  const previousDirective = path.parent.directives?.at(-1);
+  return (
+    previousDirective &&
+    isMultilineShebangShellShim(
+      { node: previousDirective, parent: path.parent },
+      options,
+    )
+  );
 }
 
 function expressionNeedsAsiProtection(path, options) {
@@ -128,6 +193,7 @@ function isSingleVueEventBindingExpressionStatement(path, options) {
 }
 
 export {
+  isMultilineShebangShellShim,
   isSingleHtmlEventHandlerExpressionStatement,
   isSingleJsxExpressionStatementInMarkdown,
   isSingleVueEventBindingExpressionStatement,

--- a/tests/format/js/shebang/__snapshots__/format.test.js.snap
+++ b/tests/format/js/shebang/__snapshots__/format.test.js.snap
@@ -56,3 +56,37 @@ parsers: ["babel", "flow", "typescript"]
 
 ================================================================================
 `;
+
+exports[`snippet: Multiline shebang shell shim format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+const ten = 10;
+
+=====================================output=====================================
+#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+const ten = 10;
+
+================================================================================
+`;
+
+exports[`snippet: Multiline shebang shell shim with ASI protection format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+;(() => console.log(1))();
+
+=====================================output=====================================
+#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+;(() => console.log(1))();
+
+================================================================================
+`;

--- a/tests/format/js/shebang/format.test.js
+++ b/tests/format/js/shebang/format.test.js
@@ -10,6 +10,14 @@ runFormatTest(
         name: "Empty file with shebang",
         code: "#!/usr/bin/env node\n",
       },
+      {
+        name: "Multiline shebang shell shim",
+        code: '#!/bin/sh\n":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"\nconst ten = 10;\n',
+      },
+      {
+        name: "Multiline shebang shell shim with ASI protection",
+        code: '#!/bin/sh\n":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"\n;(() => console.log(1))();\n',
+      },
     ],
   },
   ["babel", "flow", "typescript"],


### PR DESCRIPTION
## Description

Fixes #7562.

This preserves the multiline shebang shell shim form `":" //; exec ...` by avoiding the semicolon that Prettier previously inserted before the shell comment. When the following JavaScript statement still needs ASI protection, Prettier keeps a leading semicolon on that next statement instead.

Validated with:

- `node .yarn/releases/yarn-4.15.0.cjs test tests/format/js/shebang -w=2`
- `node .yarn/releases/yarn-4.15.0.cjs prettier src/language-js/semicolon/semicolon.js src/language-js/print/expression-statement.js src/language-js/print/estree.js tests/format/js/shebang/format.test.js changelog_unreleased/javascript/7562.md --check`
- `node .yarn/releases/yarn-4.15.0.cjs eslint src/language-js/semicolon/semicolon.js src/language-js/print/expression-statement.js src/language-js/print/estree.js tests/format/js/shebang/format.test.js --format stylish`
- `node .yarn/releases/yarn-4.15.0.cjs lint:changelog`
- `git diff --check`

## Checklist

- [x] I added tests to confirm my change works.
- [x] (If changing the API or CLI) Not applicable; this does not change the API or CLI.
- [x] (If the change is user-facing) I added my changes to `changelog_unreleased/javascript/7562.md` following `changelog_unreleased/TEMPLATE.md`.
- [x] I read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
