### PR TITLE
fix: incorrect reference link about .wxss extension

### DIFF
--- a/src/language-css/languages.evaluate.js
+++ b/src/language-css/languages.evaluate.js
@@ -8,7 +8,7 @@ const languages = [
     extensions: [
       ...data.extensions,
       // `WeiXin Style Sheets`(Weixin Mini Programs)
-      // https://developers.weixin.qq.com/miniprogram/en/dev/framework/view/wxs/
+      // https://developers.weixin.qq.com/miniprogram/en/dev/framework/view/wxss.html
       ".wxss",
     ],
   })),

--- a/src/language-css/languages.evaluate.js
+++ b/src/language-css/languages.evaluate.js
@@ -7,7 +7,7 @@ const languages = [
     vscodeLanguageIds: ["css"],
     extensions: [
       ...data.extensions,
-      // `WeiXin Style Sheets`(Weixin Mini Programs)
+      // WeiXin Style Sheets (Weixin Mini Programs)
       // https://developers.weixin.qq.com/miniprogram/en/dev/framework/view/wxss.html
       ".wxss",
     ],


### PR DESCRIPTION
<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

When I was reading the source code, I found that the `.wxss` extension was linked to `.wxs`, so I had this PR to correct the problem.

Reference #9081

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.
