### PR TITLE
Markdown: respect useTabs for indented code blocks and footnote bodies

### DIFF
--- a/changelog_unreleased/markdown/19352.md
+++ b/changelog_unreleased/markdown/19352.md
@@ -1,0 +1,36 @@
+#### Respect `useTabs` for indented code blocks and footnote bodies (#19352 by @WhoamiI00)
+
+When `useTabs` is enabled, Prettier now uses a tab instead of four spaces to indent the body of an indented code block and the continuation blocks of a footnote definition. A tab is structurally equivalent to four spaces in these cases per the CommonMark spec.
+
+<!-- prettier-ignore -->
+```md
+<!-- Input (with `--use-tabs`) -->
+# Indented code block
+
+	first line
+	second line
+
+[^x]: Footnote
+
+	Continuation paragraph.
+
+<!-- Prettier stable -->
+# Indented code block
+
+    first line
+    second line
+
+[^x]: Footnote
+
+    Continuation paragraph.
+
+<!-- Prettier main -->
+# Indented code block
+
+	first line
+	second line
+
+[^x]: Footnote
+
+	Continuation paragraph.
+```

--- a/src/language-markdown/print/mdast.js
+++ b/src/language-markdown/print/mdast.js
@@ -230,8 +230,9 @@ function printMdast(path, options, print) {
       return printHeading(path, options, print);
     case "code": {
       if (node.isIndented) {
-        // indented code block
-        const alignment = " ".repeat(4);
+        // indented code block: CommonMark treats one tab as 4 columns,
+        // so when `useTabs` is enabled a single tab is equivalent.
+        const alignment = options.useTabs ? "\t" : " ".repeat(4);
         return align(alignment, [
           alignment,
           replaceEndOfLine(node.value, hardline),
@@ -350,7 +351,7 @@ function printMdast(path, options, print) {
           ? printChildren(path, options, print)
           : group([
               align(
-                " ".repeat(4),
+                options.useTabs ? "\t" : " ".repeat(4),
                 printChildren(path, options, print, {
                   processor: ({ isFirst }) =>
                     isFirst ? group([softline, print()]) : print(),

--- a/tests/format/markdown/use-tabs/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/use-tabs/__snapshots__/format.test.js.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`footnote-definition.md - {"useTabs":true} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+useTabs: true
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+# Footnote definition
+
+Here is a footnote reference,[^1] and another.[^longnote]
+
+[^1]: Here is the footnote.
+
+[^longnote]: Here's one with multiple blocks.
+
+	Subsequent paragraphs are indented to show that they belong to the previous footnote.
+
+		{ some.code }
+
+	The whole paragraph can be indented, or just the first line.
+
+=====================================output=====================================
+# Footnote definition
+
+Here is a footnote reference,[^1] and another.[^longnote]
+
+[^1]: Here is the footnote.
+
+[^longnote]: Here's one with multiple blocks.
+
+	Subsequent paragraphs are indented to show that they belong to the previous footnote.
+
+		{ some.code }
+
+	The whole paragraph can be indented, or just the first line.
+
+================================================================================
+`;
+
+exports[`indented-code-block.md - {"useTabs":true} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+useTabs: true
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+# Indented code block
+
+	first line
+	second line
+	third line
+
+Trailing paragraph.
+
+=====================================output=====================================
+# Indented code block
+
+	first line
+	second line
+	third line
+
+Trailing paragraph.
+
+================================================================================
+`;

--- a/tests/format/markdown/use-tabs/footnote-definition.md
+++ b/tests/format/markdown/use-tabs/footnote-definition.md
@@ -1,0 +1,13 @@
+# Footnote definition
+
+Here is a footnote reference,[^1] and another.[^longnote]
+
+[^1]: Here is the footnote.
+
+[^longnote]: Here's one with multiple blocks.
+
+	Subsequent paragraphs are indented to show that they belong to the previous footnote.
+
+		{ some.code }
+
+	The whole paragraph can be indented, or just the first line.

--- a/tests/format/markdown/use-tabs/format.test.js
+++ b/tests/format/markdown/use-tabs/format.test.js
@@ -1,0 +1,1 @@
+runFormatTest(import.meta, ["markdown"], { useTabs: true });

--- a/tests/format/markdown/use-tabs/indented-code-block.md
+++ b/tests/format/markdown/use-tabs/indented-code-block.md
@@ -1,0 +1,7 @@
+# Indented code block
+
+	first line
+	second line
+	third line
+
+Trailing paragraph.


### PR DESCRIPTION
## Description

Fixes a subset of #8782 — when `useTabs` is enabled, Prettier was still emitting four literal spaces for indented code blocks and for the 4-column alignment used inside footnote definitions.

CommonMark explicitly treats a tab as advancing to the next 4-column stop ([spec §2.2](https://spec.commonmark.org/0.31.2/#tabs)), so a single `\t` is structurally equivalent to four spaces for both of these cases — the document still parses as an indented code block / footnote continuation, and `tabWidth` doesn't change that (the 4-column rule is fixed by the spec, not by Prettier's setting).

List-item alignment is intentionally **not** changed in this PR: list prefixes (`- `, `1. `, …) are not multiples of 4 columns, so substituting a tab there would actually break the structure. That part of #8782 needs a separate, more involved fix.

### Before / after

```md
<!-- Input (with `--use-tabs`) -->
# Indented code block

	first line
	second line

[^x]: Footnote

	Continuation paragraph.
```

```md
<!-- Prettier stable (4 spaces — ignores --use-tabs) -->
# Indented code block

    first line
    second line

[^x]: Footnote

    Continuation paragraph.
```

```md
<!-- Prettier main (tab — respects --use-tabs) -->
# Indented code block

	first line
	second line

[^x]: Footnote

	Continuation paragraph.
```

## Checklist

- [x] I've added tests to confirm my change works.
- [ ] (If changing the API or CLI) I've documented the changes I've made (in the `docs/` directory).
- [x] (If the change is user-facing) I've added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I've read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did *not* use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.