### PR TITLE
Fix sign spacing for channel values in CSS relative color syntax

### DIFF
--- a/changelog_unreleased/css/19286.md
+++ b/changelog_unreleased/css/19286.md
@@ -1,0 +1,21 @@
+#### Keep sign attached to channel values in CSS relative color syntax (#19286 by @LeSingh1)
+
+In the relative color syntax, a leading `+`/`-` on a channel value is a sign, not a math operator. Adding a space after it changes the value, because the sign makes the channel adjustment relative instead of absolute.
+
+<!-- prettier-ignore -->
+```css
+/* Input */
+:root {
+  --color-my-green: oklch(from rgb(255, 0, 0) l c +130);
+}
+
+/* Prettier stable */
+:root {
+  --color-my-green: oklch(from rgb(255, 0, 0) l c + 130);
+}
+
+/* Prettier main */
+:root {
+  --color-my-green: oklch(from rgb(255, 0, 0) l c +130);
+}
+```

--- a/src/language-css/print/comma-separated-value-group.js
+++ b/src/language-css/print/comma-separated-value-group.js
@@ -33,6 +33,7 @@ import {
   isParenGroupNode,
   isPostcssSimpleVarNode,
   isRelationalOperatorNode,
+  isRelativeColorSyntaxNode,
   isRightCurlyBraceNode,
   isSCSSControlDirectiveNode,
   isSubtractionNode,
@@ -330,6 +331,19 @@ function printCommaSeparatedValueGroup(path, options, print) {
       parentParentNode &&
       isColorAdjusterFuncNode(parentParentNode) &&
       !hasEmptyRawBefore(iNextNode);
+
+    // Keep the sign attached to a channel value in the relative color syntax
+    // (e.g. `oklch(from red l c +130)`). The `+`/`-` here is a sign, not a math
+    // operator, so adding a space (`+ 130`) would change the value.
+    if (
+      (isAdditionNode(iNode) || isSubtractionNode(iNode)) &&
+      iNextNode.type === "value-number" &&
+      !hasEmptyRawBefore(iNode) &&
+      hasEmptyRawBefore(iNextNode) &&
+      isRelativeColorSyntaxNode(node, parentParentNode)
+    ) {
+      continue;
+    }
 
     // Space before unary minus followed by a function call.
     if (

--- a/src/language-css/utilities/index.js
+++ b/src/language-css/utilities/index.js
@@ -371,6 +371,38 @@ function isColorAdjusterFuncNode(node) {
   return colorAdjusterFunctions.has(node.value.toLowerCase());
 }
 
+// CSS Color functions that accept the relative color syntax
+// (i.e. `oklch(from red l c h)`). See https://www.w3.org/TR/css-color-5/#relative-colors
+const relativeColorFunctions = new Set([
+  "rgb",
+  "rgba",
+  "hsl",
+  "hsla",
+  "hwb",
+  "lab",
+  "lch",
+  "oklab",
+  "oklch",
+  "color",
+]);
+
+// In the relative color syntax, a leading `+` or `-` directly attached to a
+// channel value is a sign, not a math operator (i.e. `oklch(from red l c +130)`).
+// Printing a space after the sign (`+ 130`) changes the meaning of the value, so
+// we keep these signs attached to the number.
+function isRelativeColorSyntaxNode(commaGroupNode, funcNode) {
+  if (
+    funcNode?.type !== "value-func" ||
+    !relativeColorFunctions.has(funcNode.value.toLowerCase()) ||
+    commaGroupNode?.type !== "value-comma_group"
+  ) {
+    return false;
+  }
+
+  const firstNode = commaGroupNode.groups?.[0];
+  return firstNode?.type === "value-word" && firstNode.value === "from";
+}
+
 function lastLineHasInlineComment(text) {
   return /\/\//.test(text.split(/[\n\r]/).pop());
 }
@@ -444,6 +476,7 @@ export {
   isParenGroupNode,
   isPostcssSimpleVarNode,
   isRelationalOperatorNode,
+  isRelativeColorSyntaxNode,
   isRightCurlyBraceNode,
   isSCSSControlDirectiveNode,
   isSCSSMapItemNode,

--- a/tests/format/css/color/__snapshots__/format.test.js.snap
+++ b/tests/format/css/color/__snapshots__/format.test.js.snap
@@ -380,6 +380,45 @@ parsers: ["css"]
 ================================================================================
 `;
 
+exports[`relative-color-syntax.css format 1`] = `
+====================================options=====================================
+parsers: ["css"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+/* https://www.w3.org/TR/css-color-5/#relative-colors */
+/* A leading \`+\`/\`-\` on a channel value is a sign, not a math operator, so it
+   must stay attached to the number. */
+:root {
+  --a: oklch(from rgb(255, 0, 0) l c +130);
+  --b: oklch(from red l c -130);
+  --c: oklab(from var(--base) l a +0.1);
+  --d: lch(from blue calc(l + 10%) c h);
+  --e: color(from red srgb r g +0.2);
+  --f: hsl(from red h s +10%);
+  --g: rgb(from red r g +20);
+  --h: lab(from teal l a +12);
+  --i: hwb(from red h +10% +5%);
+}
+
+=====================================output=====================================
+/* https://www.w3.org/TR/css-color-5/#relative-colors */
+/* A leading \`+\`/\`-\` on a channel value is a sign, not a math operator, so it
+   must stay attached to the number. */
+:root {
+  --a: oklch(from rgb(255, 0, 0) l c +130);
+  --b: oklch(from red l c -130);
+  --c: oklab(from var(--base) l a +0.1);
+  --d: lch(from blue calc(l + 10%) c h);
+  --e: color(from red srgb r g +0.2);
+  --f: hsl(from red h s +10%);
+  --g: rgb(from red r g +20);
+  --h: lab(from teal l a +12);
+  --i: hwb(from red h +10% +5%);
+}
+
+================================================================================
+`;
+
 exports[`whitespace-syntax.css format 1`] = `
 ====================================options=====================================
 parsers: ["css"]

--- a/tests/format/css/color/relative-color-syntax.css
+++ b/tests/format/css/color/relative-color-syntax.css
@@ -1,0 +1,14 @@
+/* https://www.w3.org/TR/css-color-5/#relative-colors */
+/* A leading `+`/`-` on a channel value is a sign, not a math operator, so it
+   must stay attached to the number. */
+:root {
+  --a: oklch(from rgb(255, 0, 0) l c +130);
+  --b: oklch(from red l c -130);
+  --c: oklab(from var(--base) l a +0.1);
+  --d: lch(from blue calc(l + 10%) c h);
+  --e: color(from red srgb r g +0.2);
+  --f: hsl(from red h s +10%);
+  --g: rgb(from red r g +20);
+  --h: lab(from teal l a +12);
+  --i: hwb(from red h +10% +5%);
+}


### PR DESCRIPTION
Fixes #18320

In the CSS relative color syntax, a leading `+` or `-` on a channel value is a sign, not a math operator. Prettier was inserting a space after it, which changes the meaning of the value because the sign makes the channel adjustment relative instead of absolute.

Before this change:

```css
:root {
  --color-my-green: oklch(from rgb(255, 0, 0) l c +130);
}
```

was printed as:

```css
:root {
  --color-my-green: oklch(from rgb(255, 0, 0) l c + 130);
}
```

The `+ 130` and `+130` are not equivalent here, so the output was producing different CSS than the input.

The comma-separated value group printer now detects relative color function groups (the ones that start with the `from` keyword inside `rgb`, `hsl`, `hwb`, `lab`, `lch`, `oklab`, `oklch`, or `color`) and keeps a sign that is directly attached to a number attached, instead of treating it as a binary operator. A `+`/`-` that is separated from the number by whitespace, or one that appears inside `calc()`, is left untouched, so genuine math is still spaced normally.

I added a fixture under `tests/format/css/color/relative-color-syntax.css` covering each relative color function plus a `calc()` channel to confirm normal math spacing is preserved. The existing legacy `color()` adjuster snapshots are unchanged.
