### PR TITLE
Don't treat SCSS `!default`/`!global` inside strings as flags

### DIFF
--- a/changelog_unreleased/scss/19404.md
+++ b/changelog_unreleased/scss/19404.md
@@ -1,0 +1,21 @@
+#### Don't treat SCSS `!default`/`!global` inside strings as flags (#19404 by @patrickwehbe)
+
+`!default` and `!global` inside a string or function argument are no longer treated as Sass declaration flags, so the value is left untouched instead of having a space injected. Genuine trailing flags keep working.
+
+<!-- prettier-ignore -->
+```scss
+// Input
+$a: "!default";
+$b: unquote("!default");
+$c: url("x!global");
+
+// Prettier stable
+$a: " !default";
+$b: unquote(" !default");
+$c: url("x !global");
+
+// Prettier main
+$a: "!default";
+$b: unquote("!default");
+$c: url("x!global");
+```

--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -19,8 +19,8 @@ import { hasIgnorePragma, hasPragma } from "./pragma.js";
 import isModuleRuleName from "./utilities/is-module-rule-name.js";
 import isSCSSNestedPropertyNode from "./utilities/is-scss-nested-property-node.js";
 
-const DEFAULT_SCSS_DIRECTIVE = /(\s*)(!default).*$/;
-const GLOBAL_SCSS_DIRECTIVE = /(\s*)(!global).*$/;
+const DEFAULT_SCSS_DIRECTIVE = /(\s*)(!default)(?:\s|\/\*.*?\*\/)*$/s;
+const GLOBAL_SCSS_DIRECTIVE = /(\s*)(!global)(?:\s|\/\*.*?\*\/)*$/s;
 
 function parseNestedCSS(node, options) {
   if (isObject(node)) {

--- a/tests/format/scss/flag/19203.scss
+++ b/tests/format/scss/flag/19203.scss
@@ -17,3 +17,12 @@ $k: "!default" !default;
 $l: "!global" !global;
 $m: map-get($map, "!default") !default;
 $n: map-get($map, "!global") !global;
+
+// A trailing flag followed by comments is still detected, including when the
+// value contains the flag text inside a string.
+$o: 1 !default /* trailing comment */;
+$p: 1 !global /* trailing comment */;
+$q: 1 !default /* c1 */ /* c2 */;
+$r: "!default" !default /* trailing comment */;
+$s: 1 !default /* multi
+line comment */;

--- a/tests/format/scss/flag/19203.scss
+++ b/tests/format/scss/flag/19203.scss
@@ -26,3 +26,8 @@ $q: 1 !default /* c1 */ /* c2 */;
 $r: "!default" !default /* trailing comment */;
 $s: 1 !default /* multi
 line comment */;
+
+// A trailing flag is also detected when the statement has a single-line comment.
+$t: 1 !default; // trailing comment
+$u: 1 !global; // trailing comment
+$v: "!default" !default; // trailing comment

--- a/tests/format/scss/flag/19203.scss
+++ b/tests/format/scss/flag/19203.scss
@@ -1,0 +1,19 @@
+// `!default` / `!global` inside strings or function arguments are not flags
+// and must be left untouched (no stray space injected).
+$a: "!default";
+$b: "!global";
+$c: "x !default";
+$d: "x !global";
+$e: unquote("!default");
+$f: unquote("!global");
+$g: url("x!default");
+$h: url("x!global");
+$i: map-get($map, "!default");
+$j: map-get($map, "!global");
+
+// A genuine trailing flag is still detected, even when the value also
+// contains the flag text inside a string.
+$k: "!default" !default;
+$l: "!global" !global;
+$m: map-get($map, "!default") !default;
+$n: map-get($map, "!global") !global;

--- a/tests/format/scss/flag/__snapshots__/format.test.js.snap
+++ b/tests/format/scss/flag/__snapshots__/format.test.js.snap
@@ -110,6 +110,15 @@ $l: "!global" !global;
 $m: map-get($map, "!default") !default;
 $n: map-get($map, "!global") !global;
 
+// A trailing flag followed by comments is still detected, including when the
+// value contains the flag text inside a string.
+$o: 1 !default /* trailing comment */;
+$p: 1 !global /* trailing comment */;
+$q: 1 !default /* c1 */ /* c2 */;
+$r: "!default" !default /* trailing comment */;
+$s: 1 !default /* multi
+line comment */;
+
 =====================================output=====================================
 // \`!default\` / \`!global\` inside strings or function arguments are not flags
 // and must be left untouched (no stray space injected).
@@ -130,6 +139,15 @@ $k: "!default" !default;
 $l: "!global" !global;
 $m: map-get($map, "!default") !default;
 $n: map-get($map, "!global") !global;
+
+// A trailing flag followed by comments is still detected, including when the
+// value contains the flag text inside a string.
+$o: 1 !default /* trailing comment */;
+$p: 1 !global /* trailing comment */;
+$q: 1 !default /* c1 */ /* c2 */;
+$r: "!default" !default /* trailing comment */;
+$s: 1 !default /* multi
+line comment */;
 
 ================================================================================
 `;
@@ -160,6 +178,15 @@ $l: "!global" !global;
 $m: map-get($map, "!default") !default;
 $n: map-get($map, "!global") !global;
 
+// A trailing flag followed by comments is still detected, including when the
+// value contains the flag text inside a string.
+$o: 1 !default /* trailing comment */;
+$p: 1 !global /* trailing comment */;
+$q: 1 !default /* c1 */ /* c2 */;
+$r: "!default" !default /* trailing comment */;
+$s: 1 !default /* multi
+line comment */;
+
 =====================================output=====================================
 // \`!default\` / \`!global\` inside strings or function arguments are not flags
 // and must be left untouched (no stray space injected).
@@ -180,6 +207,15 @@ $k: "!default" !default;
 $l: "!global" !global;
 $m: map-get($map, "!default") !default;
 $n: map-get($map, "!global") !global;
+
+// A trailing flag followed by comments is still detected, including when the
+// value contains the flag text inside a string.
+$o: 1 !default /* trailing comment */;
+$p: 1 !global /* trailing comment */;
+$q: 1 !default /* c1 */ /* c2 */;
+$r: "!default" !default /* trailing comment */;
+$s: 1 !default /* multi
+line comment */;
 
 ================================================================================
 `;

--- a/tests/format/scss/flag/__snapshots__/format.test.js.snap
+++ b/tests/format/scss/flag/__snapshots__/format.test.js.snap
@@ -83,3 +83,103 @@ $global: "very-long-long-long-long-long-long-long-long-long-long-long-value" !gl
 
 ================================================================================
 `;
+
+exports[`19203.scss - {"trailingComma":"es5"} format 1`] = `
+====================================options=====================================
+parsers: ["scss"]
+trailingComma: "es5"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// \`!default\` / \`!global\` inside strings or function arguments are not flags
+// and must be left untouched (no stray space injected).
+$a: "!default";
+$b: "!global";
+$c: "x !default";
+$d: "x !global";
+$e: unquote("!default");
+$f: unquote("!global");
+$g: url("x!default");
+$h: url("x!global");
+$i: map-get($map, "!default");
+$j: map-get($map, "!global");
+
+// A genuine trailing flag is still detected, even when the value also
+// contains the flag text inside a string.
+$k: "!default" !default;
+$l: "!global" !global;
+$m: map-get($map, "!default") !default;
+$n: map-get($map, "!global") !global;
+
+=====================================output=====================================
+// \`!default\` / \`!global\` inside strings or function arguments are not flags
+// and must be left untouched (no stray space injected).
+$a: "!default";
+$b: "!global";
+$c: "x !default";
+$d: "x !global";
+$e: unquote("!default");
+$f: unquote("!global");
+$g: url("x!default");
+$h: url("x!global");
+$i: map-get($map, "!default");
+$j: map-get($map, "!global");
+
+// A genuine trailing flag is still detected, even when the value also
+// contains the flag text inside a string.
+$k: "!default" !default;
+$l: "!global" !global;
+$m: map-get($map, "!default") !default;
+$n: map-get($map, "!global") !global;
+
+================================================================================
+`;
+
+exports[`19203.scss - {"trailingComma":"none"} format 1`] = `
+====================================options=====================================
+parsers: ["scss"]
+trailingComma: "none"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// \`!default\` / \`!global\` inside strings or function arguments are not flags
+// and must be left untouched (no stray space injected).
+$a: "!default";
+$b: "!global";
+$c: "x !default";
+$d: "x !global";
+$e: unquote("!default");
+$f: unquote("!global");
+$g: url("x!default");
+$h: url("x!global");
+$i: map-get($map, "!default");
+$j: map-get($map, "!global");
+
+// A genuine trailing flag is still detected, even when the value also
+// contains the flag text inside a string.
+$k: "!default" !default;
+$l: "!global" !global;
+$m: map-get($map, "!default") !default;
+$n: map-get($map, "!global") !global;
+
+=====================================output=====================================
+// \`!default\` / \`!global\` inside strings or function arguments are not flags
+// and must be left untouched (no stray space injected).
+$a: "!default";
+$b: "!global";
+$c: "x !default";
+$d: "x !global";
+$e: unquote("!default");
+$f: unquote("!global");
+$g: url("x!default");
+$h: url("x!global");
+$i: map-get($map, "!default");
+$j: map-get($map, "!global");
+
+// A genuine trailing flag is still detected, even when the value also
+// contains the flag text inside a string.
+$k: "!default" !default;
+$l: "!global" !global;
+$m: map-get($map, "!default") !default;
+$n: map-get($map, "!global") !global;
+
+================================================================================
+`;

--- a/tests/format/scss/flag/__snapshots__/format.test.js.snap
+++ b/tests/format/scss/flag/__snapshots__/format.test.js.snap
@@ -119,6 +119,11 @@ $r: "!default" !default /* trailing comment */;
 $s: 1 !default /* multi
 line comment */;
 
+// A trailing flag is also detected when the statement has a single-line comment.
+$t: 1 !default; // trailing comment
+$u: 1 !global; // trailing comment
+$v: "!default" !default; // trailing comment
+
 =====================================output=====================================
 // \`!default\` / \`!global\` inside strings or function arguments are not flags
 // and must be left untouched (no stray space injected).
@@ -148,6 +153,11 @@ $q: 1 !default /* c1 */ /* c2 */;
 $r: "!default" !default /* trailing comment */;
 $s: 1 !default /* multi
 line comment */;
+
+// A trailing flag is also detected when the statement has a single-line comment.
+$t: 1 !default; // trailing comment
+$u: 1 !global; // trailing comment
+$v: "!default" !default; // trailing comment
 
 ================================================================================
 `;
@@ -187,6 +197,11 @@ $r: "!default" !default /* trailing comment */;
 $s: 1 !default /* multi
 line comment */;
 
+// A trailing flag is also detected when the statement has a single-line comment.
+$t: 1 !default; // trailing comment
+$u: 1 !global; // trailing comment
+$v: "!default" !default; // trailing comment
+
 =====================================output=====================================
 // \`!default\` / \`!global\` inside strings or function arguments are not flags
 // and must be left untouched (no stray space injected).
@@ -216,6 +231,11 @@ $q: 1 !default /* c1 */ /* c2 */;
 $r: "!default" !default /* trailing comment */;
 $s: 1 !default /* multi
 line comment */;
+
+// A trailing flag is also detected when the statement has a single-line comment.
+$t: 1 !default; // trailing comment
+$u: 1 !global; // trailing comment
+$v: "!default" !default; // trailing comment
 
 ================================================================================
 `;


### PR DESCRIPTION
## Description

Fixes #19203.

`!default` and `!global` inside a string or function argument were treated as Sass declaration flags. The flag text was sliced off the value, which injected a stray space:

```scss
/* input */
$a: "!default";
$b: unquote("!default");
$c: url("x!global");

/* before */
$a: " !default";
$b: unquote(" !default");
$c: url("x !global");
```

### Cause

The directives were detected with `/(\s*)(!default).*$/` and `/(\s*)(!global).*$/`. The `.*$` matches the flag text anywhere in the value, including inside strings and `url(...)` / function arguments, after which everything from the match onward is sliced off.

### Fix

In #19245 fisker suggested tightening the pattern to `/(\s*)(!default)\s?$/` so it only matches a trailing flag. That is the right direction, but it drops the existing support for a flag followed by a comment, e.g. `green !global /* note */`, which has a snapshot in `tests/format/scss/comments/variable-declaration.scss`.

So the patterns now match the flag only when it sits at the end of the value, optionally followed by block comments:

```js
const DEFAULT_SCSS_DIRECTIVE = /(\s*)(!default)(?:\s|\/\*.*?\*\/)*$/s;
const GLOBAL_SCSS_DIRECTIVE = /(\s*)(!global)(?:\s|\/\*.*?\*\/)*$/s;
```

Flag text inside a string or function no longer matches, while genuine trailing flags keep working, including a flag after a quoted value (`$d: "!default" !default;`) and a flag followed by a comment.

```scss
/* after */
$a: "!default";
$b: unquote("!default");
$c: url("x!global");

$d: "!default" !default;
$e: map-get($map, "!default") !default;
```

### Tests

Added `tests/format/scss/flag/19203.scss` covering the in-string, `url(...)`, and function-argument cases, plus mixed cases where a string value is followed by a real trailing flag. The existing `flag` and `comments` snapshots are unchanged, so genuine flags and flag-with-comment behavior are preserved.

## Checklist

- [x] I've added tests to confirm my change works.
- [ ] (If changing the API or CLI) I've documented the changes I've made (in the `docs/` directory).
- [x] (If the change is user-facing) I've added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I've read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
