### PR TITLE
Fix overrun when a block comment precedes a value in a comma-separated list

### DIFF
--- a/changelog_unreleased/css/19449.md
+++ b/changelog_unreleased/css/19449.md
@@ -1,0 +1,29 @@
+#### Keep a value on its own line after an own-line block comment (#19449 by @Hossam-Ismail)
+
+A block comment that sits on its own line between comma-separated values was glued to the following value, which could overrun `printWidth` — especially when the value started with a unary minus such as `-1px`. The value now stays on its own line, matching the source. Inline block comments are unaffected.
+
+<!-- prettier-ignore -->
+```css
+/* Input */
+.foo {
+  box-shadow: 2px 2px 4px gray,
+    /* long long long long long long long long long long long long comment */
+    -1px -1px 2px lightgray;
+}
+
+/* Prettier stable */
+.foo {
+  box-shadow:
+    2px 2px 4px gray,
+    /* long long long long long long long long long long long long comment */ -1px -1px
+      2px lightgray;
+}
+
+/* Prettier main */
+.foo {
+  box-shadow:
+    2px 2px 4px gray,
+    /* long long long long long long long long long long long long comment */
+    -1px -1px 2px lightgray;
+}
+```

--- a/src/language-css/print/comma-separated-value-group.js
+++ b/src/language-css/print/comma-separated-value-group.js
@@ -140,6 +140,22 @@ function printCommaSeparatedValueGroup(path, options, print) {
       continue;
     }
 
+    // A block comment that sits on its own line in the source keeps the
+    // following value on its own line too, instead of gluing a short value to a
+    // long comment (which overruns `printWidth`). Without this, a unary minus
+    // (e.g. `-1px`) would be glued to the comment by the math-operator handling
+    // below. (#18311)
+    if (
+      !atRuleAncestorNode &&
+      iNode.type === "value-comment" &&
+      !iNode.inline &&
+      iNextNode.type !== "value-comment" &&
+      iNextNode.raws?.before?.includes("\n")
+    ) {
+      parts.push(dedent(hardline), "");
+      continue;
+    }
+
     // Don't print a space before the `;` branch delimiter in the SCSS `if()`
     // function (i.e. `if(condition: value; else: value)`)
     if (

--- a/tests/format/css/comments/18311.css
+++ b/tests/format/css/comments/18311.css
@@ -1,0 +1,13 @@
+/* A block comment on its own line between comma-separated values should keep
+   the following value on its own line instead of gluing it (which overruns
+   printWidth). (#18311) */
+.foo {
+  box-shadow: 2px 2px 4px gray,
+    /* long long long long long long long long long long long long comment */
+    -1px -1px 2px lightgray;
+}
+
+/* An inline block comment stays inline. */
+.bar {
+  box-shadow: 2px 2px 4px gray, /* inline */ -1px -1px 2px lightgray;
+}

--- a/tests/format/css/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/css/comments/__snapshots__/format.test.js.snap
@@ -76,6 +76,46 @@ parsers: ["css"]
 ================================================================================
 `;
 
+exports[`18311.css format 1`] = `
+====================================options=====================================
+parsers: ["css"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+/* A block comment on its own line between comma-separated values should keep
+   the following value on its own line instead of gluing it (which overruns
+   printWidth). (#18311) */
+.foo {
+  box-shadow: 2px 2px 4px gray,
+    /* long long long long long long long long long long long long comment */
+    -1px -1px 2px lightgray;
+}
+
+/* An inline block comment stays inline. */
+.bar {
+  box-shadow: 2px 2px 4px gray, /* inline */ -1px -1px 2px lightgray;
+}
+
+=====================================output=====================================
+/* A block comment on its own line between comma-separated values should keep
+   the following value on its own line instead of gluing it (which overruns
+   printWidth). (#18311) */
+.foo {
+  box-shadow:
+    2px 2px 4px gray,
+    /* long long long long long long long long long long long long comment */
+    -1px -1px 2px lightgray;
+}
+
+/* An inline block comment stays inline. */
+.bar {
+  box-shadow:
+    2px 2px 4px gray,
+    /* inline */ -1px -1px 2px lightgray;
+}
+
+================================================================================
+`;
+
 exports[`CRLF.css format 1`] = `
 ====================================options=====================================
 parsers: ["css"]

--- a/tests/format/less/parens/__snapshots__/format.test.js.snap
+++ b/tests/format/less/parens/__snapshots__/format.test.js.snap
@@ -23,7 +23,8 @@ parsers: ["less"]
   background: linear-gradient(
     to right,
 
-    /* Should preserve empty lines */ @white 0%,
+    /* Should preserve empty lines */
+    @white 0%,
     @white (@cut - 0.01%),
     @portal-background @cut,
     @portal-background 100%

--- a/tests/format/scss/map/__snapshots__/format.test.js.snap
+++ b/tests/format/scss/map/__snapshots__/format.test.js.snap
@@ -1026,12 +1026,14 @@ $map: (
 
 =====================================output=====================================
 $map: (
-  /* comment */ key1: value,
+  /* comment */
+  key1: value,
 
   // comment
   key2: value,
 
-  /* comment */ /* comment */ key3: value,
+  /* comment */ /* comment */
+  key3: value,
 
   /* comment */
   key4: (
@@ -1088,12 +1090,14 @@ $map: (
 
 =====================================output=====================================
 $map: (
-  /* comment */ key1: value,
+  /* comment */
+  key1: value,
 
   // comment
   key2: value,
 
-  /* comment */ /* comment */ key3: value,
+  /* comment */ /* comment */
+  key3: value,
 
   /* comment */
   key4: (


### PR DESCRIPTION
**Description**

Fixes #18311.

A block comment that sits on its own line between comma-separated values (e.g. in a `box-shadow`) was glued onto the following value. When the value begins with a unary minus (`-1px`), the math-operator handling inserts a space right after the comment, so the value never broke onto its own line — overrunning `printWidth` and producing an ugly mid-value break.

```css
/* Input */
.foo {
  box-shadow: 2px 2px 4px gray,
    /* long long long long long long long long long long long long comment */
    -1px -1px 2px lightgray;
}

/* Prettier stable */
.foo {
  box-shadow:
    2px 2px 4px gray,
    /* long long long long long long long long long long long long comment */ -1px -1px
      2px lightgray;
}

/* Prettier main (this PR) */
.foo {
  box-shadow:
    2px 2px 4px gray,
    /* long long long long long long long long long long long long comment */
    -1px -1px 2px lightgray;
}
```

**Fix**

When a non-inline (block) comment is followed by a value and the source had a newline between them (`iNextNode.raws.before` contains `\n`), break after the comment so the value keeps its own line. This is checked before the math-operator handling that was gluing the space. Inline block comments (`/* c */ value` on one line) are unaffected.

**Side effect (improvement)**

This also makes a few existing SCSS map / LESS snapshots more faithful to the source: an own-line block comment no longer pulls the following key/value up onto the comment's line. For example `tests/format/scss/map/comment.scss`:

```scss
/* before */ key1: value,   // was glued
/* after */
key1: value,                // now preserved as written
```

**Tests**

- Added `tests/format/css/comments/18311.css` (own-line vs inline block comment).
- Updated 3 existing snapshots (scss/map, less/parens) to the more faithful output.
- Full `tests/format` suite passes (29284 tests); output is idempotent.

**Checklist**

- [x] I've added tests.
- [x] I've read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] Changelog entry added in a follow-up commit using this PR number.