### PR TITLE
Allow decorators to be used with `declare` on class fields

### DIFF
--- a/changelog_unreleased/typescript/19492.md
+++ b/changelog_unreleased/typescript/19492.md
@@ -1,6 +1,6 @@
 #### Allow decorators to be used with declare on class fields (#19492 by @evoactivity)
 
-Extensively used within the Ember ecoysystem, decorators with `declare` on class fields will ignore the babel parser error and allow Prettier to format the code without breaking it.
+Extensively used within the Ember ecosystem, decorators with `declare` on class fields will ignore the babel parser error and allow Prettier to format the code without breaking it.
 
 <!-- prettier-ignore -->
 ```ts

--- a/changelog_unreleased/typescript/19492.md
+++ b/changelog_unreleased/typescript/19492.md
@@ -1,0 +1,23 @@
+#### Allow decorators to be used with declare on class fields (#19492 by @evoactivity)
+
+Extensively used within the Ember ecoysystem, decorators with `declare` on class fields will ignore the babel parser error and allow Prettier to format the code without breaking it.
+
+<!-- prettier-ignore -->
+```ts
+// Input
+export default class ProjectStatusComponent extends Component<ProjectStatusSig> {
+  @service declare server: ServerService;
+}
+
+// Prettier stable
+// SyntaxError: Decorators can't be used with a declare field. (2:3)
+//  1 | export default class ProjectStatusComponent extends Component<ProjectStatusSig> {
+//> 2 |   @service declare server: ServerService;
+//    |   ^
+//  3 | }
+
+// Prettier main
+export default class ProjectStatusComponent extends Component<ProjectStatusSig> {
+  @service declare server: ServerService;
+}
+```

--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -222,6 +222,12 @@ const allowedReasonCodesArray = [
   ```
   */
   "DeclarationMissingInitializer",
+
+  /*
+  Allow decorators to be used with declare fields
+  https://github.com/prettier/prettier/issues/19491
+  */
+  "DecoratorAbstractMethod"
 ];
 const allowedReasonCodes = new Set(allowedReasonCodesArray);
 

--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -227,7 +227,7 @@ const allowedReasonCodesArray = [
   Allow decorators to be used with declare fields
   https://github.com/prettier/prettier/issues/19491
   */
-  "DecoratorAbstractMethod"
+  "DecoratorAbstractMethod",
 ];
 const allowedReasonCodes = new Set(allowedReasonCodesArray);
 

--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -226,6 +226,7 @@ const allowedReasonCodesArray = [
   /*
   Allow decorators to be used with declare fields
   https://github.com/prettier/prettier/issues/19491
+  https://github.com/babel/babel/pull/17949
   */
   "DecoratorAbstractMethod",
 ];

