### PR TITLE
docs: align homepage ecosystem stats layout

### DIFF
--- a/changelog_unreleased/misc/19395.md
+++ b/changelog_unreleased/misc/19395.md
@@ -1,0 +1,3 @@
+#### Improve homepage ecosystem stats layout (#19395 by @Hsiii)
+
+Align the homepage ecosystem stats so the State of JS, GitHub, and npm items keep more consistent spacing across desktop and mobile widths.

--- a/website/src/pages/index.jsx
+++ b/website/src/pages/index.jsx
@@ -308,12 +308,14 @@ function UsersSection() {
               <ul>
                 <li>
                   <Link to="https://2021.stateofjs.com/en-US/other-tools/#utilities">
-                    More than 83% of respondents to State of JS 2021.
+                    More than <strong>83%</strong> of respondents to State of JS
+                    2021.
                   </Link>
                 </li>
                 <li>
                   <Link to="https://2020.stateofjs.com/en-US/other-tools/#utilities">
-                    More than 70% of respondents to State of JS 2020.
+                    More than <strong>70%</strong> of respondents to State of JS
+                    2020.
                   </Link>
                 </li>
               </ul>

--- a/website/src/pages/index.jsx
+++ b/website/src/pages/index.jsx
@@ -299,7 +299,6 @@ function UsersSection() {
           <div className={styles.ecosystemGridItem}>
             <Link
               to="https://2021.stateofjs.com/en-US/other-tools/utilities"
-              style={{ marginTop: "15px" }}
               aria-label="Statistic for utility tools in the State of JavaScript survey"
             >
               <img src="/images/state_of_js_grey.svg" alt="" />

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -301,8 +301,9 @@
   gap: 1.5rem 1rem;
 }
 
-@media only screen and (max-width: 736px) {
+@media only screen and (max-width: 1100px) {
   .ecosystemGrid {
+    flex-direction: column;
     gap: 2rem 1rem;
   }
 }
@@ -310,6 +311,9 @@
 .ecosystemGridItem {
   display: grid;
   grid-template-columns: auto 260px;
+  align-items: center;
+  flex: 1 1 0;
+  min-width: 0;
   gap: 0.8rem;
   font-size: 14px;
   line-height: 1.4;
@@ -317,7 +321,14 @@
   --ifm-link-color: #b0c4ce;
   --ifm-link-hover-color: var(--ifm-color-white);
   --ifm-list-left-padding: 2rem;
-  --ifm-paragraph-margin-bottom: 1rem;
+  --ifm-paragraph-margin-bottom: 0.5rem;
+}
+
+.ecosystemGridItem > a {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
 }
 
 .ecosystemGridItem img {

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -314,7 +314,7 @@
   align-items: center;
   flex: 1 1 0;
   min-width: 0;
-  gap: 0.8rem;
+  gap: calc(var(--ifm-spacing-horizontal) / 2);
   font-size: 14px;
   line-height: 1.4;
   color: #b0c4ce;

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -309,8 +309,10 @@
 }
 
 .ecosystemGridItem {
+  --ecosystem-logo-size: 80px;
+
   display: grid;
-  grid-template-columns: auto 260px;
+  grid-template-columns: var(--ecosystem-logo-size) 260px;
   align-items: center;
   flex: 1 1 0;
   min-width: 0;
@@ -332,7 +334,7 @@
 }
 
 .ecosystemGridItem img {
-  width: 80px;
+  width: var(--ecosystem-logo-size);
 }
 
 .ecosystemGridItem li + li {


### PR DESCRIPTION
## Description

Aligns the homepage ecosystem stats so the State of JS, GitHub, and npm items have more consistent spacing across desktop and mobile widths.

### Screenshots

| View | Before | After |
| --- | --- | --- |
| Desktop | <img width="1320" height="209" alt="before-desktop" src="https://github.com/user-attachments/assets/882dc090-1927-4b03-bdf4-5c0cfdbde093" />| <img width="1320" height="201" alt="after-desktop" src="https://github.com/user-attachments/assets/1d6b0a72-42cb-468f-93b1-484ef6e18fa8" />|
| Mobile | <img width="390" height="497" alt="before-mobile" src="https://github.com/user-attachments/assets/346dca8d-9204-4bf3-8a17-51e3e9d0ef77" />| <img width="390" height="473" alt="after-mobile" src="https://github.com/user-attachments/assets/e594bc45-ede0-422b-a28d-c90e917fdd3f" /> |

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.