### PR TITLE
Preserve YAML block scalar values during AST massage

### DIFF
--- a/src/language-yaml/massage-ast/index.js
+++ b/src/language-yaml/massage-ast/index.js
@@ -32,11 +32,6 @@ function massageAstNode(original, cloned /* , parent */) {
           .map((line) => line.replace(/[ \t]+$/, ""))
           .join("\n");
       }
-
-      // TODO: Fix this
-      else if (original.chomping === "clip" || original.chomping === "strip") {
-        cloned.value = original.value.trimEnd();
-      }
       break;
   }
 }

--- a/tests/config/format-test/failed-format-tests.js
+++ b/tests/config/format-test/failed-format-tests.js
@@ -44,7 +44,13 @@ const unstableTests = new Map(
   }),
 );
 
-const unstableAstTests = new Map();
+const unstableAstTests = new Map(
+  [
+    // The YAML printer currently drops trailing whitespace from this folded
+    // scalar, so the reparsed AST has a different value.
+    "yaml/block-folded/block-folded-strip.yml",
+  ].map((fixture) => [path.join(FORMAT_TEST_DIRECTORY, fixture), () => true]),
+);
 
 // These tests works on `babel`, `acorn`, `espree`, `oxc`, and `meriyah`
 const commentClosureTypecaseTests = [

--- a/tests/unit/massage-ast.js
+++ b/tests/unit/massage-ast.js
@@ -1,5 +1,6 @@
 import massageAst from "../../src/main/massage-ast.js";
 import { normalizePrinter } from "../../src/main/parser-and-printer.js";
+import { massageAstNode as massageYamlAstNode } from "../../src/language-yaml/massage-ast/index.js";
 
 test("massageAst", () => {
   const nonNodeObject = { foo: "foo" };
@@ -26,4 +27,30 @@ test("massageAst", () => {
   expect(result.nonNodeObject).toBe(nonNodeObject);
   expect(result.nodeObject).not.toBe(nodeObject);
   expect(result.nodeObject).toStrictEqual(nodeObject);
+});
+
+test("YAML block scalar value massage", () => {
+  for (const chomping of ["clip", "strip"]) {
+    const original = {
+      type: "blockLiteral",
+      chomping,
+      value: "line\n\n",
+    };
+    const cloned = { ...original };
+
+    massageYamlAstNode(original, cloned);
+
+    expect(cloned.value).toBe(original.value);
+  }
+
+  const original = {
+    type: "blockFolded",
+    chomping: "keep",
+    value: "line  \nnext\t\n",
+  };
+  const cloned = { ...original };
+
+  massageYamlAstNode(original, cloned);
+
+  expect(cloned.value).toBe("line\nnext\n");
 });


### PR DESCRIPTION
## Summary

- Stop trimming YAML `blockLiteral` / `blockFolded` values during AST massage for `clip` and `strip` chomping.
- Add unit coverage that preserves `clip` / `strip` values while keeping the existing `keep` trailing-space normalization.
- Mark the existing folded-strip fixture as AST-unstable because the printer still drops trailing whitespace when reparsed.

Fixes #19256.

## Verification

- `node .yarn/releases/yarn-4.17.0.cjs test tests/unit/massage-ast.js --runInBand`
- `FULL_TEST=1 node .yarn/releases/yarn-4.17.0.cjs test tests/format/yaml/block-literal tests/format/yaml/block-folded --runInBand`
- `node .yarn/releases/yarn-4.17.0.cjs prettier --check src/language-yaml/massage-ast/index.js tests/unit/massage-ast.js tests/config/format-test/failed-format-tests.js`
- `node .yarn/releases/yarn-4.17.0.cjs lint:changelog && git diff --check`

## AI usage

This PR was AI-assisted. I reviewed the diff manually and ran the verification above.

## Checklist

- [x] I've added tests to confirm my change works.
- [ ] (If changing the API or CLI) I've documented the changes I've made (in the `docs/` directory).
- [ ] (If the change is user-facing) I've added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I've read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
