### PR TITLE
Fix CSS attr type multiplier spacing

### DIFF
--- a/changelog_unreleased/css/19509.md
+++ b/changelog_unreleased/css/19509.md
@@ -1,0 +1,19 @@
+#### Preserve CSS `attr()` type multipliers (#19509 by @1cbyc)
+
+<!-- prettier-ignore -->
+```css
+/* Input */
+div {
+  border-radius: attr(data-size type(<length> +));
+}
+
+/* Prettier stable */
+div {
+  border-radius: attr(data-size type(<length> +));
+}
+
+/* Prettier main */
+div {
+  border-radius: attr(data-size type(<length>+));
+}
+```

--- a/src/language-css/print/comma-separated-value-group.js
+++ b/src/language-css/print/comma-separated-value-group.js
@@ -332,6 +332,12 @@ function printCommaSeparatedValueGroup(path, options, print) {
       continue;
     }
 
+    // CSS `attr()` type syntax embeds CSS value-definition grammar, where
+    // multipliers are suffixes rather than math operators (e.g. `<length>+`).
+    if (insideValueFunctionNode(path, "type") && isAdditionNode(iNextNode)) {
+      continue;
+    }
+
     // Space before unary minus followed by a function call.
     if (
       options.parser === "scss" &&

--- a/tests/format/css/parens/__snapshots__/format.test.js.snap
+++ b/tests/format/css/parens/__snapshots__/format.test.js.snap
@@ -271,6 +271,8 @@ a {
     20
     )
     ;
+    prop26: attr(data-size type(<length>+));
+    prop27: attr(data-size type(<length> +));
 }
 
 .bar {
@@ -434,6 +436,8 @@ a {
   prop23: attr(data-size em, 20);
   prop24: attr(data-size em, 20);
   prop25: attr(data-size em, 20);
+  prop26: attr(data-size type(<length>+));
+  prop27: attr(data-size type(<length>+));
 }
 
 .bar {

--- a/tests/format/css/parens/parens.css
+++ b/tests/format/css/parens/parens.css
@@ -234,6 +234,8 @@ a {
     20
     )
     ;
+    prop26: attr(data-size type(<length>+));
+    prop27: attr(data-size type(<length> +));
 }
 
 .bar {


### PR DESCRIPTION
## Summary
- Preserve CSS `attr()` `type()` value-definition multipliers such as `<length>+`.
- Add CSS format coverage for `attr(data-size type(<length>+))` and the spaced input form.
- Add an unreleased changelog entry for the CSS formatter fix.

## Test Plan
- `corepack yarn jest tests/format/css/parens --runInBand`
- `node ./bin/prettier.cjs /tmp/prettier-19509.css --parser css`
- `corepack yarn prettier --check src/language-css/print/comma-separated-value-group.js tests/format/css/parens/parens.css tests/format/css/parens/__snapshots__/format.test.js.snap changelog_unreleased/css/19509.md`
- `EFF_NO_LINK_RULES=true corepack yarn eslint src/language-css/print/comma-separated-value-group.js tests/format/css/parens/format.test.js --format friendly`
- `corepack yarn lint:format-test`
- `corepack yarn lint:changelog`
- `git diff --check`

Fixes #19509
