### PR TITLE
Prevent the addition of space in `type()` with `+`

### DIFF
--- a/changelog_unreleased/css/19516.md
+++ b/changelog_unreleased/css/19516.md
@@ -1,0 +1,21 @@
+#### Prevent the addition of space in `type()` with `+` (#19516 by @bigandy)
+
+This fixes the addition of a space before a + in a CSS `type()` declaration. For example `type(<number>+)` was being converted into `type(<number> +)` which is invalid CSS and does not work.
+
+<!-- prettier-ignore -->
+```css
+/* Input */
+div {
+  border-radius: attr(br type(<length>+));
+}
+
+/* Prettier stable */
+div {
+  border-radius: attr(br type(<length> +));
+}
+
+/* Prettier main */
+div {
+  border-radius: attr(br type(<length>+));
+}
+```

--- a/changelog_unreleased/css/19516.md
+++ b/changelog_unreleased/css/19516.md
@@ -1,6 +1,6 @@
-#### Prevent the addition of space in `type()` with `+` (#19516 by @bigandy)
+#### Prevent addition space in `type()` with `+` (#19516 by @bigandy)
 
-This fixes the addition of a space before a `+` in a CSS `type()` declaration. For example `type(<number>+)` was being converted into `type(<number> +)` which is invalid CSS and does not work.
+This fixes the addition space before `+` in CSS `type()` declaration. For example `type(<number>+)` was being converted into `type(<number> +)` which is invalid CSS and does not work.
 
 <!-- prettier-ignore -->
 ```css

--- a/changelog_unreleased/css/19516.md
+++ b/changelog_unreleased/css/19516.md
@@ -1,6 +1,6 @@
 #### Prevent the addition of space in `type()` with `+` (#19516 by @bigandy)
 
-This fixes the addition of a space before a + in a CSS `type()` declaration. For example `type(<number>+)` was being converted into `type(<number> +)` which is invalid CSS and does not work.
+This fixes the addition of a space before a `+` in a CSS `type()` declaration. For example `type(<number>+)` was being converted into `type(<number> +)` which is invalid CSS and does not work.
 
 <!-- prettier-ignore -->
 ```css

--- a/src/language-css/print/comma-separated-value-group.js
+++ b/src/language-css/print/comma-separated-value-group.js
@@ -311,6 +311,17 @@ function printCommaSeparatedValueGroup(path, options, print) {
       continue;
     }
 
+    // Prevent the addition of a space inside type() declarations that include an + operator
+    // due to the fact that it is not valid syntax
+    // (i.e. `type(<number> +)`, `type(<color> +)`)
+    if (
+      isAdditionNode(iNextNode) &&
+      insideValueFunctionNode(path, "type") &&
+      hasEmptyRawBefore(iNextNode)
+    ) {
+      continue;
+    }
+
     // absolute paths are only parsed as one token if they are part of url(/abs/path) call
     // but if you have custom -fb-url(/abs/path/) then it is parsed as "division /" and rest
     // of the path. We don't want to put a space after that first division in this case.

--- a/tests/format/css/type-function/__snapshots__/format.test.js.snap
+++ b/tests/format/css/type-function/__snapshots__/format.test.js.snap
@@ -28,6 +28,7 @@ div {
 div {
   aspect-ratio: attr(data-ar type(*));
 }
+
 =====================================output=====================================
 div {
   border-radius: attr(br type(<length>+));

--- a/tests/format/css/type-function/__snapshots__/format.test.js.snap
+++ b/tests/format/css/type-function/__snapshots__/format.test.js.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`type.css format 1`] = `
+====================================options=====================================
+parsers: ["css"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+div {
+  border-radius: attr(br type(<length>+));
+}
+
+div {
+  background: attr(bg type(<color>+));
+}
+
+div {
+  background: attr(bg type(<color>#));
+}
+
+div {
+  margin: attr(data-margin type(<percentage> | <number> | auto));
+}
+
+div {
+  margin: attr(data-margin type(<percentage>+ | <number>+ | auto));
+}
+
+div {
+  aspect-ratio: attr(data-ar type(*));
+}
+=====================================output=====================================
+div {
+  border-radius: attr(br type(<length>+));
+}
+
+div {
+  background: attr(bg type(<color>+));
+}
+
+div {
+  background: attr(bg type(<color>#));
+}
+
+div {
+  margin: attr(data-margin type(<percentage> | <number> | auto));
+}
+
+div {
+  margin: attr(data-margin type(<percentage>+ | <number>+ | auto));
+}
+
+div {
+  aspect-ratio: attr(data-ar type(*));
+}
+
+================================================================================
+`;

--- a/tests/format/css/type-function/format.test.js
+++ b/tests/format/css/type-function/format.test.js
@@ -1,0 +1,1 @@
+runFormatTest(import.meta, ["css"]);

--- a/tests/format/css/type-function/type.css
+++ b/tests/format/css/type-function/type.css
@@ -1,0 +1,23 @@
+div {
+  border-radius: attr(br type(<length>+));
+}
+
+div {
+  background: attr(bg type(<color>+));
+}
+
+div {
+  background: attr(bg type(<color>#));
+}
+
+div {
+  margin: attr(data-margin type(<percentage> | <number> | auto));
+}
+
+div {
+  margin: attr(data-margin type(<percentage>+ | <number>+ | auto));
+}
+
+div {
+  aspect-ratio: attr(data-ar type(*));
+}


### PR DESCRIPTION
<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

<!-- Please provide a brief summary of your changes -->

This fixes the addition of a space before a `+` in a CSS `type()` declaration. For example `type(<number>+)` was being converted into `type(<number> +)` which is invalid CSS and does not work.

Resolves #19509


## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.
