### PR TITLE
fix(mdx): keep line-start inline HTML in paragraphs

### DIFF
--- a/changelog_unreleased/mdx/19137.md
+++ b/changelog_unreleased/mdx/19137.md
@@ -1,0 +1,19 @@
+#### Keep line-start inline HTML in MDX paragraphs (#19137 by @puneetdixit200)
+
+Previously, a standard inline HTML tag that started a continuation line in an MDX paragraph could be parsed as a separate JSX block.
+
+<!-- prettier-ignore -->
+```mdx
+<!-- Input -->
+This paragraph wraps before the inline tag
+<span>inline text</span> and continues.
+
+<!-- Prettier stable -->
+This paragraph wraps before the inline tag
+
+<span>inline text</span> and continues.
+
+<!-- Prettier main -->
+This paragraph wraps before the inline tag
+<span>inline text</span> and continues.
+```

--- a/src/language-markdown/print/children.js
+++ b/src/language-markdown/print/children.js
@@ -1,3 +1,5 @@
+import { htmlTags } from "@prettier/html-tags";
+import htmlBlockElements from "remark-parse/lib/block-elements.js";
 import { hardline } from "../../document/index.js";
 import {
   INLINE_NODE_TYPES,
@@ -58,6 +60,16 @@ function shouldPrePrintHardline({ node, parent }) {
 }
 
 const SIBLING_NODE_TYPES = new Set(["listItem", "definition"]);
+const htmlBlockElementSet = new Set(htmlBlockElements.map(String));
+const htmlInlineTagSet = new Set(
+  htmlTags.filter((tagName) => !htmlBlockElementSet.has(tagName)).map(String),
+);
+const htmlTagNameStartRegex = /^<\/?\s*([a-z][\w:-]*)/u;
+
+function startsWithInlineHtmlTag(value) {
+  const tagName = htmlTagNameStartRegex.exec(value)?.[1]?.toLowerCase();
+  return tagName !== undefined && htmlInlineTagSet.has(tagName);
+}
 
 /**
  * @param {AstPath} path
@@ -115,6 +127,12 @@ function shouldPrePrintDoubleHardline(path, options) {
     node.type === "html" &&
     previous.type === "paragraph" &&
     previous.position.end.line + 1 === node.position.start.line;
+  const isMdxInlineHtmlWithoutBlankLineBetweenPrevParagraph =
+    options.parser === "mdx" &&
+    node.type === "jsx" &&
+    previous.type === "paragraph" &&
+    previous.position.end.line + 1 === node.position.start.line &&
+    startsWithInlineHtmlTag(node.value);
   const isHtmlDirectAfterListItem =
     node.type === "html" &&
     parent.type === "listItem" &&
@@ -127,6 +145,7 @@ function shouldPrePrintDoubleHardline(path, options) {
     isPrevNodePrettierIgnore ||
     isBlockHtmlWithoutBlankLineBetweenPrevHtml ||
     isBlockHtmlWithoutBlankLineBetweenPrevParagraph ||
+    isMdxInlineHtmlWithoutBlankLineBetweenPrevParagraph ||
     isHtmlDirectAfterListItem
   );
 }

--- a/tests/format/mdx/inline-html/format.test.js
+++ b/tests/format/mdx/inline-html/format.test.js
@@ -1,0 +1,14 @@
+runFormatTest(
+  {
+    importMeta: import.meta,
+    snippets: [
+      {
+        name: "line-start inline html remains in paragraph",
+        code: "This paragraph has enough words before the inline span so Prettier wraps the span\n<span>inline text</span> and keeps the surrounding text together.\n",
+        output:
+          "This paragraph has enough words before the inline span so Prettier wraps the span\n<span>inline text</span> and keeps the surrounding text together.\n",
+      },
+    ],
+  },
+  ["mdx"],
+);


### PR DESCRIPTION
## Description

Fixes #19137.

This keeps standard inline HTML tags that start a continuation line in an MDX paragraph adjacent to the preceding paragraph when the original source has no blank line separator. The parser stays unchanged; the spacing decision is handled in the markdown printer so MDX block JSX behavior remains intact.

This replaces #19249 after the implementation was moved to the printer side.

I used AI assistance while preparing this patch; I reviewed the code and verified the final behavior locally.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory). Not applicable.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

Verification:

- `yarn jest tests/format/mdx/inline-html`
- `yarn lint:typecheck`
- `yarn lint:format-test`
- `yarn lint:changelog`
- `yarn lint:prettier`
- `yarn cross-env EFF_NO_LINK_RULES=true eslint src/language-markdown/parse/parse-mdx.js src/language-markdown/print/children.js tests/format/mdx/inline-html/format.test.js --format friendly`
- `git diff --check`
