### PR TITLE
Fix YAML block scalar AST massage

### DIFF
--- a/src/language-yaml/massage-ast/index.js
+++ b/src/language-yaml/massage-ast/index.js
@@ -32,11 +32,6 @@ function massageAstNode(original, cloned /* , parent */) {
           .map((line) => line.replace(/[ \t]+$/, ""))
           .join("\n");
       }
-
-      // TODO: Fix this
-      if (original.chomping === "clip" || original.chomping === "strip") {
-        cloned.value = original.value.trimEnd();
-      }
       break;
   }
 }

--- a/tests/config/format-test/failed-format-tests.js
+++ b/tests/config/format-test/failed-format-tests.js
@@ -43,7 +43,13 @@ const unstableTests = new Map(
   }),
 );
 
-const unstableAstTests = new Map();
+const unstableAstTests = new Map(
+  [
+    // TODO: The YAML block scalar printer drops whitespace-only trailing
+    // content lines for folded scalars with strip chomping.
+    "yaml/block-folded/block-folded-strip.yml",
+  ].map((file) => [path.join(FORMAT_TEST_DIRECTORY, file), () => true]),
+);
 
 // These tests works on `babel`, `acorn`, `espree`, `oxc`, and `meriyah`
 const commentClosureTypecaseTests = [

--- a/tests/unit/yaml-massage-ast.js
+++ b/tests/unit/yaml-massage-ast.js
@@ -1,0 +1,35 @@
+import { massageAstNode } from "../../src/language-yaml/massage-ast/index.js";
+
+test.each([
+  ["blockLiteral", "clip"],
+  ["blockLiteral", "strip"],
+  ["blockFolded", "clip"],
+  ["blockFolded", "strip"],
+])("%s with %s chomping preserves value", (type, chomping) => {
+  const original = {
+    type,
+    chomping,
+    value: "line\n\n",
+  };
+  const cloned = { ...original };
+
+  massageAstNode(original, cloned);
+
+  expect(cloned.value).toBe(original.value);
+});
+
+test.each(["blockLiteral", "blockFolded"])(
+  "%s with keep chomping still ignores trailing line whitespace",
+  (type) => {
+    const original = {
+      type,
+      chomping: "keep",
+      value: "line  \nnext\t\n",
+    };
+    const cloned = { ...original };
+
+    massageAstNode(original, cloned);
+
+    expect(cloned.value).toBe("line\nnext\n");
+  },
+);


### PR DESCRIPTION
## Description

Fixes #19256.

This removes the `trimEnd()` normalization for YAML `blockLiteral` and `blockFolded` nodes with clip/strip chomping during AST massage. Their parsed `value` is semantic data and should not be changed by the comparison cleanup step.

I also added unit coverage for the YAML massage behavior and marked the existing folded-strip formatter fixture as AST-unstable now that the comparison no longer hides the printer's whitespace-only trailing-line behavior.

No changelog entry: this changes internal AST comparison/test behavior; formatter output and public API are unchanged.

## Verification

- `corepack yarn test tests/unit/yaml-massage-ast.js --runInBand`
- `$env:FULL_TEST='1'; corepack yarn test tests/format/yaml/block-literal tests/format/yaml/block-folded --runInBand`
- `corepack yarn prettier --check src/language-yaml/massage-ast/index.js tests/unit/yaml-massage-ast.js tests/config/format-test/failed-format-tests.js`
- `corepack yarn lint:changelog`
- `git diff --check`

## Checklist

- [x] I've added tests to confirm my change works.
- [ ] (If changing the API or CLI) I've documented the changes I've made (in the `docs/` directory).
- [ ] (If the change is user-facing) I've added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I've read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.