--- a/tests/format/typescript/comments/16065-2.ts
+++ b/tests/format/typescript/comments/16065-2.ts
@@ -3,6 +3,14 @@ class Foo {
   @decorator
   readonly /* comment */ propertyDefinition;
 
+  // TSAbstractPropertyDefinition
+  @decorator
+  abstract /* comment */ abstractPropertyDefinition;
+
+  // TSAbstractMethodDefinition
+  @decorator
+  abstract /* comment */ abstractMethodDefinition;
+
   // MethodDefinition
   @decorator
   private /* comment */ methodDefinition() {}

--- a/tests/format/typescript/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/comments/__snapshots__/format.test.js.snap
@@ -260,6 +260,14 @@ class Foo {
   @decorator
   readonly /* comment */ propertyDefinition;
 
+  // TSAbstractPropertyDefinition
+  @decorator
+  abstract /* comment */ abstractPropertyDefinition;
+
+  // TSAbstractMethodDefinition
+  @decorator
+  abstract /* comment */ abstractMethodDefinition;
+
   // MethodDefinition
   @decorator
   private /* comment */ methodDefinition() {}
@@ -280,6 +288,14 @@ class Foo {
   // PropertyDefinition
   @decorator
   readonly /* comment */ propertyDefinition;
+
+  // TSAbstractPropertyDefinition
+  @decorator
+  abstract /* comment */ abstractPropertyDefinition;
+
+  // TSAbstractMethodDefinition
+  @decorator
+  abstract /* comment */ abstractMethodDefinition;
 
   // MethodDefinition
   @decorator

--- a/tests/format/typescript/decorators/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/decorators/__snapshots__/format.test.js.snap
@@ -82,31 +82,6 @@ class Something {
 ================================================================================
 `;
 
-exports[`decorator-declare.ts format 1`] = `
-====================================options=====================================
-parsers: ["typescript"]
-                                                      printWidth: 80 (default) |
-=====================================input======================================
-/**
- * decorators with declare is used extensively in Ember ecosystem,
- * and we want to make sure that Prettier doesn't break them.
- */
-export default class ProjectStatusComponent extends Component<ProjectStatusSig> {
-  @service declare server: ServerService;
-}
-
-=====================================output=====================================
-/**
- * decorators with declare is used extensively in Ember ecosystem,
- * and we want to make sure that Prettier doesn't break them.
- */
-export default class ProjectStatusComponent extends Component<ProjectStatusSig> {
-  @service declare server: ServerService;
-}
-
-================================================================================
-`;
-
 exports[`decorator-type-assertion.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -358,6 +333,37 @@ class Something2 {
   @foo()
   // comment
   abstract property: Array<string>;
+}
+
+================================================================================
+`;
+
+exports[`ember.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+/*
+https://github.com/prettier/prettier/issues/19491
+
+decorators with declare is used extensively in Ember ecosystem,
+and we want to make sure that Prettier doesn't break them.
+*/
+
+export default class ProjectStatusComponent extends Component<ProjectStatusSig> {
+  @service declare server: ServerService;
+}
+
+=====================================output=====================================
+/*
+https://github.com/prettier/prettier/issues/19491
+
+decorators with declare is used extensively in Ember ecosystem,
+and we want to make sure that Prettier doesn't break them.
+*/
+
+export default class ProjectStatusComponent extends Component<ProjectStatusSig> {
+  @service declare server: ServerService;
 }
 
 ================================================================================

--- a/tests/format/typescript/decorators/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/decorators/__snapshots__/format.test.js.snap
@@ -309,6 +309,12 @@ class Something {
     readonly property: Array<string>
 }
 
+class Something2 {
+    @foo()
+    // comment
+    abstract property: Array<string>
+}
+
 =====================================output=====================================
 class Foo1 {
   @foo
@@ -338,6 +344,12 @@ class Something {
   @foo()
   // comment
   readonly property: Array<string>;
+}
+
+class Something2 {
+  @foo()
+  // comment
+  abstract property: Array<string>;
 }
 
 ================================================================================

--- a/tests/format/typescript/decorators/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/decorators/__snapshots__/format.test.js.snap
@@ -87,11 +87,19 @@ exports[`decorator-declare.ts format 1`] = `
 parsers: ["typescript"]
                                                       printWidth: 80 (default) |
 =====================================input======================================
+/**
+ * decorators with declare is used extensively in Ember ecosystem,
+ * and we want to make sure that Prettier doesn't break them.
+ */
 export default class ProjectStatusComponent extends Component<ProjectStatusSig> {
   @service declare server: ServerService;
 }
 
 =====================================output=====================================
+/**
+ * decorators with declare is used extensively in Ember ecosystem,
+ * and we want to make sure that Prettier doesn't break them.
+ */
 export default class ProjectStatusComponent extends Component<ProjectStatusSig> {
   @service declare server: ServerService;
 }

--- a/tests/format/typescript/decorators/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/decorators/__snapshots__/format.test.js.snap
@@ -82,6 +82,23 @@ class Something {
 ================================================================================
 `;
 
+exports[`decorator-declare.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+export default class ProjectStatusComponent extends Component<ProjectStatusSig> {
+  @service declare server: ServerService;
+}
+
+=====================================output=====================================
+export default class ProjectStatusComponent extends Component<ProjectStatusSig> {
+  @service declare server: ServerService;
+}
+
+================================================================================
+`;
+
 exports[`decorator-type-assertion.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/decorators/decorator-declare.ts
+++ b/tests/format/typescript/decorators/decorator-declare.ts
@@ -1,7 +1,0 @@
-/**
- * decorators with declare is used extensively in Ember ecosystem,
- * and we want to make sure that Prettier doesn't break them.
- */
-export default class ProjectStatusComponent extends Component<ProjectStatusSig> {
-  @service declare server: ServerService;
-}

--- a/tests/format/typescript/decorators/decorator-declare.ts
+++ b/tests/format/typescript/decorators/decorator-declare.ts
@@ -1,0 +1,7 @@
+/**
+ * decorators with declare is used extensively in Ember ecosystem,
+ * and we want to make sure that Prettier doesn't break them.
+ */
+export default class ProjectStatusComponent extends Component<ProjectStatusSig> {
+  @service declare server: ServerService;
+}

--- a/tests/format/typescript/decorators/decorators-comments.ts
+++ b/tests/format/typescript/decorators/decorators-comments.ts
@@ -28,3 +28,9 @@ class Something {
     // comment
     readonly property: Array<string>
 }
+
+class Something2 {
+    @foo()
+    // comment
+    abstract property: Array<string>
+}

--- a/tests/format/typescript/decorators/ember.ts
+++ b/tests/format/typescript/decorators/ember.ts
@@ -1,0 +1,10 @@
+/*
+https://github.com/prettier/prettier/issues/19491
+
+decorators with declare is used extensively in Ember ecosystem,
+and we want to make sure that Prettier doesn't break them.
+*/
+
+export default class ProjectStatusComponent extends Component<ProjectStatusSig> {
+  @service declare server: ServerService;
+}


### PR DESCRIPTION
## Description

Ember projects regularly use decorators on class fields with `declare`, this is a new addition to babel and the babel project makes this same change, as a patch, to test against prettier. The author of the change also suggested prettier should ignore `DecoratorAbstractMethod` errors.

Closes #19491

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.
