### PR TITLE
Improve formatting hot path performance

### DIFF
--- a/changelog_unreleased/misc/19293.md
+++ b/changelog_unreleased/misc/19293.md
@@ -1,0 +1,3 @@
+#### Improve formatting performance in core hot paths (#19293 by @Poliklot)
+
+Prettier now avoids some unnecessary overhead in core formatting hot paths, including doc traversal, doc fitting, plugin loading, and option normalization.

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -6,17 +6,17 @@ class AstPath {
   /** @type {string | null} */
   get key() {
     const { stack, siblings } = this;
-    return stack.at(siblings === null ? -2 : -4) ?? null;
+    return stack[stack.length - (siblings === null ? 2 : 4)] ?? null;
   }
 
   /** @type {number | null} */
   get index() {
-    return this.siblings === null ? null : this.stack.at(-2);
+    return this.siblings === null ? null : this.stack[this.stack.length - 2];
   }
 
   /** @type {object} */
   get node() {
-    return this.stack.at(-1);
+    return this.stack[this.stack.length - 1];
   }
 
   /** @type {object | null} */
@@ -37,7 +37,7 @@ class AstPath {
   /** @type {object[] | null} */
   get siblings() {
     const { stack } = this;
-    const maybeArray = stack.at(-3);
+    const maybeArray = stack[stack.length - 3];
     return Array.isArray(maybeArray) ? maybeArray : null;
   }
 
@@ -85,7 +85,7 @@ class AstPath {
     const { stack } = this;
     const { length } = stack;
     if (length > 1) {
-      return stack.at(-2);
+      return stack[length - 2];
     }
     // Since the name is a string/number/symbol, null is a safe sentinel value
     // to return if we do not know the name of the (root) value.
@@ -96,7 +96,7 @@ class AstPath {
   // The value of the current property is always the final element of
   // this.stack.
   getValue() {
-    return this.stack.at(-1);
+    return this.stack[this.stack.length - 1];
   }
 
   getNode(count = 0) {
@@ -126,7 +126,7 @@ class AstPath {
   call(callback, ...names) {
     const { stack } = this;
     const { length } = stack;
-    let value = stack.at(-1);
+    let value = stack[stack.length - 1];
 
     for (const name of names) {
       value = value?.[name];
@@ -162,7 +162,7 @@ class AstPath {
   each(callback, ...names) {
     const { stack } = this;
     const { length } = stack;
-    let value = stack.at(-1);
+    let value = stack[stack.length - 1];
 
     for (const name of names) {
       value = value[name];

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -6,17 +6,22 @@ class AstPath {
   /** @type {string | null} */
   get key() {
     const { stack, siblings } = this;
-    return stack[stack.length - (siblings === null ? 2 : 4)] ?? null;
+    const { length } = stack;
+    return stack[length - (siblings === null ? 2 : 4)] ?? null;
   }
 
   /** @type {number | null} */
   get index() {
-    return this.siblings === null ? null : this.stack[this.stack.length - 2];
+    const { stack, siblings } = this;
+    const { length } = stack;
+    return siblings === null ? null : stack[length - 2];
   }
 
   /** @type {object} */
   get node() {
-    return this.stack[this.stack.length - 1];
+    const { stack } = this;
+    const { length } = stack;
+    return stack[length - 1];
   }
 
   /** @type {object | null} */
@@ -37,7 +42,8 @@ class AstPath {
   /** @type {object[] | null} */
   get siblings() {
     const { stack } = this;
-    const maybeArray = stack[stack.length - 3];
+    const { length } = stack;
+    const maybeArray = stack[length - 3];
     return Array.isArray(maybeArray) ? maybeArray : null;
   }
 
@@ -96,7 +102,9 @@ class AstPath {
   // The value of the current property is always the final element of
   // this.stack.
   getValue() {
-    return this.stack[this.stack.length - 1];
+    const { stack } = this;
+    const { length } = stack;
+    return stack[length - 1];
   }
 
   getNode(count = 0) {
@@ -126,7 +134,7 @@ class AstPath {
   call(callback, ...names) {
     const { stack } = this;
     const { length } = stack;
-    let value = stack[stack.length - 1];
+    let value = stack[length - 1];
 
     for (const name of names) {
       value = value?.[name];
@@ -162,7 +170,7 @@ class AstPath {
   each(callback, ...names) {
     const { stack } = this;
     const { length } = stack;
-    let value = stack[stack.length - 1];
+    let value = stack[length - 1];
 
     for (const name of names) {
       value = value[name];

--- a/src/document/printer/printer.js
+++ b/src/document/printer/printer.js
@@ -54,7 +54,7 @@ function getDocTypeForPrinting(doc) {
     return;
   }
 
-  const type = doc.type;
+  const { type } = doc;
   return type === DOC_TYPE_STRING || type === DOC_TYPE_ARRAY ? undefined : type;
 }
 
@@ -81,25 +81,25 @@ function fits(
 
   let restCommandsIndex = restCommands.length;
   let hasPendingSpace = false;
-  const docs = [next.doc];
+  const documentStack = [next.doc];
   /** @type {Mode[]} */
   const modes = [next.mode];
   // `output` is only used for width counting because `trim` requires to look
   // backwards for space characters.
   let output = "";
   while (remainingWidth >= 0) {
-    if (docs.length === 0) {
+    if (documentStack.length === 0) {
       if (restCommandsIndex === 0) {
         return true;
       }
       const command = restCommands[--restCommandsIndex];
-      docs.push(command.doc);
+      documentStack.push(command.doc);
       modes.push(command.mode);
 
       continue;
     }
 
-    const doc = docs.pop();
+    const doc = documentStack.pop();
     const mode = /** @type {Mode} */ (modes.pop());
     const docType = getDocTypeForPrinting(doc);
     switch (docType) {
@@ -118,7 +118,7 @@ function fits(
 
       case DOC_TYPE_ARRAY:
         for (let index = doc.length - 1; index >= 0; index--) {
-          docs.push(doc[index]);
+          documentStack.push(doc[index]);
           modes.push(mode);
         }
         break;
@@ -127,7 +127,7 @@ function fits(
         const { parts } = doc;
         const end = doc[DOC_FILL_PRINTED_LENGTH] ?? 0;
         for (let index = parts.length - 1; index >= end; index--) {
-          docs.push(parts[index]);
+          documentStack.push(parts[index]);
           modes.push(mode);
         }
         break;
@@ -137,7 +137,7 @@ function fits(
       case DOC_TYPE_ALIGN:
       case DOC_TYPE_INDENT_IF_BREAK:
       case DOC_TYPE_LABEL:
-        docs.push(doc.contents);
+        documentStack.push(doc.contents);
         modes.push(mode);
         break;
 
@@ -153,12 +153,15 @@ function fits(
           return false;
         }
         const groupMode = doc.break ? MODE_BREAK : mode;
-        // The most expanded state takes up the least space on the current line.
-        const contents =
-          doc.expandedStates && groupMode === MODE_BREAK
-            ? doc.expandedStates[doc.expandedStates.length - 1]
-            : doc.contents;
-        docs.push(contents);
+        let { contents } = doc;
+        if (doc.expandedStates && groupMode === MODE_BREAK) {
+          // The most expanded state takes up the least space on the current
+          // line.
+          const { expandedStates } = doc;
+          const { length } = expandedStates;
+          contents = expandedStates[length - 1];
+        }
+        documentStack.push(contents);
         modes.push(groupMode);
         break;
       }
@@ -170,7 +173,7 @@ function fits(
         const contents =
           groupMode === MODE_BREAK ? doc.breakContents : doc.flatContents;
         if (contents) {
-          docs.push(contents);
+          documentStack.push(contents);
           modes.push(mode);
         }
         break;
@@ -340,10 +343,12 @@ function printDocToString(doc, options) {
             }
           }
 
+          const { expandedStates } = doc;
+          const { length } = expandedStates;
           return {
             indent,
             mode: MODE_BREAK,
-            doc: doc.expandedStates[doc.expandedStates.length - 1],
+            doc: expandedStates[length - 1],
           };
         })();
 

--- a/src/document/printer/printer.js
+++ b/src/document/printer/printer.js
@@ -19,7 +19,7 @@ import {
   hardlineWithoutBreakParent,
   indent as indentDoc,
 } from "../builders/index.js";
-import { getDocType, propagateBreaks } from "../utilities/index.js";
+import { propagateBreaks } from "../utilities/index.js";
 import InvalidDocError from "../utilities/invalid-doc-error.js";
 import { makeAlign, makeIndent, ROOT_INDENT } from "./indent.js";
 import PrintResult from "./print-result.js";
@@ -40,6 +40,23 @@ const MODE_BREAK = Symbol("MODE_BREAK");
 const MODE_FLAT = Symbol("MODE_FLAT");
 
 const DOC_FILL_PRINTED_LENGTH = Symbol("DOC_FILL_PRINTED_LENGTH");
+
+function getDocTypeForPrinting(doc) {
+  if (typeof doc === "string") {
+    return DOC_TYPE_STRING;
+  }
+
+  if (Array.isArray(doc)) {
+    return DOC_TYPE_ARRAY;
+  }
+
+  if (!doc) {
+    return;
+  }
+
+  const type = doc.type;
+  return type === DOC_TYPE_STRING || type === DOC_TYPE_ARRAY ? undefined : type;
+}
 
 /**
  * @param {Command} next
@@ -64,23 +81,27 @@ function fits(
 
   let restCommandsIndex = restCommands.length;
   let hasPendingSpace = false;
-  /** @type {Array<Omit<Command, 'indent'>>} */
-  const commands = [next];
+  const docs = [next.doc];
+  /** @type {Mode[]} */
+  const modes = [next.mode];
   // `output` is only used for width counting because `trim` requires to look
   // backwards for space characters.
   let output = "";
   while (remainingWidth >= 0) {
-    if (commands.length === 0) {
+    if (docs.length === 0) {
       if (restCommandsIndex === 0) {
         return true;
       }
-      commands.push(restCommands[--restCommandsIndex]);
+      const command = restCommands[--restCommandsIndex];
+      docs.push(command.doc);
+      modes.push(command.mode);
 
       continue;
     }
 
-    const { mode, doc } = commands.pop();
-    const docType = getDocType(doc);
+    const doc = docs.pop();
+    const mode = /** @type {Mode} */ (modes.pop());
+    const docType = getDocTypeForPrinting(doc);
     switch (docType) {
       case DOC_TYPE_STRING:
         if (doc) {
@@ -96,11 +117,18 @@ function fits(
         break;
 
       case DOC_TYPE_ARRAY:
+        for (let index = doc.length - 1; index >= 0; index--) {
+          docs.push(doc[index]);
+          modes.push(mode);
+        }
+        break;
+
       case DOC_TYPE_FILL: {
-        const parts = docType === DOC_TYPE_ARRAY ? doc : doc.parts;
+        const { parts } = doc;
         const end = doc[DOC_FILL_PRINTED_LENGTH] ?? 0;
         for (let index = parts.length - 1; index >= end; index--) {
-          commands.push({ mode, doc: parts[index] });
+          docs.push(parts[index]);
+          modes.push(mode);
         }
         break;
       }
@@ -109,7 +137,8 @@ function fits(
       case DOC_TYPE_ALIGN:
       case DOC_TYPE_INDENT_IF_BREAK:
       case DOC_TYPE_LABEL:
-        commands.push({ mode, doc: doc.contents });
+        docs.push(doc.contents);
+        modes.push(mode);
         break;
 
       case DOC_TYPE_TRIM: {
@@ -127,9 +156,10 @@ function fits(
         // The most expanded state takes up the least space on the current line.
         const contents =
           doc.expandedStates && groupMode === MODE_BREAK
-            ? doc.expandedStates.at(-1)
+            ? doc.expandedStates[doc.expandedStates.length - 1]
             : doc.contents;
-        commands.push({ mode: groupMode, doc: contents });
+        docs.push(contents);
+        modes.push(groupMode);
         break;
       }
 
@@ -140,7 +170,8 @@ function fits(
         const contents =
           groupMode === MODE_BREAK ? doc.breakContents : doc.flatContents;
         if (contents) {
-          commands.push({ mode, doc: contents });
+          docs.push(contents);
+          modes.push(mode);
         }
         break;
       }
@@ -198,7 +229,7 @@ function printDocToString(doc, options) {
 
   while (commands.length > 0) {
     const { indent, mode, doc } = commands.pop();
-    switch (getDocType(doc)) {
+    switch (getDocTypeForPrinting(doc)) {
       case DOC_TYPE_STRING: {
         const formatted =
           newLine !== "\n" ? doc.replaceAll("\n", newLine) : doc;
@@ -309,7 +340,11 @@ function printDocToString(doc, options) {
             }
           }
 
-          return { indent, mode: MODE_BREAK, doc: doc.expandedStates.at(-1) };
+          return {
+            indent,
+            mode: MODE_BREAK,
+            doc: doc.expandedStates[doc.expandedStates.length - 1],
+          };
         })();
 
         commands.push(command);

--- a/src/document/utilities/assert-doc.js
+++ b/src/document/utilities/assert-doc.js
@@ -58,7 +58,8 @@ const assertDocFillParts =
       */
       function (parts) {
         assertDocArray(parts);
-        if (parts.length > 1 && isEmptyDoc(parts[parts.length - 1])) {
+        const { length } = parts;
+        if (length > 1 && isEmptyDoc(parts[length - 1])) {
           // stripTrailingHardline can transform trailing hardline into empty string.
           // The trailing empty string is not a problem even if it's a line element.
           parts = parts.slice(0, -1);

--- a/src/document/utilities/assert-doc.js
+++ b/src/document/utilities/assert-doc.js
@@ -58,7 +58,7 @@ const assertDocFillParts =
       */
       function (parts) {
         assertDocArray(parts);
-        if (parts.length > 1 && isEmptyDoc(parts.at(-1))) {
+        if (parts.length > 1 && isEmptyDoc(parts[parts.length - 1])) {
           // stripTrailingHardline can transform trailing hardline into empty string.
           // The trailing empty string is not a problem even if it's a line element.
           parts = parts.slice(0, -1);

--- a/src/document/utilities/index.js
+++ b/src/document/utilities/index.js
@@ -129,8 +129,9 @@ function willBreak(doc) {
 }
 
 function breakParentGroup(groupStack) {
-  if (groupStack.length > 0) {
-    const parentGroup = groupStack[groupStack.length - 1];
+  const { length } = groupStack;
+  if (length > 0) {
+    const parentGroup = groupStack[length - 1];
     // Breaks are not propagated through conditional groups because
     // the user is expected to manually handle what breaks.
     if (!parentGroup.expandedStates && !parentGroup.break) {
@@ -190,7 +191,7 @@ function propagateBreaks(doc) {
         docsStack.push(doc.flatContents, doc.breakContents);
         break;
 
-      case DOC_TYPE_GROUP:
+      case DOC_TYPE_GROUP: {
         groupStack.push(doc);
         docsStack.push(doc, propagateBreaksOnExitStackMarker);
 
@@ -208,6 +209,7 @@ function propagateBreaks(doc) {
           docsStack.push(doc.contents);
         }
         break;
+      }
 
       case DOC_TYPE_ALIGN:
       case DOC_TYPE_INDENT:
@@ -257,17 +259,21 @@ function removeLines(doc) {
 function stripTrailingHardlineFromParts(parts) {
   parts = [...parts];
 
-  while (
-    parts.length >= 2 &&
-    parts[parts.length - 2].type === DOC_TYPE_LINE &&
-    parts[parts.length - 1].type === DOC_TYPE_BREAK_PARENT
-  ) {
-    parts.length -= 2;
+  while (parts.length >= 2) {
+    const { length } = parts;
+    if (
+      parts[length - 2].type !== DOC_TYPE_LINE ||
+      parts[length - 1].type !== DOC_TYPE_BREAK_PARENT
+    ) {
+      break;
+    }
+    parts.length = length - 2;
   }
 
-  if (parts.length > 0) {
-    const lastPart = stripTrailingHardlineFromDoc(parts[parts.length - 1]);
-    parts[parts.length - 1] = lastPart;
+  const { length } = parts;
+  if (length > 0) {
+    const lastPart = stripTrailingHardlineFromDoc(parts[length - 1]);
+    parts[length - 1] = lastPart;
   }
 
   return parts;
@@ -370,11 +376,12 @@ function cleanDocFn(doc) {
           continue;
         }
         const [currentPart, ...restParts] = Array.isArray(part) ? part : [part];
+        const lastPartIndex = parts.length - 1;
         if (
           typeof currentPart === "string" &&
-          typeof parts[parts.length - 1] === "string"
+          typeof parts[lastPartIndex] === "string"
         ) {
-          parts[parts.length - 1] += currentPart;
+          parts[lastPartIndex] += currentPart;
         } else {
           parts.push(currentPart);
         }

--- a/src/document/utilities/index.js
+++ b/src/document/utilities/index.js
@@ -130,7 +130,7 @@ function willBreak(doc) {
 
 function breakParentGroup(groupStack) {
   if (groupStack.length > 0) {
-    const parentGroup = groupStack.at(-1);
+    const parentGroup = groupStack[groupStack.length - 1];
     // Breaks are not propagated through conditional groups because
     // the user is expected to manually handle what breaks.
     if (!parentGroup.expandedStates && !parentGroup.break) {
@@ -142,35 +142,96 @@ function breakParentGroup(groupStack) {
   return null;
 }
 
+// Using a unique object to compare by reference.
+const propagateBreaksOnExitStackMarker = {};
+
 function propagateBreaks(doc) {
   const alreadyVisitedSet = new Set();
   const groupStack = [];
-  function propagateBreaksOnEnterFn(doc) {
-    if (doc.type === DOC_TYPE_BREAK_PARENT) {
-      breakParentGroup(groupStack);
-    }
-    if (doc.type === DOC_TYPE_GROUP) {
-      groupStack.push(doc);
-      if (alreadyVisitedSet.has(doc)) {
-        return false;
-      }
-      alreadyVisitedSet.add(doc);
-    }
-  }
-  function propagateBreaksOnExitFn(doc) {
-    if (doc.type === DOC_TYPE_GROUP) {
+  const docsStack = [doc];
+
+  while (docsStack.length > 0) {
+    doc = docsStack.pop();
+
+    if (doc === propagateBreaksOnExitStackMarker) {
+      docsStack.pop();
       const group = groupStack.pop();
       if (group.break) {
         breakParentGroup(groupStack);
       }
+      continue;
+    }
+
+    if (typeof doc === "string") {
+      continue;
+    }
+
+    if (Array.isArray(doc)) {
+      for (let index = doc.length - 1; index >= 0; index--) {
+        docsStack.push(doc[index]);
+      }
+      continue;
+    }
+
+    if (!doc) {
+      throw new InvalidDocError(doc);
+    }
+
+    switch (doc.type) {
+      case DOC_TYPE_FILL: {
+        const { parts } = doc;
+        for (let index = parts.length - 1; index >= 0; index--) {
+          docsStack.push(parts[index]);
+        }
+        break;
+      }
+
+      case DOC_TYPE_IF_BREAK:
+        docsStack.push(doc.flatContents, doc.breakContents);
+        break;
+
+      case DOC_TYPE_GROUP:
+        groupStack.push(doc);
+        docsStack.push(doc, propagateBreaksOnExitStackMarker);
+
+        const alreadyVisitedCount = alreadyVisitedSet.size;
+        alreadyVisitedSet.add(doc);
+        if (alreadyVisitedSet.size === alreadyVisitedCount) {
+          break;
+        }
+
+        if (doc.expandedStates) {
+          for (let index = doc.expandedStates.length - 1; index >= 0; index--) {
+            docsStack.push(doc.expandedStates[index]);
+          }
+        } else {
+          docsStack.push(doc.contents);
+        }
+        break;
+
+      case DOC_TYPE_ALIGN:
+      case DOC_TYPE_INDENT:
+      case DOC_TYPE_INDENT_IF_BREAK:
+      case DOC_TYPE_LABEL:
+      case DOC_TYPE_LINE_SUFFIX:
+        docsStack.push(doc.contents);
+        break;
+
+      case DOC_TYPE_BREAK_PARENT:
+        breakParentGroup(groupStack);
+        break;
+
+      case DOC_TYPE_CURSOR:
+      case DOC_TYPE_TRIM:
+      case DOC_TYPE_LINE_SUFFIX_BOUNDARY:
+      case DOC_TYPE_LINE:
+        // No children
+        break;
+
+      default:
+        throw new InvalidDocError(doc);
     }
   }
-  traverseDoc(
-    doc,
-    propagateBreaksOnEnterFn,
-    propagateBreaksOnExitFn,
-    /* shouldTraverseConditionalGroups */ true,
-  );
 }
 
 function removeLinesFn(doc) {
@@ -198,14 +259,14 @@ function stripTrailingHardlineFromParts(parts) {
 
   while (
     parts.length >= 2 &&
-    parts.at(-2).type === DOC_TYPE_LINE &&
-    parts.at(-1).type === DOC_TYPE_BREAK_PARENT
+    parts[parts.length - 2].type === DOC_TYPE_LINE &&
+    parts[parts.length - 1].type === DOC_TYPE_BREAK_PARENT
   ) {
     parts.length -= 2;
   }
 
   if (parts.length > 0) {
-    const lastPart = stripTrailingHardlineFromDoc(parts.at(-1));
+    const lastPart = stripTrailingHardlineFromDoc(parts[parts.length - 1]);
     parts[parts.length - 1] = lastPart;
   }
 
@@ -311,7 +372,7 @@ function cleanDocFn(doc) {
         const [currentPart, ...restParts] = Array.isArray(part) ? part : [part];
         if (
           typeof currentPart === "string" &&
-          typeof parts.at(-1) === "string"
+          typeof parts[parts.length - 1] === "string"
         ) {
           parts[parts.length - 1] += currentPart;
         } else {

--- a/src/index.js
+++ b/src/index.js
@@ -48,16 +48,21 @@ function withPlugins(
   return async (...args) => {
     const options = args[optionsArgumentIndex] ?? {};
     const { plugins = [] } = options;
+    const builtinPluginsPromise = loadBuiltinPlugins();
+    const loadedPluginsPromise =
+      plugins.length === 0 ? undefined : loadPlugins(plugins);
+    const builtinPlugins = await builtinPluginsPromise;
 
     args[optionsArgumentIndex] = {
       ...options,
-      plugins: (
-        await Promise.all([
-          loadBuiltinPlugins(),
-          // TODO: standalone version allow `plugins` to be `prettierPlugins` which is an object, should allow that too
-          loadPlugins(plugins),
-        ])
-      ).flat(),
+      plugins:
+        plugins.length === 0
+          ? builtinPlugins
+          : [
+              ...builtinPlugins,
+              // TODO: standalone version allow `plugins` to be `prettierPlugins` which is an object, should allow that too
+              ...(await loadedPluginsPromise),
+            ],
     };
 
     return fn(...args);

--- a/src/main/normalize-format-options.js
+++ b/src/main/normalize-format-options.js
@@ -18,6 +18,34 @@ const formatOptionsHiddenDefaults = {
   getVisitorKeys: null,
 };
 
+const emptyPlugins = [];
+const supportInfoCache = new WeakMap();
+
+function getSupportInfoForFormatOptions(plugins = emptyPlugins) {
+  let cachedSupportInfo = supportInfoCache.get(plugins);
+  if (!cachedSupportInfo) {
+    const supportOptions = getSupportInfo({
+      plugins,
+      showDeprecated: true,
+    }).options;
+
+    cachedSupportInfo = {
+      supportOptions,
+      defaults: {
+        ...formatOptionsHiddenDefaults,
+        ...Object.fromEntries(
+          supportOptions
+            .filter((optionInfo) => optionInfo.default !== undefined)
+            .map((option) => [option.name, option.default]),
+        ),
+      },
+    };
+    supportInfoCache.set(plugins, cachedSupportInfo);
+  }
+
+  return cachedSupportInfo;
+}
+
 // Copy options and fill in default values.
 async function normalizeFormatOptions(options, opts = {}) {
   const rawOptions = { ...options };
@@ -39,19 +67,9 @@ async function normalizeFormatOptions(options, opts = {}) {
     }
   }
 
-  const supportOptions = getSupportInfo({
-    plugins: options.plugins,
-    showDeprecated: true,
-  }).options;
-
-  const defaults = {
-    ...formatOptionsHiddenDefaults,
-    ...Object.fromEntries(
-      supportOptions
-        .filter((optionInfo) => optionInfo.default !== undefined)
-        .map((option) => [option.name, option.default]),
-    ),
-  };
+  const { supportOptions, defaults } = getSupportInfoForFormatOptions(
+    rawOptions.plugins,
+  );
 
   const parserPlugin = getParserPluginByParserName(
     rawOptions.plugins,

--- a/src/main/normalize-options.js
+++ b/src/main/normalize-options.js
@@ -195,13 +195,13 @@ function optionInfoToSchema(optionInfo, { isCLI, optionInfos, FlagSchema }) {
   // allow CLI overriding, e.g., prettier package.json --tab-width 1 --tab-width 2
   if (isCLI && !optionInfo.array) {
     const originalPreprocess = parameters.preprocess || ((x) => x);
-    parameters.preprocess = (value, schema, utils) =>
-      schema.preprocess(
-        originalPreprocess(
-          Array.isArray(value) ? value[value.length - 1] : value,
-        ),
-        utils,
-      );
+    parameters.preprocess = (value, schema, utils) => {
+      if (Array.isArray(value)) {
+        const { length } = value;
+        value = value[length - 1];
+      }
+      return schema.preprocess(originalPreprocess(value), utils);
+    };
   }
 
   return optionInfo.array

--- a/src/main/normalize-options.js
+++ b/src/main/normalize-options.js
@@ -197,7 +197,9 @@ function optionInfoToSchema(optionInfo, { isCLI, optionInfos, FlagSchema }) {
     const originalPreprocess = parameters.preprocess || ((x) => x);
     parameters.preprocess = (value, schema, utils) =>
       schema.preprocess(
-        originalPreprocess(Array.isArray(value) ? value.at(-1) : value),
+        originalPreprocess(
+          Array.isArray(value) ? value[value.length - 1] : value,
+        ),
         utils,
       );
   }

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -79,8 +79,10 @@ function normalizeOptionSettings(settings) {
     const option = { name, ...originalOption };
 
     // This work this way because we used support `[{value: [], since: '0.0.0'}]`
-    if (Array.isArray(option.default)) {
-      option.default = option.default[option.default.length - 1].value;
+    const { default: defaultValue } = option;
+    if (Array.isArray(defaultValue)) {
+      const { length } = defaultValue;
+      option.default = defaultValue[length - 1].value;
     }
 
     options.push(option);

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -80,7 +80,7 @@ function normalizeOptionSettings(settings) {
 
     // This work this way because we used support `[{value: [], since: '0.0.0'}]`
     if (Array.isArray(option.default)) {
-      option.default = option.default.at(-1).value;
+      option.default = option.default[option.default.length - 1].value;
     }
 
     options.push(option);

--- a/tests/unit/print-doc-to-string.js
+++ b/tests/unit/print-doc-to-string.js
@@ -1,4 +1,11 @@
-import { cursor, hardline } from "../../src/document/index.js";
+import {
+  breakParent,
+  conditionalGroup,
+  cursor,
+  group,
+  hardline,
+  line,
+} from "../../src/document/index.js";
 import { printDocToString } from "../../src/document/printer/printer.js";
 
 const options = { printWidth: 80, tabWidth: 2 };
@@ -27,4 +34,21 @@ test("Should properly trim with cursor", () => {
     cursorNodeStart: 3,
     cursorNodeText: "Prettier",
   });
+});
+
+test("Should propagate breakParent through shared groups", () => {
+  const shared = group(["a", line, "b", breakParent]);
+  const doc = group(["x", line, shared, line, shared]);
+
+  expect(printDocToString(doc, options).formatted).toBe("x\na\nb\na\nb");
+});
+
+test("Should not propagate breakParent through conditional groups", () => {
+  const doc = group([
+    "x",
+    line,
+    conditionalGroup([["flat"], ["broken", breakParent]]),
+  ]);
+
+  expect(printDocToString(doc, options).formatted).toBe("x flat");
 });


### PR DESCRIPTION
<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

This PR improves several formatting hot paths without changing formatted output.

The changes are intentionally small and mechanical:

- avoid `Array.prototype.at()` in frequently executed core/doc paths, using direct indexed access instead;
- make `propagateBreaks()` use a specialized iterative traversal instead of the generic `traverseDoc()` callback path;
- reduce temporary command object allocations in `fits()` by keeping docs and modes in separate stacks;
- cache normalized support options/defaults per plugin array in `normalizeFormatOptions()`;
- avoid calling `loadPlugins([])` and flattening plugin arrays for the common no-extra-plugins API path.

I measured this locally against `origin/main` (`8ea698ccc`) using source builds with `NODE_ENV=production` and shared dependencies. Median results from repeated runs:

| Case | main | this PR | Change |
| --- | ---: | ---: | ---: |
| tiny JS | 0.2239 ms | 0.1629 ms | -28.42% |
| `src/language-js/print/estree.js` / babel | 4.8789 ms | 4.2307 ms | -13.29% |
| `src/language-js/print/estree.js` / typescript | 6.7344 ms | 6.0675 ms | -9.90% |
| `package.json` / json | 1.8605 ms | 1.5914 ms | -14.46% |
| `docs/index.md` / markdown | 4.9928 ms | 4.2822 ms | -14.23% |
| `website/index.html` / html | 1.4029 ms | 1.2001 ms | -14.46% |

## Checklist

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory). <!-- Not applicable: no API/CLI behavior changes. -->
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

Validation run locally:

- `yarn prettier src/common/ast-path.js src/document/printer/printer.js src/document/utilities/assert-doc.js src/document/utilities/index.js src/index.js src/main/normalize-format-options.js src/main/normalize-options.js src/main/support.js tests/unit/print-doc-to-string.js --check`
- `yarn jest tests/unit/print-doc-to-string.js tests/unit/doc-printer.js tests/unit/ast-path.js tests/unit/builtin-plugins.js tests/integration/__tests__/format.js --runInBand --no-watchman`
- `yarn lint:typecheck`
- `yarn build`
