### PR TITLE
Angular: Format `@content(name)` -> `@content (name)` to align with other block syntax

### DIFF
--- a/changelog_unreleased/angular/19499.md
+++ b/changelog_unreleased/angular/19499.md
@@ -1,0 +1,37 @@
+#### Format `@content(name)` -> `@content (name)` to align with other block syntax (#19499 by @fisker)
+
+<!-- prettier-ignore -->
+```html
+<!-- Input -->
+<FancyButton [label]="title">
+  @content (icon) {
+    <span>Icon!</span>
+  }
+  @content (description) {
+    <span>Description text</span>
+  }
+  <span>Other children</span>
+</FancyButton>
+
+<!-- Prettier stable -->
+<FancyButton [label]="title">
+  @content(icon) {
+    <span>Icon!</span>
+  }
+  @content(description) {
+    <span>Description text</span>
+  }
+  <span>Other children</span>
+</FancyButton>
+
+<!-- Prettier main -->
+<FancyButton [label]="title">
+  @content (icon) {
+    <span>Icon!</span>
+  }
+  @content (description) {
+    <span>Description text</span>
+  }
+  <span>Other children</span>
+</FancyButton>
+```

--- a/src/language-html/print/angular-control-flow-block.js
+++ b/src/language-html/print/angular-control-flow-block.js
@@ -10,8 +10,6 @@ import { hasPrettierIgnore } from "../utilities/index.js";
 import { ANGULAR_CONTROL_FLOW_BLOCK_SETTINGS } from "./angular-control-flow-block-settings.evaluate.js";
 import { printChildren } from "./children.js";
 
-const blocksShouldNotPrintSpaceAfterName = new Set(["content"]);
-
 function printAngularControlFlowBlock(path, options, print) {
   const { node } = path;
   const docs = [];
@@ -28,12 +26,7 @@ function printAngularControlFlowBlock(path, options, print) {
   }
 
   if (node.parameters) {
-    docs.push(
-      blocksShouldNotPrintSpaceAfterName.has(node.name) ? "" : " ",
-      "(",
-      group(print("parameters")),
-      ")",
-    );
+    docs.push(" ", "(", group(print("parameters")), ")");
   }
 
   if (!isSwitchFallthroughCase(node)) {

--- a/tests/format/angular/control-flow/__snapshots__/format.test.js.snap
+++ b/tests/format/angular/control-flow/__snapshots__/format.test.js.snap
@@ -90,16 +90,64 @@ parsers: ["angular"]
   <span>Other children</span>
    </FancyButton>
 
+<FancyButton [label]="title">
+      @content (items; let item, index) {
+        <span>#{{index}}: {{item}}</span>
+      }
+    </FancyButton>
+
+<FancyList>
+            @content (renderHeader; let _) {
+              <span>Header Content</span>
+            }
+          </FancyList>
+
+<FancyTable>
+            @content (renderRow; let row, idx, isLast) {
+              <span>{{ idx }} - {{ row }} (Last: {{ isLast }})</span>
+            }
+          </FancyTable>
+
+<DynamicIf [injector]="injector" [cond]="visible">
+            @content (children; let result) {
+              <child>{{ result }}</child>
+            }
+          </DynamicIf>
+
 =====================================output=====================================
 <FancyButton [label]="title">
-  @content(icon) {
+  @content (icon) {
     <span>Icon!</span>
   }
-  @content(description) {
+  @content (description) {
     <span>Description text</span>
   }
   <span>Other children</span>
 </FancyButton>
+
+<FancyButton [label]="title">
+  @content (items; let item, index) {
+    <span>#{{ index }}: {{ item }}</span>
+  }
+</FancyButton>
+
+<FancyList>
+  @content (renderHeader; let _) {
+    <span>Header Content</span>
+  }
+</FancyList>
+
+<FancyTable>
+  @content (renderRow; let row, idx, isLast) {
+    <span>{{ idx }} - {{ row }} (Last: {{ isLast }})</span>
+  }
+</FancyTable>
+
+<DynamicIf [injector]="injector" [cond]="visible">
+  @content (children; let result) {
+    <child>{{ result }}</child>
+  }
+</DynamicIf>
 
 ================================================================================
 `;

--- a/tests/format/angular/control-flow/content.html
+++ b/tests/format/angular/control-flow/content.html
@@ -7,3 +7,27 @@
       }
   <span>Other children</span>
    </FancyButton>
+
+<FancyButton [label]="title">
+      @content (items; let item, index) {
+        <span>#{{index}}: {{item}}</span>
+      }
+    </FancyButton>
+
+<FancyList>
+            @content (renderHeader; let _) {
+              <span>Header Content</span>
+            }
+          </FancyList>
+
+<FancyTable>
+            @content (renderRow; let row, idx, isLast) {
+              <span>{{ idx }} - {{ row }} (Last: {{ isLast }})</span>
+            }
+          </FancyTable>
+
+<DynamicIf [injector]="injector" [cond]="visible">
+            @content (children; let result) {
+              <child>{{ result }}</child>
+            }
+          </DynamicIf>


### PR DESCRIPTION


<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

<!-- Please provide a brief summary of your changes -->

Follow the official style https://github.com/angular/angular/commit/a720094deb21c77126ba536542651b1d6992bc47

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.
