### PR TITLE
Fix SCSS inline comment indentation in deeply nested function calls

### DIFF
--- a/src/language-css/print/comma-separated-value-group.js
+++ b/src/language-css/print/comma-separated-value-group.js
@@ -403,7 +403,7 @@ function printCommaSeparatedValueGroup(path, options, print) {
     // Add `hardline` after inline comment (i.e. `// comment\n foo: bar;`)
     if (isInlineValueCommentNode(iNode)) {
       if (parentNode.type === "value-paren_group") {
-        parts.push(dedent(hardline), "");
+        parts.push(hardline, "");
         continue;
       }
       parts.push(hardline, "");
@@ -554,6 +554,13 @@ function printCommaSeparatedValueGroup(path, options, print) {
   // when type is value-comma_group
   // example @import url("verylongurl") projection,tv
   if (insideURLFunctionInImportAtRuleNode(path)) {
+    return group(fill(parts));
+  }
+
+  // When inside a value-paren_group and a comma_group has an inline comment,
+  // the fill normally adds an extra indent level. Remove the indent wrapper
+  // to keep the content at the correct indentation level.
+  if (hasInlineComment && parentNode.type === "value-paren_group") {
     return group(fill(parts));
   }
 

--- a/tests/format/scss/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/scss/comments/__snapshots__/format.test.js.snap
@@ -138,6 +138,8 @@ parsers: ["scss"]
         2,
         // This next pow is really powerful
         someVeryLongFunctionNameForJustAPow(
+          2,
+          someVeryLongFunctionNameForJustAPow(
             2,
             someVeryLongFunctionNameForJustAPow(
               2,
@@ -151,10 +153,7 @@ parsers: ["scss"]
                       2,
                       someVeryLongFunctionNameForJustAPow(
                         2,
-                        someVeryLongFunctionNameForJustAPow(
-                          2,
-                          someVeryLongFunctionNameForJustAPow(2, 2)
-                        )
+                        someVeryLongFunctionNameForJustAPow(2, 2)
                       )
                     )
                   )
@@ -162,6 +161,7 @@ parsers: ["scss"]
               )
             )
           )
+        )
       )
     )
   );
@@ -176,9 +176,9 @@ parsers: ["scss"]
         2,
         // This next pow is really powerful
         pow(
-            2,
-            pow(2, pow(2, pow(2, pow(2, pow(2, pow(2, pow(2, pow(2, 2))))))))
-          )
+          2,
+          pow(2, pow(2, pow(2, pow(2, pow(2, pow(2, pow(2, pow(2, 2))))))))
+        )
       )
     )
   );


### PR DESCRIPTION
## Description

When an inline \//\ comment is the first element of a \alue-comma_group\ inside a \alue-paren_group\, the \dedent(hardline)\ used to cancel the \indent\ wrapper did not affect content after the break. This caused arguments after inline comments in deeply nested SCSS function calls to have excessive indentation.

## Changes

In \src/language-css/print/comma-separated-value-group.js\:

1. **Removed \dedent(hardline)\** in the inline comment handling for \alue-paren_group\ parents — the dedent only affected the line break point, not the content after the break.

2. **Removed the \indent\ wrapper** from the return value when a \alue-comma_group\ inside a \alue-paren_group\ has an inline comment — the extra indent level was cascading into the function call's internal indentation.

## Test Results

- 20/20 SCSS comment tests pass (1 snapshot updated)
- 137/137 SCSS tests pass
- 177/177 CSS tests pass
- 43/43 Less tests pass

Fixes #19427