### PR TITLE
Add Deno commands to docs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,7 +11,7 @@ prettier [options] [file/dir/glob ...]
 
 :::note
 
-To run your locally installed version of Prettier, prefix the command with `npx`, `yarn exec`, `pnpm exec`, or `bunx`, i.e. `npx prettier --help`, `yarn exec prettier --help`, `pnpm exec prettier --help`, or `bunx prettier --help`.
+To run your locally installed version of Prettier, prefix the command with `npx`, `yarn exec`, `pnpm exec`, `bunx`, or `deno x`, i.e. `npx prettier --help`, `yarn exec prettier --help`, `pnpm exec prettier --help`, `bunx prettier --help`, or `deno x prettier --help`.
 
 :::
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -37,6 +37,13 @@ bun add --dev --exact prettier@%PRETTIER_VERSION%
 ```
 
 </TabItem>
+<TabItem value="deno">
+
+```bash
+deno install --dev prettier@%PRETTIER_VERSION%
+```
+
+</TabItem>
 </Tabs>
 
 Then, create an empty config file to let editors and other tools know you are using Prettier:

--- a/docs/install.md
+++ b/docs/install.md
@@ -40,7 +40,7 @@ bun add --dev --exact prettier@%PRETTIER_VERSION%
 <TabItem value="deno">
 
 ```bash
-deno install --dev prettier@%PRETTIER_VERSION%
+deno install --dev --save-exact prettier@%PRETTIER_VERSION%
 ```
 
 </TabItem>

--- a/docs/install.md
+++ b/docs/install.md
@@ -152,7 +152,7 @@ deno x prettier . --write
 
 :::info
 
-What is `deno x prettier` doing at the start? It runs the locally installed Prettier. We’ll leave off the `deno x prettier` part for brevity throughout the rest of this file!
+What is `deno x` doing at the start? It runs the locally installed Prettier. We’ll leave off the `deno x` part for brevity throughout the rest of this file!
 
 :::
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -144,6 +144,19 @@ If you forget to install Prettier first, `bunx` will temporarily download the la
 :::
 
 </TabItem>
+<TabItem value="deno">
+
+```bash
+deno x prettier . --write
+```
+
+:::info
+
+What is `deno x prettier` doing at the start? It runs the locally installed Prettier. We’ll leave off the `deno x prettier` part for brevity throughout the rest of this file!
+
+:::
+
+</TabItem>
 </Tabs>
 
 `prettier --write .` is great for formatting everything, but for a big project it might take a little while. You may run `prettier --write app/` to format a certain directory, or `prettier --write app/components/Button.js` to format a certain file. Or use a _glob_ like `prettier --write "app/**/*.test.js"` to format all tests in a directory (see [fast-glob](https://github.com/mrmlnc/fast-glob#pattern-syntax) for supported glob syntax).
@@ -224,6 +237,15 @@ node --eval "fs.writeFileSync('.husky/pre-commit','pnpm exec lint-staged\n')"
 bun add --dev husky lint-staged
 bunx husky init
 bun --eval "fs.writeFileSync('.husky/pre-commit','bunx lint-staged\n')"
+```
+
+</TabItem>
+<TabItem value="deno">
+
+```bash
+deno install --dev husky lint-staged
+deno x husky init
+deno eval "Deno.writeTextFileSync('.husky/pre-commit','deno x lint-staged\n')"
 ```
 
 </TabItem>

--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -65,6 +65,15 @@ bun simple-git-hooks
 ```
 
 </TabItem>
+<TabItem value="deno">
+
+```bash
+deno install --dev simple-git-hooks pretty-quick
+deno eval "Deno.writeTextFileSync('.simple-git-hooks.json',JSON.stringify({'pre-commit':'deno x pretty-quick --staged'},undefined,2)+'\n')"
+deno x simple-git-hooks
+```
+
+</TabItem>
 </Tabs>
 
 Read more at the [pretty-quick](https://github.com/prettier/pretty-quick) repo.
@@ -137,6 +146,15 @@ node --eval "fs.writeFileSync('.husky/pre-commit', 'git-format-staged -f \'prett
 bunx husky init
 bun add --dev git-format-staged
 bun --eval "fs.writeFileSync('.husky/pre-commit', 'git-format-staged -f \'prettier --ignore-unknown --stdin --stdin-filepath \"{}\"\' .\n')"
+```
+
+</TabItem>
+<TabItem value="deno">
+
+```bash
+deno x husky init
+deno install --dev git-format-staged
+deno eval "Deno.writeTextFileSync('.husky/pre-commit', 'git-format-staged -f \'prettier --ignore-unknown --stdin --stdin-filepath \"{}\"\' .\n')"
 ```
 
 </TabItem>

--- a/docs/sharing-configurations.md
+++ b/docs/sharing-configurations.md
@@ -110,6 +110,13 @@ bun add --dev @username/prettier-config
 ```
 
 </TabItem>
+<TabItem value="deno">
+
+```bash
+deno install --dev @username/prettier-config
+```
+
+</TabItem>
 </Tabs>
 
 Then, you can reference it in your `package.json`:


### PR DESCRIPTION
## Description

👋 Bartek from the Deno team here.

The install instructions list npm, Yarn, pnpm, and Bun, but not Deno. Since Deno is a drop-in replacement for npm these days, I'd like to add a Deno line so Deno users have a copy-pasteable command, in parity with the others:

```sh
deno install --dev prettier@%PRETTIER_VERSION%
```

(As of Deno 2.8 there's no `npm:` prefix needed, it's the same command shape as `npm install prettier`.)

Totally fine to close this if you'd rather keep the list short, no hard feelings. Happy to adjust wording, placement, or move it elsewhere.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
