### PR TITLE
docs: explain Prettier is not rule-based

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -11,6 +11,8 @@ Linters have two categories of rules:
 
 Prettier alleviates the need for this whole category of rules! Prettier is going to reprint the entire program from scratch in a consistent way, so it’s not possible for the programmer to make a mistake there anymore :)
 
+Unlike a linter, Prettier is not built from a list of independent formatting rules that can be enabled, disabled, or configured independently. It parses your code, discards the original formatting, and prints it again using a single printing process configured by a small set of options. Those options are parameters to the printer, not pluggable rules.
+
 **Code-quality rules**: eg [no-unused-vars](https://eslint.org/docs/rules/no-unused-vars), [no-extra-bind](https://eslint.org/docs/rules/no-extra-bind), [no-implicit-globals](https://eslint.org/docs/rules/no-implicit-globals), [prefer-promise-reject-errors](https://eslint.org/docs/rules/prefer-promise-reject-errors)…
 
 Prettier does nothing to help with those kind of rules. They are also the most important ones provided by linters as they are likely to catch real bugs with your code!

--- a/website/versioned_docs/version-stable/comparison.md
+++ b/website/versioned_docs/version-stable/comparison.md
@@ -11,6 +11,8 @@ Linters have two categories of rules:
 
 Prettier alleviates the need for this whole category of rules! Prettier is going to reprint the entire program from scratch in a consistent way, so it’s not possible for the programmer to make a mistake there anymore :)
 
+Unlike a linter, Prettier is not built from a list of independent formatting rules that can be enabled, disabled, or configured independently. It parses your code, discards the original formatting, and prints it again using a single printing process configured by a small set of options. Those options are parameters to the printer, not pluggable rules.
+
 **Code-quality rules**: eg [no-unused-vars](https://eslint.org/docs/rules/no-unused-vars), [no-extra-bind](https://eslint.org/docs/rules/no-extra-bind), [no-implicit-globals](https://eslint.org/docs/rules/no-implicit-globals), [prefer-promise-reject-errors](https://eslint.org/docs/rules/prefer-promise-reject-errors)…
 
 Prettier does nothing to help with those kind of rules. They are also the most important ones provided by linters as they are likely to catch real bugs with your code!


### PR DESCRIPTION
Closes #8432.

This adds the short clarification requested in the issue to the comparison page: Prettier replaces formatting rules rather than exposing independent linter-style rules, and options are parameters to the printer rather than pluggable rules.

I updated both the current docs page and the stable versioned copy so the published comparison page stays in sync with the source docs.

Validation:

- `yarn install --immutable`
- `yarn prettier docs/comparison.md website/versioned_docs/version-stable/comparison.md --check`
- `git diff origin/main --check`
- `review-fix-loop` on the uncommitted docs diff: no findings
- `review-fix-loop` on a scratch current-`main` worktree with this commit cherry-picked as an uncommitted PR diff: no findings
