### PR TITLE
Avoid corrupting Markdown URL with `<`, `(`, `\` (v2)

### DIFF
--- a/changelog_unreleased/markdown/19482.md
+++ b/changelog_unreleased/markdown/19482.md
@@ -1,0 +1,15 @@
+#### Avoid corrupting URL with `<`, `(`, `\` (#19482 by @andersk)
+
+Avoid corrupting a link, image, or link reference definition with with certain characters like `<`, `(`, `\`, by using `<...>` wrapping and `\` escaping as appropriate.
+
+<!-- prettier-ignore -->
+```md
+<!-- Input -->
+[link](<\<(\\>)
+
+<!-- Prettier stable -->
+[link](<(\)
+
+<!-- Prettier main -->
+[link](<\<(\\>)
+```

--- a/src/language-markdown/print/mdast.js
+++ b/src/language-markdown/print/mdast.js
@@ -519,18 +519,23 @@ function printUrl(url, unwrapBalancedParens) {
   // Backslash followed by ASCII punctuation would be misinterpreted as an
   // escape sequence, so must itself be escaped.
   url = url.replaceAll(/\\(?![^!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/g, "\\\\");
+
   // CommonMark forbids ASCII controls, space, unbalanced parentheses, and
   // initial <, unless wrapped in <> with any inner < or > escaped. CommonMark
   // only suggests implementations "should" support at least three levels of
   // parenthesis nesting, so it's unclear whether we can safely rely on three
   // levels as we do here, but we certainly can't expect more.
-  // eslint-disable-next-line no-control-regex
-  return /[\x00-\x1f\x7f ]|^</.test(url) ||
+  if (
+    // eslint-disable-next-line no-control-regex
+    /[\x00-\x1f\x7f ]|^</.test(url) ||
     (unwrapBalancedParens
       ? !/^(?:[^()]|\((?:[^()]|\((?:[^()]|\([^()]*\))*\))*\))*$/.test(url)
       : /[()]/.test(url))
-    ? `<${url.replaceAll(/([<>])/g, String.raw`\$1`)}>`
-    : url;
+  ) {
+    url = `<${url.replaceAll(/([<>])/g, String.raw`\$1`)}>`;
+  }
+
+  return url;
 }
 
 function printTitle(title, options, printSpace = true) {

--- a/src/language-markdown/print/mdast.js
+++ b/src/language-markdown/print/mdast.js
@@ -1,5 +1,4 @@
 import collapseWhiteSpace from "collapse-white-space";
-import escapeStringRegexp from "escape-string-regexp";
 import {
   align,
   DOC_TYPE_STRING,
@@ -226,7 +225,7 @@ function printMdast(path, options, print) {
             "](",
             options.parser !== "mdx" && node.url === ""
               ? "<>"
-              : printUrl(node.url, ")"),
+              : printUrl(node.url, false),
             printTitle(node.title, options),
             ")",
           ];
@@ -243,7 +242,7 @@ function printMdast(path, options, print) {
         "](",
         options.parser !== "mdx" && node.url === ""
           ? "<>"
-          : printUrl(node.url, ")"),
+          : printUrl(node.url, false),
         printTitle(node.title, options),
         ")",
       ];
@@ -344,7 +343,7 @@ function printMdast(path, options, print) {
           lineOrSpace,
           options.parser !== "mdx" && node.url === ""
             ? "<>"
-            : printUrl(node.url),
+            : printUrl(node.url, true),
           node.title === null
             ? ""
             : [lineOrSpace, printTitle(node.title, options, false)],
@@ -511,30 +510,26 @@ function shouldRemainTheSameContent(path) {
   );
 }
 
-const encodeUrl = (url, characters) => {
-  for (const character of characters) {
-    url = url.replaceAll(character, encodeURIComponent(character));
-  }
-  return url;
-};
-
 /**
  * @param {string} url
- * @param {string[] | string} [dangerousCharOrChars]
+ * @param {boolean} unwrapBalancedParens
  * @returns {string}
  */
-function printUrl(url, dangerousCharOrChars = []) {
-  const dangerousChars = [
-    " ",
-    ...(Array.isArray(dangerousCharOrChars)
-      ? dangerousCharOrChars
-      : [dangerousCharOrChars]),
-  ];
-
-  return new RegExp(
-    dangerousChars.map((x) => escapeStringRegexp(x)).join("|"),
-  ).test(url)
-    ? `<${encodeUrl(url, "<>")}>`
+function printUrl(url, unwrapBalancedParens) {
+  // Backslash followed by ASCII punctuation would be misinterpreted as an
+  // escape sequence, so must itself be escaped.
+  url = url.replaceAll(/\\(?![^!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/g, "\\\\");
+  // CommonMark forbids ASCII controls, space, unbalanced parentheses, and
+  // initial <, unless wrapped in <> with any inner < or > escaped. CommonMark
+  // only suggests implementations "should" support at least three levels of
+  // parenthesis nesting, so it's unclear whether we can safely rely on three
+  // levels as we do here, but we certainly can't expect more.
+  // eslint-disable-next-line no-control-regex
+  return /[\x00-\x1f\x7f ]|^</.test(url) ||
+    (unwrapBalancedParens
+      ? !/^(?:[^()]|\((?:[^()]|\((?:[^()]|\([^()]*\))*\))*\))*$/.test(url)
+      : /[()]/.test(url))
+    ? `<${url.replaceAll(/([<>])/g, String.raw`\$1`)}>`
     : url;
 }
 
@@ -551,7 +546,13 @@ function printTitle(title, options, printSpace = true) {
     title = title.replaceAll(/\\(?=["')])/g, "");
   }
 
-  if (title.includes('"') && title.includes("'") && !title.includes(")")) {
+  if (
+    title.includes('"') &&
+    title.includes("'") &&
+    !title.includes("(") &&
+    !title.includes(")")
+  ) {
+    title = title.replaceAll("\\", "\\\\");
     return `(${title})`; // avoid escaped quotes
   }
   const quote = getPreferredQuote(title, options.singleQuote);

--- a/tests/format/markdown/link/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/link/__snapshots__/format.test.js.snap
@@ -82,35 +82,53 @@ proseWrap: "always"
 [link](https://www.google.fr/foo-%3Ebar)
 [link](https://www.google.fr/foo-<bar)
 [link](https://www.google.fr/foo-%3Cbar)
+[link](\\<)
+[link](\\()
+[link](\\\\)
+[link](<	>)
 
 ![link](https://www.google.fr/()foo->bar)
 ![link](https://www.google.fr/foo->bar)
 ![link](https://www.google.fr/foo-%3Ebar)
 ![link](https://www.google.fr/foo-<bar)
 ![link](https://www.google.fr/foo-%3Cbar)
+![link](\\<)
+![link](\\()
+![link](\\\\)
+![link](<	>)
 
 [link]: https://www.google.fr/()foo->bar
 [link]: https://www.google.fr/foo->bar
 [link]: https://www.google.fr/foo-%3Ebar
 [link]: https://www.google.fr/foo-<bar
 [link]: https://www.google.fr/foo-%3Cbar
+[link]: \\<
+[link]: \\(
+[link]: \\\\
+[link]: <	>
 
 =====================================output=====================================
-[link](<https://www.google.fr/()foo-%3Ebar>)
+[link](<https://www.google.fr/()foo-\\>bar>)
 [link](https://www.google.fr/foo->bar) [link](https://www.google.fr/foo-%3Ebar)
 [link](https://www.google.fr/foo-<bar) [link](https://www.google.fr/foo-%3Cbar)
+[link](<\\<>) [link](<(>) [link](\\\\) [link](<	>)
 
-![link](<https://www.google.fr/()foo-%3Ebar>)
+![link](<https://www.google.fr/()foo-\\>bar>)
 ![link](https://www.google.fr/foo->bar)
 ![link](https://www.google.fr/foo-%3Ebar)
 ![link](https://www.google.fr/foo-<bar)
-![link](https://www.google.fr/foo-%3Cbar)
+![link](https://www.google.fr/foo-%3Cbar) ![link](<\\<>) ![link](<(>) ![link](\\\\)
+![link](<	>)
 
 [link]: https://www.google.fr/()foo->bar
 [link]: https://www.google.fr/foo->bar
 [link]: https://www.google.fr/foo-%3Ebar
 [link]: https://www.google.fr/foo-<bar
 [link]: https://www.google.fr/foo-%3Cbar
+[link]: <\\<>
+[link]: <(>
+[link]: \\\\
+[link]: <	>
 
 ================================================================================
 `;

--- a/tests/format/markdown/link/encodedLink.md
+++ b/tests/format/markdown/link/encodedLink.md
@@ -3,15 +3,27 @@
 [link](https://www.google.fr/foo-%3Ebar)
 [link](https://www.google.fr/foo-<bar)
 [link](https://www.google.fr/foo-%3Cbar)
+[link](\<)
+[link](\()
+[link](\\)
+[link](<	>)
 
 ![link](https://www.google.fr/()foo->bar)
 ![link](https://www.google.fr/foo->bar)
 ![link](https://www.google.fr/foo-%3Ebar)
 ![link](https://www.google.fr/foo-<bar)
 ![link](https://www.google.fr/foo-%3Cbar)
+![link](\<)
+![link](\()
+![link](\\)
+![link](<	>)
 
 [link]: https://www.google.fr/()foo->bar
 [link]: https://www.google.fr/foo->bar
 [link]: https://www.google.fr/foo-%3Ebar
 [link]: https://www.google.fr/foo-<bar
 [link]: https://www.google.fr/foo-%3Cbar
+[link]: \<
+[link]: \(
+[link]: \\
+[link]: <	>


### PR DESCRIPTION
## Description

Avoid corrupting a Markdown link, image, or link reference definition with certain characters like `<`, `(`, `\`, by using `<...>` wrapping and `\` escaping as appropriate.

```md
<!-- Input -->
[link](<\<(\\>)

<!-- Before -->
[link](<(\)

<!-- After -->
[link](<\<(\\>)
```

#19150 was reverted for making too many changes to mdn/content; this modified version makes **no changes** to mdn/content versus 3.9.0.

### CommonMark specification references

> **[2.4 Backslash escapes](https://spec.commonmark.org/0.31.2/#backslash-escapes)**
>
> Any ASCII punctuation character may be backslash-escaped:
>
> ```md
> \!\"\#\$\%\&\'\(\)\*\+\,\-\.\/\:\;\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~
> ```
>
> Backslashes before other characters are treated as literal backslashes:
>
> ```md
> \→\A\a\ \3\φ\«
> ```

> **[6.3 Links](https://spec.commonmark.org/0.31.2/#links)**
> …
> A [link destination](https://spec.commonmark.org/0.31.2/#link-destination) consists of either
> - a sequence of zero or more characters between an opening `<` and a closing `>` that contains no line endings or unescaped `<` or `>` characters, or
> - a nonempty sequence of characters that does not start with `<`, does not include [ASCII control characters](https://spec.commonmark.org/0.31.2/#ascii-control-character) or [space](https://spec.commonmark.org/0.31.2/#space) character, and includes parentheses only if (a) they are backslash-escaped or (b) they are part of a balanced pair of unescaped parentheses. (Implementations may impose limits on parentheses nesting to avoid performance issues, but at least three levels of nesting should be supported.)

## Checklist

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.
