### PR TITLE
Keep `<syntax>` multipliers adjacent inside CSS `type()`

### DIFF
--- a/changelog_unreleased/css/19512.md
+++ b/changelog_unreleased/css/19512.md
@@ -1,0 +1,21 @@
+#### Keep `<syntax>` multipliers adjacent inside `type()` (#19512 by @CedricConday)
+
+The `type()` function of `attr()` takes a `<syntax>`, whose multipliers (`+`, `*`, `#`, …) are grammar tokens, not math operators. Prettier inserted a space around `+`/`*`, producing invalid CSS.
+
+<!-- prettier-ignore -->
+```css
+/* Input */
+a {
+  width: attr(data-width type(<length>+));
+}
+
+/* Prettier stable */
+a {
+  width: attr(data-width type(<length> +));
+}
+
+/* Prettier main */
+a {
+  width: attr(data-width type(<length>+));
+}
+```

--- a/src/language-css/print/comma-separated-value-group.js
+++ b/src/language-css/print/comma-separated-value-group.js
@@ -300,6 +300,16 @@ function printCommaSeparatedValueGroup(path, options, print) {
     const isMathOperator = isMathOperatorNode(iNode);
     const isNextMathOperator = isMathOperatorNode(iNextNode);
 
+    // Multipliers such as `+` and `*` inside the `type()` function of `attr()`
+    // are `<syntax>` grammar tokens, not math operators, so they must stay
+    // adjacent (e.g. `type(<length>+)`, not `type(<length> +)`).
+    if (
+      (isMathOperator || isNextMathOperator) &&
+      insideValueFunctionNode(path, "type")
+    ) {
+      continue;
+    }
+
     // Print spaces before and after math operators beside SCSS interpolation as is
     // (i.e. `#{$var}+5`, `#{$var} +5`, `#{$var}+ 5`, `#{$var} + 5`)
     // (i.e. `5+#{$var}`, `5 +#{$var}`, `5+ #{$var}`, `5 + #{$var}`)

--- a/tests/format/css/attr-type/__snapshots__/format.test.js.snap
+++ b/tests/format/css/attr-type/__snapshots__/format.test.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`attr-type.css format 1`] = `
+====================================options=====================================
+parsers: ["css"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+a {
+  width: attr(data-width type(<length>+));
+  color: attr(data-color type(<color>#));
+  gap: attr(data-gap type(<length>*));
+  height: attr(data-height type(<length>));
+}
+
+=====================================output=====================================
+a {
+  width: attr(data-width type(<length>+));
+  color: attr(data-color type(<color>#));
+  gap: attr(data-gap type(<length>*));
+  height: attr(data-height type(<length>));
+}
+
+================================================================================
+`;

--- a/tests/format/css/attr-type/attr-type.css
+++ b/tests/format/css/attr-type/attr-type.css
@@ -1,0 +1,6 @@
+a {
+  width: attr(data-width type(<length>+));
+  color: attr(data-color type(<color>#));
+  gap: attr(data-gap type(<length>*));
+  height: attr(data-height type(<length>));
+}

--- a/tests/format/css/attr-type/format.test.js
+++ b/tests/format/css/attr-type/format.test.js
@@ -1,0 +1,1 @@
+runFormatTest(import.meta, ["css"]);


### PR DESCRIPTION
Fixes #19509.

The `type()` function of `attr()` takes a `<syntax>`, whose multipliers (`+`, `*`, `#`, …) are grammar tokens — not math operators. Prettier treated `+`/`*` as math operators and inserted a space, producing invalid CSS:

```css
/* Input */
a { width: attr(data-width type(<length>+)); }
/* Prettier stable */
a { width: attr(data-width type(<length> +)); }
/* This PR */
a { width: attr(data-width type(<length>+)); }
```

The fix skips math-operator spacing when inside a `type()` value function, mirroring the existing `calc()` carve-out. Added a snapshot fixture (`tests/format/css/attr-type`) covering `+`, `*`, `#`, and a plain `<length>`; it fails before the change and passes after. Changelog entry to follow in a moment.

---
*Disclosure: authored with AI assistance (Claude Code); reviewed by me and I'll shepherd it through review.*