### PR TITLE
Fix !default/!global inside strings being treated as SCSS declaration flags

### DIFF
--- a/changelog_unreleased/scss/19448.md
+++ b/changelog_unreleased/scss/19448.md
@@ -1,0 +1,21 @@
+#### Don't treat `!default` / `!global` inside strings as SCSS declaration flags (#19448 by @Hossam-Ismail)
+
+`!default` and `!global` were detected anywhere in a declaration value, so values that merely contained the text (inside a string, `url()`, or a function argument) were split as if they had a trailing Sass flag, inserting a spurious space. They are now only recognized as flags when they appear at the top level.
+
+<!-- prettier-ignore -->
+```scss
+/* Input */
+$a: "!default";
+$b: unquote("!default");
+$c: url("x!global");
+
+/* Prettier stable */
+$a: " !default";
+$b: unquote(" !default");
+$c: url("x !global");
+
+/* Prettier main */
+$a: "!default";
+$b: unquote("!default");
+$c: url("x!global");
+```

--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -19,8 +19,55 @@ import { hasIgnorePragma, hasPragma } from "./pragma.js";
 import isModuleRuleName from "./utilities/is-module-rule-name.js";
 import isSCSSNestedPropertyNode from "./utilities/is-scss-nested-property-node.js";
 
-const DEFAULT_SCSS_DIRECTIVE = /(\s*)(!default).*$/;
-const GLOBAL_SCSS_DIRECTIVE = /(\s*)(!global).*$/;
+// Returns `true` when `value[index]` is not inside a string or parentheses,
+// i.e. a position where a trailing SCSS flag like `!default` may legitimately
+// appear (rather than inside a quoted value such as `"!default"`).
+function isTopLevelIndex(value, index) {
+  let stringChar = "";
+  let parenDepth = 0;
+  for (let i = 0; i < index; i++) {
+    const character = value[i];
+    if (stringChar) {
+      if (character === "\\") {
+        i++;
+      } else if (character === stringChar) {
+        stringChar = "";
+      }
+    } else if (character === '"' || character === "'") {
+      stringChar = character;
+    } else if (character === "(") {
+      parenDepth++;
+    } else if (character === ")" && parenDepth > 0) {
+      parenDepth--;
+    }
+  }
+  return !stringChar && parenDepth === 0;
+}
+
+// Finds a trailing SCSS flag (`!default` / `!global`) that is a real
+// declaration flag — i.e. appears at the top level — and returns the matched
+// text (including the leading whitespace) and its start index. A flag that
+// only occurs inside a string or parentheses (e.g. `$x: "!default"`) is
+// ignored. (#19203)
+function matchTrailingSCSSDirective(value, directive) {
+  let searchFrom = 0;
+  while (true) {
+    const directiveIndex = value.indexOf(directive, searchFrom);
+    if (directiveIndex === -1) {
+      return null;
+    }
+
+    if (isTopLevelIndex(value, directiveIndex)) {
+      let start = directiveIndex;
+      while (start > 0 && /\s/u.test(value[start - 1])) {
+        start--;
+      }
+      return { index: start, matched: value.slice(start) };
+    }
+
+    searchFrom = directiveIndex + directive.length;
+  }
+}
 
 function parseNestedCSS(node, options) {
   if (isObject(node)) {
@@ -163,25 +210,28 @@ function parseNestedCSS(node, options) {
     }
 
     if (value.trim().length > 0) {
-      const defaultSCSSDirectiveIndex = value.match(DEFAULT_SCSS_DIRECTIVE);
+      const defaultSCSSDirective = matchTrailingSCSSDirective(
+        value,
+        "!default",
+      );
 
-      if (defaultSCSSDirectiveIndex) {
-        value = value.slice(0, defaultSCSSDirectiveIndex.index);
+      if (defaultSCSSDirective) {
+        value = value.slice(0, defaultSCSSDirective.index);
         node.scssDefault = true;
 
-        if (defaultSCSSDirectiveIndex[0].trim() !== "!default") {
-          node.raws.scssDefault = defaultSCSSDirectiveIndex[0];
+        if (defaultSCSSDirective.matched.trim() !== "!default") {
+          node.raws.scssDefault = defaultSCSSDirective.matched;
         }
       }
 
-      const globalSCSSDirectiveIndex = value.match(GLOBAL_SCSS_DIRECTIVE);
+      const globalSCSSDirective = matchTrailingSCSSDirective(value, "!global");
 
-      if (globalSCSSDirectiveIndex) {
-        value = value.slice(0, globalSCSSDirectiveIndex.index);
+      if (globalSCSSDirective) {
+        value = value.slice(0, globalSCSSDirective.index);
         node.scssGlobal = true;
 
-        if (globalSCSSDirectiveIndex[0].trim() !== "!global") {
-          node.raws.scssGlobal = globalSCSSDirectiveIndex[0];
+        if (globalSCSSDirective.matched.trim() !== "!global") {
+          node.raws.scssGlobal = globalSCSSDirective.matched;
         }
       }
 

--- a/tests/format/scss/flag/19203.scss
+++ b/tests/format/scss/flag/19203.scss
@@ -1,0 +1,13 @@
+// `!default` / `!global` inside strings, urls and function arguments must not
+// be treated as Sass declaration flags. (#19203)
+$a: "!default";
+$b: unquote("!default");
+$c: url("x!global");
+$d: "foo !default bar";
+$e: "a" + "!global";
+
+// Real trailing flags still apply, even alongside a string containing the flag.
+$f: "!default" !default;
+$g: "!global" !global;
+$h: 1px !default;
+$i: map(a: 1, b: 2) !default;

--- a/tests/format/scss/flag/__snapshots__/format.test.js.snap
+++ b/tests/format/scss/flag/__snapshots__/format.test.js.snap
@@ -83,3 +83,85 @@ $global: "very-long-long-long-long-long-long-long-long-long-long-long-value" !gl
 
 ================================================================================
 `;
+
+exports[`19203.scss - {"trailingComma":"es5"} format 1`] = `
+====================================options=====================================
+parsers: ["scss"]
+trailingComma: "es5"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// \`!default\` / \`!global\` inside strings, urls and function arguments must not
+// be treated as Sass declaration flags. (#19203)
+$a: "!default";
+$b: unquote("!default");
+$c: url("x!global");
+$d: "foo !default bar";
+$e: "a" + "!global";
+
+// Real trailing flags still apply, even alongside a string containing the flag.
+$f: "!default" !default;
+$g: "!global" !global;
+$h: 1px !default;
+$i: map(a: 1, b: 2) !default;
+
+=====================================output=====================================
+// \`!default\` / \`!global\` inside strings, urls and function arguments must not
+// be treated as Sass declaration flags. (#19203)
+$a: "!default";
+$b: unquote("!default");
+$c: url("x!global");
+$d: "foo !default bar";
+$e: "a" + "!global";
+
+// Real trailing flags still apply, even alongside a string containing the flag.
+$f: "!default" !default;
+$g: "!global" !global;
+$h: 1px !default;
+$i: map(
+  a: 1,
+  b: 2,
+) !default;
+
+================================================================================
+`;
+
+exports[`19203.scss - {"trailingComma":"none"} format 1`] = `
+====================================options=====================================
+parsers: ["scss"]
+trailingComma: "none"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// \`!default\` / \`!global\` inside strings, urls and function arguments must not
+// be treated as Sass declaration flags. (#19203)
+$a: "!default";
+$b: unquote("!default");
+$c: url("x!global");
+$d: "foo !default bar";
+$e: "a" + "!global";
+
+// Real trailing flags still apply, even alongside a string containing the flag.
+$f: "!default" !default;
+$g: "!global" !global;
+$h: 1px !default;
+$i: map(a: 1, b: 2) !default;
+
+=====================================output=====================================
+// \`!default\` / \`!global\` inside strings, urls and function arguments must not
+// be treated as Sass declaration flags. (#19203)
+$a: "!default";
+$b: unquote("!default");
+$c: url("x!global");
+$d: "foo !default bar";
+$e: "a" + "!global";
+
+// Real trailing flags still apply, even alongside a string containing the flag.
+$f: "!default" !default;
+$g: "!global" !global;
+$h: 1px !default;
+$i: map(
+  a: 1,
+  b: 2
+) !default;
+
+================================================================================
+`;


### PR DESCRIPTION
**Description**

Fixes #19203.

SCSS `!default` / `!global` flag detection in `parser-postcss.js` matched the directive **anywhere** in a declaration value using `/(\s*)(!default).*$/`. As a result, values that merely *contained* the text — inside a string, `url()`, or function argument — were split as if they had a trailing Sass flag, inserting a spurious space.

```scss
/* Input */
$a: "!default";
$b: unquote("!default");
$c: url("x!global");

/* Prettier stable */
$a: " !default";
$b: unquote(" !default");
$c: url("x !global");

/* Prettier main (this PR) */
$a: "!default";
$b: unquote("!default");
$c: url("x!global");
```

**Fix**

A real `!default` / `!global` flag is only ever a *top-level trailing* token. The directive is now detected only when it appears outside of any string or parentheses (`matchTrailingSCSSDirective` + `isTopLevelIndex`). Genuine trailing flags are unchanged, including the edge case where a string contains the flag text and a real flag follows:

```scss
$f: "!default" !default; // string preserved, flag still applied
$h: 1px !default;
$i: map(a: 1, b: 2) !default;
```

**Tests**

- Added `tests/format/scss/flag/19203.scss` covering flags inside strings/`url()`/functions plus genuine trailing flags.
- Full `tests/format` suite passes (29283 tests). No existing snapshots changed.

**Checklist**

- [x] I've added tests.
- [x] I've read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] Changelog entry added in a follow-up commit using this PR number.