### PR TITLE
ci: report bundle size changes for PRs from forks

### DIFF
--- a/.github/workflows/check-sizes-comment.yml
+++ b/.github/workflows/check-sizes-comment.yml
@@ -1,0 +1,46 @@
+name: Check Sizes Comment
+
+on:
+  workflow_run:
+    workflows: ["Check Sizes"]
+    types: [completed]
+
+jobs:
+  comment:
+    name: Comment
+    # Only handle successful PR runs from forks.
+    # Same-repository PRs can be commented on by the original pull_request workflow if it has permission.
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name != github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      pull-requests: write
+
+    steps:
+      - name: Download comment body
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          name: check-sizes-comment
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: /tmp
+
+      - name: Download PR number
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          name: check-sizes-pr-number
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: /tmp
+
+      - name: Get PR number
+        id: pr
+        run: echo "pr=$(</tmp/check-sizes-pr-number)" >> "$GITHUB_OUTPUT"
+
+      - uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          path: /tmp/check-sizes-comment.md
+          number_force: ${{ steps.pr.outputs.pr }}

--- a/.github/workflows/check-sizes.yml
+++ b/.github/workflows/check-sizes.yml
@@ -25,9 +25,36 @@ jobs:
           cache: "yarn"
 
       - name: Check Sizes
+        id: compressed-size
         uses: preactjs/compressed-size-action@f322c295dde06a1cb7ccaef105732dd8a726d1d9 # 2.10.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           pattern: "./dist/**/*"
           compression: none
           build-script: "build --clean"
+
+      - name: Save comment body
+        env:
+          COMMENT_BODY: ${{ steps.compressed-size.outputs.comment-body }}
+        run: |
+          printf '%s\n' "$COMMENT_BODY" > /tmp/check-sizes-comment.md
+
+      - name: Save PR number
+        env:
+          PULL_REQUEST_NUMBER: ${{ github.event.number }}
+        run: |
+          echo "$PULL_REQUEST_NUMBER" > /tmp/check-sizes-pr-number
+
+      - name: Upload comment body
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: check-sizes-comment
+          path: /tmp/check-sizes-comment.md
+          retention-days: 1
+
+      - name: Upload PR number
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: check-sizes-pr-number
+          path: /tmp/check-sizes-pr-number
+          retention-days: 1


### PR DESCRIPTION
<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

<!-- Please provide a brief summary of your changes -->

Previously, `compressed-size-action` could not add comments to PRs opened from forks, so we had to check the results from the workflow logs, which was inconvenient.

Starting from 2.10.0, it exposes the full `comment-body`, so we can now publish comments for PRs from forks. I hope this helps with project maintenance.

https://github.com/preactjs/compressed-size-action#:~:text=The%20markdown%20comment%20that%20compressed%2Dsize%2Daction%20posts%20to%20pull%20requests%20is%20also%20exposed%20as%20the%20comment%2Dbody%20output.%20This%20can%20be%20used%20by%20later%20workflow%20steps%20to%20archive%20the%20report%2C%20pass%20it%20to%20another%20job%2C%20or%20post%20the%20comment%20from%20a%20separate%20workflow%20with%20the%20permissions%20you%20need%3A

See my test here https://github.com/rzzf/prettier/pull/1#issuecomment-4806179562

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.


