### PR TITLE
Fix plain array default of an `array` option being dropped

### DIFF
--- a/changelog_unreleased/api/19409.md
+++ b/changelog_unreleased/api/19409.md
@@ -1,0 +1,18 @@
+#### Fix plain array default of an `array` option being dropped (#19409 by @chatman-media)
+
+A plugin `array` option (`array: true`) with a plain array `default` — the shape the [plugin options docs](https://prettier.io/docs/plugins#options) demonstrate — had its default silently dropped to `undefined`, so a plugin validating the option failed with `Expected an array of a string, but received undefined`. An empty array `default` threw a `TypeError`. The redundant-default format `[{ value }]` is now the only array `default` that gets unwrapped.
+
+<!-- prettier-ignore -->
+```js
+// Plugin
+export const options = {
+  myList: {
+    type: "string",
+    array: true,
+    default: ["a", "b"],
+  },
+};
+
+// Prettier stable: default resolves to `undefined`
+// Prettier main:   default resolves to `["a", "b"]`
+```

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -1,3 +1,4 @@
+import isNonEmptyArray from "../utilities/is-non-empty-array.js";
 import coreOptions from "./core-options.evaluate.js";
 
 /**
@@ -79,7 +80,18 @@ function normalizeOptionSettings(settings) {
     const option = { name, ...originalOption };
 
     // This work this way because we used support `[{value: [], since: '0.0.0'}]`
-    if (Array.isArray(option.default)) {
+    // Only this redundant-default format (a non-empty array of `{ value }`
+    // entries) should be unwrapped. A plain array value, e.g. the `default` of
+    // an `array` option, must be kept as-is.
+    if (
+      isNonEmptyArray(option.default) &&
+      option.default.every(
+        (defaultEntry) =>
+          defaultEntry !== null &&
+          typeof defaultEntry === "object" &&
+          "value" in defaultEntry,
+      )
+    ) {
       option.default = option.default.at(-1).value;
     }
 

--- a/tests/unit/normalize-option-settings.js
+++ b/tests/unit/normalize-option-settings.js
@@ -1,0 +1,49 @@
+import { normalizeOptionSettings } from "../../src/main/support.js";
+
+function getNormalizedDefault(optionSettings) {
+  const [{ default: normalizedDefault }] = normalizeOptionSettings({
+    testOption: optionSettings,
+  });
+  return normalizedDefault;
+}
+
+describe("normalizeOptionSettings default handling", () => {
+  test("keeps a plain array default of an `array` option (#19012)", () => {
+    expect(
+      getNormalizedDefault({
+        type: "string",
+        array: true,
+        default: ["a", "b"],
+      }),
+    ).toStrictEqual(["a", "b"]);
+  });
+
+  test("keeps an empty array default without throwing", () => {
+    expect(
+      getNormalizedDefault({ type: "string", array: true, default: [] }),
+    ).toStrictEqual([]);
+  });
+
+  test("unwraps the redundant-default `[{ value }]` format", () => {
+    expect(
+      getNormalizedDefault({
+        type: "string",
+        array: true,
+        default: [{ value: ["a"] }],
+      }),
+    ).toStrictEqual(["a"]);
+  });
+
+  test("unwraps to the latest value of a redundant-default list", () => {
+    expect(
+      getNormalizedDefault({
+        type: "choice",
+        default: [{ value: "old" }, { value: "new" }],
+      }),
+    ).toBe("new");
+  });
+
+  test("keeps a scalar default", () => {
+    expect(getNormalizedDefault({ type: "string", default: "x" })).toBe("x");
+  });
+});


### PR DESCRIPTION
<!-- Please make sure you have read and understood the contribution guidelines -->

**Description**

Fixes #19012.

When a plugin declares an `array` option (`array: true`) and gives it a `default` that is a plain array — the shape the [plugin options docs](https://prettier.io/docs/plugins#options) demonstrate (`default: <value>`) — Prettier silently drops the default to `undefined`, and a plugin that validates the option fails with:

```
[error] Invalid OptionName value. Expected an array of a string, but received undefined.
```

**Root cause**

`normalizeOptionSettings` in `src/main/support.js` treated *any* array `default` as the legacy redundant-default format `[{ value, since }]` and unwrapped it via `option.default.at(-1).value`:

```js
if (Array.isArray(option.default)) {
  option.default = option.default.at(-1).value;
}
```

For an `array` option, the `default` is a plain array of primitives, so `["a", "b"].at(-1).value` is `"b".value` === `undefined`. An empty-array default (`default: []`) was even worse — `[].at(-1).value` threw `TypeError: Cannot read properties of undefined (reading 'value')`.

**Fix**

Only unwrap when the value actually is the redundant-default format — a non-empty array whose every entry is a `{ value }` wrapper object. A plain array default (e.g. of an `array` option) is left untouched.

```js
if (
  isNonEmptyArray(option.default) &&
  option.default.every(
    (defaultEntry) =>
      defaultEntry !== null &&
      typeof defaultEntry === "object" &&
      "value" in defaultEntry,
  )
) {
  option.default = option.default.at(-1).value;
}
```

The existing redundant-default format (the core `plugins` option uses `default: [{ value: [] }]`) and `choice` defaults like `[{ value: "a" }, { value: "b" }]` keep working.

**Tests**

Added `tests/unit/normalize-option-settings.js`. Two cases fail without the fix:
- a plain array default of an `array` option (`["a", "b"]`) was resolved to `undefined`;
- an empty-array default (`[]`) threw.

The three preservation cases (redundant-default wrapper, choice wrapper, scalar default) pass with and without the fix.

**Checklist**
- [x] I've added tests
- [x] I've added a changelog entry
