### PR TITLE
Fix missing parentheses around `TSInstantiationExpression`

### DIFF
--- a/changelog_unreleased/typescript/19442.md
+++ b/changelog_unreleased/typescript/19442.md
@@ -1,0 +1,25 @@
+#### Fix missing parentheses around instantiation expression (#19442 by @fisker)
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+async function* f() {
+  makeRecord = (yield* makeRecordFactory)<ManualValue>;
+  makeRecord = (yield makeRecordFactory)<ManualValue>;
+  makeRecord = (await makeRecordFactory)<ManualValue>;
+}
+
+// Prettier stable
+async function* f() {
+  makeRecord = yield* makeRecordFactory<ManualValue>;
+  makeRecord = yield makeRecordFactory<ManualValue>;
+  makeRecord = await makeRecordFactory<ManualValue>;
+}
+
+// Prettier main
+async function* f() {
+  makeRecord = (yield* makeRecordFactory)<ManualValue>;
+  makeRecord = (yield makeRecordFactory)<ManualValue>;
+  makeRecord = (await makeRecordFactory)<ManualValue>;
+}
+```

--- a/src/language-js/parentheses/parent-needs-parentheses.js
+++ b/src/language-js/parentheses/parent-needs-parentheses.js
@@ -115,6 +115,16 @@ function parentNeedsParentheses(path, options, needsParentheses) {
         return true;
       }
       break;
+
+    case "TSInstantiationExpression":
+      if (
+        key === "expression" &&
+        (node.type === "AwaitExpression" || node.type === "YieldExpression")
+      ) {
+        return true;
+      }
+
+      break;
   }
 }
 

--- a/tests/format/typescript/parentheses/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/parentheses/__snapshots__/format.test.js.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`await.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+async function* f() {
+  makeRecord =
+    (await makeRecordFactory)<ManualValue>
+}
+
+=====================================output=====================================
+async function* f() {
+  makeRecord = await makeRecordFactory<ManualValue>;
+}
+
+================================================================================
+`;
+
+exports[`yield.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+async function* f() {
+  makeRecord =
+    (yield* makeRecordFactory)<ManualValue>
+  makeRecord =
+    (yield makeRecordFactory)<ManualValue>
+}
+
+=====================================output=====================================
+async function* f() {
+  makeRecord = yield* makeRecordFactory<ManualValue>;
+  makeRecord = yield makeRecordFactory<ManualValue>;
+}
+
+================================================================================
+`;

--- a/tests/format/typescript/parentheses/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/parentheses/__snapshots__/format.test.js.snap
@@ -6,8 +6,7 @@ parsers: ["typescript"]
                                                       printWidth: 80 (default) |
 =====================================input======================================
 async function* f() {
-  makeRecord =
-    (await makeRecordFactory)<ManualValue>
+  makeRecord = (   await makeRecordFactory)<ManualValue>
 }
 
 =====================================output=====================================
@@ -24,10 +23,8 @@ parsers: ["typescript"]
                                                       printWidth: 80 (default) |
 =====================================input======================================
 async function* f() {
-  makeRecord =
-    (yield* makeRecordFactory)<ManualValue>
-  makeRecord =
-    (yield makeRecordFactory)<ManualValue>
+  makeRecord = (   yield* makeRecordFactory)<ManualValue>
+  makeRecord = (    yield makeRecordFactory)<ManualValue>
 }
 
 =====================================output=====================================

--- a/tests/format/typescript/parentheses/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/parentheses/__snapshots__/format.test.js.snap
@@ -12,7 +12,7 @@ async function* f() {
 
 =====================================output=====================================
 async function* f() {
-  makeRecord = await makeRecordFactory<ManualValue>;
+  makeRecord = (await makeRecordFactory)<ManualValue>;
 }
 
 ================================================================================
@@ -32,8 +32,8 @@ async function* f() {
 
 =====================================output=====================================
 async function* f() {
-  makeRecord = yield* makeRecordFactory<ManualValue>;
-  makeRecord = yield makeRecordFactory<ManualValue>;
+  makeRecord = (yield* makeRecordFactory)<ManualValue>;
+  makeRecord = (yield makeRecordFactory)<ManualValue>;
 }
 
 ================================================================================

--- a/tests/format/typescript/parentheses/await.ts
+++ b/tests/format/typescript/parentheses/await.ts
@@ -1,0 +1,4 @@
+async function* f() {
+  makeRecord =
+    (await makeRecordFactory)<ManualValue>
+}

--- a/tests/format/typescript/parentheses/await.ts
+++ b/tests/format/typescript/parentheses/await.ts
@@ -1,4 +1,3 @@
 async function* f() {
-  makeRecord =
-    (await makeRecordFactory)<ManualValue>
+  makeRecord = (   await makeRecordFactory)<ManualValue>
 }

--- a/tests/format/typescript/parentheses/format.test.js
+++ b/tests/format/typescript/parentheses/format.test.js
@@ -1,0 +1,1 @@
+runFormatTest(import.meta, ["typescript"]);

--- a/tests/format/typescript/parentheses/yield.ts
+++ b/tests/format/typescript/parentheses/yield.ts
@@ -1,0 +1,6 @@
+async function* f() {
+  makeRecord =
+    (yield* makeRecordFactory)<ManualValue>
+  makeRecord =
+    (yield makeRecordFactory)<ManualValue>
+}

--- a/tests/format/typescript/parentheses/yield.ts
+++ b/tests/format/typescript/parentheses/yield.ts
@@ -1,6 +1,4 @@
 async function* f() {
-  makeRecord =
-    (yield* makeRecordFactory)<ManualValue>
-  makeRecord =
-    (yield makeRecordFactory)<ManualValue>
+  makeRecord = (   yield* makeRecordFactory)<ManualValue>
+  makeRecord = (    yield makeRecordFactory)<ManualValue>
 }


### PR DESCRIPTION
<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

<!-- Please provide a brief summary of your changes -->

This bug was found in Biome https://github.com/biomejs/biome/issues/10697

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.
