### PR TITLE
Fix CSS type() multipliers

### DIFF
--- a/src/language-css/print/comma-separated-value-group.js
+++ b/src/language-css/print/comma-separated-value-group.js
@@ -136,6 +136,17 @@ function printCommaSeparatedValueGroup(path, options, print) {
       continue;
     }
 
+    // In CSS type() syntax, `+` and `*` are multipliers, not math operators.
+    if (
+      insideValueFunctionNode(path, "type") &&
+      iNode.type === "value-word" &&
+      iNextNode &&
+      /^<[^>]+>$/.test(iNode.value) &&
+      (isAdditionNode(iNextNode) || isMultiplicationNode(iNextNode))
+    ) {
+      continue;
+    }
+
     // Ignore after latest node (i.e. before semicolon)
     if (!iNextNode) {
       continue;

--- a/tests/format/css/parens/__snapshots__/format.test.js.snap
+++ b/tests/format/css/parens/__snapshots__/format.test.js.snap
@@ -271,6 +271,8 @@ a {
     20
     )
     ;
+    prop26: attr(br type(<length>+));
+    prop27: attr(br type(<length> *));
 }
 
 .bar {
@@ -434,6 +436,8 @@ a {
   prop23: attr(data-size em, 20);
   prop24: attr(data-size em, 20);
   prop25: attr(data-size em, 20);
+  prop26: attr(br type(<length>+));
+  prop27: attr(br type(<length>*));
 }
 
 .bar {

--- a/tests/format/css/parens/parens.css
+++ b/tests/format/css/parens/parens.css
@@ -234,6 +234,8 @@ a {
     20
     )
     ;
+    prop26: attr(br type(<length>+));
+    prop27: attr(br type(<length> *));
 }
 
 .bar {


### PR DESCRIPTION
## Summary

- Keep CSS `type()` `+` and `*` multipliers attached to the preceding `<...>` type
- Add fixture coverage for `attr(... type(<length>+))` and `attr(... type(<length>*))`

Fixes #19509.

## Tests

- `node .yarn/releases/yarn-4.17.0.cjs jest tests/format/css/parens/format.test.js --runInBand`
- `node .yarn/releases/yarn-4.17.0.cjs jest tests/format/css --runInBand`
- `node .yarn/releases/yarn-4.17.0.cjs eslint src/language-css/print/comma-separated-value-group.js tests/format/css/parens/format.test.js`
- `git diff --check`
- `node .yarn/releases/yarn-4.17.0.cjs lint:format-test`
