### PR TITLE
Warn when explicitly passed files are ignored

### DIFF
--- a/changelog_unreleased/cli/19305.md
+++ b/changelog_unreleased/cli/19305.md
@@ -1,0 +1,17 @@
+#### Warn when explicitly passed files are ignored (#19305 by @pentaoa)
+
+Prettier now prints a warning when an explicitly passed file is ignored by an ignore pattern. Explicit files in `node_modules` get a more specific warning that points to `--with-node-modules`.
+
+<!-- prettier-ignore -->
+```sh
+prettier ignored.js
+
+# Prettier stable
+foo(
+)
+
+# Prettier main
+[warn] Ignored ignored.js because it matches an ignore pattern.
+foo(
+)
+```

--- a/src/cli/expand-patterns.js
+++ b/src/cli/expand-patterns.js
@@ -15,9 +15,13 @@ async function* expandPatterns(context) {
   const seen = new Set();
   let noResults = true;
 
-  for await (const { filePath, ignoreUnknown, error } of expandPatternsInternal(
-    context,
-  )) {
+  for await (const {
+    filePath,
+    ignoreUnknown,
+    error,
+    isExplicitFile,
+    isIgnoredByDirectory,
+  } of expandPatternsInternal(context)) {
     noResults = false;
     if (error) {
       yield { error };
@@ -32,7 +36,7 @@ async function* expandPatterns(context) {
     }
 
     seen.add(filename);
-    yield { filename, ignoreUnknown };
+    yield { filename, ignoreUnknown, isExplicitFile, isIgnoredByDirectory };
   }
 
   if (noResults && context.argv.errorOnUnmatchedPattern !== false) {
@@ -58,17 +62,24 @@ async function* expandPatternsInternal(context) {
   };
   const cwd = process.cwd();
 
-  /** @type {Array<{ type: 'file' | 'dir' | 'glob'; glob: string; input: string; }>} */
+  /** @type {Array<{ type: 'file' | 'dir' | 'glob'; glob: string; input: string; ignoreUnknown?: boolean; }>} */
   const entries = [];
 
   for (const pattern of context.filePatterns) {
     const absolutePath = path.resolve(pattern);
+    const stat = await lstatSafe(absolutePath);
 
     if (directoryIgnorer.shouldIgnore(absolutePath)) {
+      if (stat?.isFile()) {
+        yield {
+          filePath: pattern,
+          isExplicitFile: true,
+          isIgnoredByDirectory: true,
+        };
+      }
       continue;
     }
 
-    const stat = await lstatSafe(absolutePath);
     if (stat) {
       if (stat.isSymbolicLink()) {
         if (context.argv.errorOnUnmatchedPattern !== false) {
@@ -131,7 +142,11 @@ async function* expandPatternsInternal(context) {
         yield { error: `${errorMessages.emptyResults[type]}: "${input}".` };
       }
     } else {
-      yield* sortPaths(result).map((filePath) => ({ filePath, ignoreUnknown }));
+      yield* sortPaths(result).map((filePath) => ({
+        filePath,
+        ignoreUnknown,
+        isExplicitFile: type === "file",
+      }));
     }
   }
 }

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -82,6 +82,14 @@ function writeOutput(context, result, options) {
   }
 }
 
+function getIgnoredFileWarning(filename, isIgnoredByDirectory) {
+  if (isIgnoredByDirectory && filename.split("/").includes("node_modules")) {
+    return `Ignored ${filename} because it is in node_modules. Use --with-node-modules to format this file.`;
+  }
+
+  return `Ignored ${filename} because it matches an ignore pattern.`;
+}
+
 async function listDifferent(context, input, options, filename) {
   if (!context.argv.check && !context.argv.listDifferent) {
     return;
@@ -302,9 +310,13 @@ async function formatFiles(context) {
   // See https://github.com/prettier/prettier/issues/5801
   const isTTY = mockable.isStreamTTY(process.stdout) && !mockable.isCI();
 
-  for await (const { error, filename, ignoreUnknown } of expandPatterns(
-    context,
-  )) {
+  for await (const {
+    error,
+    filename,
+    ignoreUnknown,
+    isExplicitFile,
+    isIgnoredByDirectory,
+  } of expandPatterns(context)) {
     if (error) {
       context.logger.error(error);
       // Don't exit, but set the exit code to 2
@@ -312,7 +324,14 @@ async function formatFiles(context) {
       continue;
     }
 
+    const fileNameToDisplay = normalizeToPosix(path.relative(cwd, filename));
     const isFileIgnored = isIgnored(filename);
+    if (isFileIgnored && isExplicitFile) {
+      context.logger.warn(
+        getIgnoredFileWarning(fileNameToDisplay, isIgnoredByDirectory),
+      );
+    }
+
     if (
       isFileIgnored &&
       (context.argv.debugCheck ||
@@ -328,7 +347,6 @@ async function formatFiles(context) {
       filepath: filename,
     };
 
-    const fileNameToDisplay = normalizeToPosix(path.relative(cwd, filename));
     let printedFilename;
     if (isTTY) {
       printedFilename = context.logger.log(fileNameToDisplay, {

--- a/tests/integration/__tests__/patterns.js
+++ b/tests/integration/__tests__/patterns.js
@@ -43,6 +43,16 @@ describe("multiple patterns by with ignore pattern, doesn't ignore node_modules 
   });
 });
 
+describe("explicit ignored file in node_modules", () => {
+  runCli("cli/patterns", ["node_modules/node-module.js"]).test({
+    status: 0,
+    stdout: "/* eslint-disable */\n'use strict';",
+    stderr:
+      "[warn] Ignored node_modules/node-module.js because it is in node_modules. Use --with-node-modules to format this file.",
+    write: [],
+  });
+});
+
 describe("no errors on empty patterns", () => {
   // --parser is mandatory if no filepath is passed
   runCli("cli/patterns", ["--parser", "babel"]).test({

--- a/tests/integration/__tests__/print-code.js
+++ b/tests/integration/__tests__/print-code.js
@@ -1,7 +1,11 @@
 describe("Line breaking after filepath with errors", () => {
   runCli("cli/print-code", ["./ignored.js"], {
     stdoutIsTTY: true,
-  }).test({ status: 0, write: [], stderr: "" });
+  }).test({
+    status: 0,
+    write: [],
+    stderr: "[warn] Ignored ignored.js because it matches an ignore pattern.",
+  });
   runCli("cli/print-code", ["./not-ignored.js"], {
     stdoutIsTTY: true,
   }).test({ status: 0, write: [], stderr: "" });


### PR DESCRIPTION
## Description

Fixes #15700.

Prettier now warns when a user explicitly passes a file that is ignored, instead of silently printing the original content. Explicit files inside `node_modules` get a more specific warning that points to `--with-node-modules`.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

## Tests

- `npx jest tests/integration/__tests__/print-code.js tests/integration/__tests__/patterns.js --runInBand`
- `npx prettier src/cli/expand-patterns.js src/cli/format.js tests/integration/__tests__/patterns.js tests/integration/__tests__/print-code.js changelog_unreleased/cli/19305.md --check`