### PR TITLE
chore: disable Yarn lifecycle scripts during install

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,7 +6,7 @@ defaultSemverRangePrefix: ""
 
 enableGlobalCache: true
 
-enableScripts: true
+enableScripts: false
 
 nodeLinker: node-modules
 


### PR DESCRIPTION
<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

This PR sets `enableScripts: false` in `.yarnrc.yml`.
That stops Yarn from running lifecycle scripts such as `postinstall` and `preinstall` during `yarn install`.

When you install dependencies, some packages run scripts automatically. That is a common supply-chain risk: if a package is compromised, it can run arbitrary code on your machine during install — before you run the app or read the code.
Turning off install scripts lowers that risk for everyone who installs dependencies in this repo, including local development and CI.


## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
