### PR TITLE
Fix extra indentation for value after inline comment in SCSS parenthesized group

### DIFF
--- a/changelog_unreleased/scss/19446.md
+++ b/changelog_unreleased/scss/19446.md
@@ -1,0 +1,55 @@
+#### Fix extra indentation for a value after an inline comment in a parenthesized group (#19446 by @Hossam-Ismail)
+
+A value placed after an inline (`//`) comment inside a parenthesized value group was printed one indentation level too deep, and the extra level cascaded to everything nested inside it.
+
+<!-- prettier-ignore -->
+```scss
+/* Input */
+.foo {
+  width: someVeryLongFunctionNameForJustAPow(2, someVeryLongFunctionNameForJustAPow(2, someVeryLongFunctionNameForJustAPow(2,
+  // THIS
+  someVeryLongFunctionNameForJustAPow(2, someVeryLongFunctionNameForJustAPow(2, someVeryLongFunctionNameForJustAPow(2, 2))))));
+}
+
+/* Prettier stable */
+.foo {
+  width: someVeryLongFunctionNameForJustAPow(
+    2,
+    someVeryLongFunctionNameForJustAPow(
+      2,
+      someVeryLongFunctionNameForJustAPow(
+        2,
+        // THIS
+        someVeryLongFunctionNameForJustAPow(
+            2,
+            someVeryLongFunctionNameForJustAPow(
+              2,
+              someVeryLongFunctionNameForJustAPow(2, 2)
+            )
+          )
+      )
+    )
+  );
+}
+
+/* Prettier main */
+.foo {
+  width: someVeryLongFunctionNameForJustAPow(
+    2,
+    someVeryLongFunctionNameForJustAPow(
+      2,
+      someVeryLongFunctionNameForJustAPow(
+        2,
+        // THIS
+        someVeryLongFunctionNameForJustAPow(
+          2,
+          someVeryLongFunctionNameForJustAPow(
+            2,
+            someVeryLongFunctionNameForJustAPow(2, 2)
+          )
+        )
+      )
+    )
+  );
+}
+```

--- a/src/language-css/print/comma-separated-value-group.js
+++ b/src/language-css/print/comma-separated-value-group.js
@@ -71,6 +71,21 @@ function printCommaSeparatedValueGroup(path, options, print) {
   );
 
   const printed = path.map(print, "groups");
+
+  // A value following an inline comment inside a parenthesized group is wrapped
+  // in an extra `indent(...)` at the end of this function (because the comment
+  // forces it into a `value-comma_group`). Dedent it so it lines up with the
+  // comment instead of being over-indented by one level (#19427).
+  if (parentNode.type === "value-paren_group") {
+    for (let i = 1; i < node.groups.length; i++) {
+      if (
+        isInlineValueCommentNode(node.groups[i - 1]) &&
+        !isInlineValueCommentNode(node.groups[i])
+      ) {
+        printed[i] = dedent(printed[i]);
+      }
+    }
+  }
   /*
    * We assume parts always meet following conditions:
    * - parts.length is odd

--- a/tests/format/scss/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/scss/comments/__snapshots__/format.test.js.snap
@@ -138,6 +138,8 @@ parsers: ["scss"]
         2,
         // This next pow is really powerful
         someVeryLongFunctionNameForJustAPow(
+          2,
+          someVeryLongFunctionNameForJustAPow(
             2,
             someVeryLongFunctionNameForJustAPow(
               2,
@@ -151,10 +153,7 @@ parsers: ["scss"]
                       2,
                       someVeryLongFunctionNameForJustAPow(
                         2,
-                        someVeryLongFunctionNameForJustAPow(
-                          2,
-                          someVeryLongFunctionNameForJustAPow(2, 2)
-                        )
+                        someVeryLongFunctionNameForJustAPow(2, 2)
                       )
                     )
                   )
@@ -162,6 +161,7 @@ parsers: ["scss"]
               )
             )
           )
+        )
       )
     )
   );
@@ -176,9 +176,9 @@ parsers: ["scss"]
         2,
         // This next pow is really powerful
         pow(
-            2,
-            pow(2, pow(2, pow(2, pow(2, pow(2, pow(2, pow(2, pow(2, 2))))))))
-          )
+          2,
+          pow(2, pow(2, pow(2, pow(2, pow(2, pow(2, pow(2, pow(2, 2))))))))
+        )
       )
     )
   );


### PR DESCRIPTION
<!-- Please make sure the PR title and the description are clear. -->

**Description**

Fixes #19427.

When an inline (`//`) comment precedes a value inside a parenthesized value group (e.g. a nested SCSS function call argument), the value was printed one indentation level too deep, and that extra level cascaded to everything nested inside it (including the trailing `)`s).

Root cause: a value that follows an inline comment is forced into a `value-comma_group`, which `printCommaSeparatedValueGroup` wraps in an extra `indent(...)`. A bare argument is not wrapped that way, so only the post-comment value was over-indented. The fix dedents the value that follows an inline comment inside a parenthesized group to cancel that wrapping indent — mirroring the existing key/value-pair dedent compensation already in `parenthesized-value-group.js`.

**Before**

```scss
.foo {
  width: someVeryLongFunctionNameForJustAPow(
    2,
    someVeryLongFunctionNameForJustAPow(
      2,
      someVeryLongFunctionNameForJustAPow(
        2,
        // THIS
        someVeryLongFunctionNameForJustAPow(
            2,
            someVeryLongFunctionNameForJustAPow(
              2,
              someVeryLongFunctionNameForJustAPow(2, 2)
            )
          )
      )
    )
  );
}
```

**After**

```scss
.foo {
  width: someVeryLongFunctionNameForJustAPow(
    2,
    someVeryLongFunctionNameForJustAPow(
      2,
      someVeryLongFunctionNameForJustAPow(
        2,
        // THIS
        someVeryLongFunctionNameForJustAPow(
          2,
          someVeryLongFunctionNameForJustAPow(
            2,
            someVeryLongFunctionNameForJustAPow(2, 2)
          )
        )
      )
    )
  );
}
```

The existing `tests/format/scss/comments/4878.scss` fixture already exercises this exact case; its snapshot is updated to the corrected output, so it serves as the regression test. Output is idempotent and the full `tests/format` suite passes (29281 tests).

**Checklist**

- [x] I've added tests (existing `4878.scss` fixture snapshot updated to reflect the fix).
- [x] I've read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] (Changelog entry added in a follow-up commit using this PR number.)