### PR TITLE
Fix unstable HTML template literal expression formatting

### DIFF
--- a/changelog_unreleased/javascript/19520.md
+++ b/changelog_unreleased/javascript/19520.md
@@ -1,0 +1,73 @@
+#### Keep nested HTML template literal formatting idempotent (#19520 by @barry166)
+
+Prettier now keeps nested JavaScript expressions inside formatted `html` template literals stable across repeated formatting passes.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+const t = html`
+  <ol>
+    ${items.map(
+      (entry) => html`
+        <li>
+          ${entry.children
+            ? html`
+                <ol>
+                  ${entry.children.map(
+                    (child) => html`<li>${child.title}</li>`,
+                  )}
+                </ol>
+              `
+            : entry.title}
+        </li>
+      `,
+    )}
+  </ol>
+`;
+
+// Prettier stable
+const t = html`
+  <ol>
+    ${items.map(
+      (entry) => html`
+        <li>
+          ${
+            entry.children
+              ? html`
+                  <ol>
+                    ${entry.children.map(
+                    (child) => html`<li>${child.title}</li>`,
+                  )}
+                  </ol>
+                `
+              : entry.title
+          }
+        </li>
+      `,
+    )}
+  </ol>
+`;
+
+// Prettier main
+const t = html`
+  <ol>
+    ${items.map(
+      (entry) => html`
+        <li>
+          ${
+            entry.children
+              ? html`
+                  <ol>
+                    ${entry.children.map(
+                      (child) => html`<li>${child.title}</li>`,
+                    )}
+                  </ol>
+                `
+              : entry.title
+          }
+        </li>
+      `,
+    )}
+  </ol>
+`;
+```

--- a/src/language-js/embed/html.js
+++ b/src/language-js/embed/html.js
@@ -30,7 +30,10 @@ async function printEmbedHtmlLike(parser, textToDoc, print, path, options) {
     )
     .join("");
 
+  const previousEmbeddedHtmlTemplate = options.__embeddedHtmlTemplate;
+  options.__embeddedHtmlTemplate = true;
   const expressionDocs = printTemplateExpressions(path, options, print);
+  options.__embeddedHtmlTemplate = previousEmbeddedHtmlTemplate;
 
   const placeholderRegex = new RegExp(
     composePlaceholder(String.raw`(\d+)`),

--- a/src/language-js/print/template-literal.js
+++ b/src/language-js/print/template-literal.js
@@ -268,6 +268,9 @@ function printTemplateExpression(path, options, print) {
   if (options.__inJestEach) {
     indentSize = Math.max(indentSize, options.tabWidth);
   }
+  if (options.__embeddedHtmlTemplate) {
+    indentSize = 0;
+  }
   expressionDoc =
     indentSize === 0 && previousQuasiText.endsWith("\n")
       ? align(Number.NEGATIVE_INFINITY, expressionDoc)

--- a/tests/format/js/template-literals/__snapshots__/format.test.js.snap
+++ b/tests/format/js/template-literals/__snapshots__/format.test.js.snap
@@ -282,6 +282,57 @@ a = \`\${[
 ================================================================================
 `;
 
+exports[`html-map-ternary.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+const t = html\`
+  <ol>
+    \${items.map(
+      (entry) => html\`
+        <li>
+          \${entry.children
+            ? html\`
+                <ol>
+                  \${entry.children.map(
+                    (child) => html\`<li>\${child.title}</li>\`,
+                  )}
+                </ol>
+              \`
+            : entry.title}
+        </li>
+      \`,
+    )}
+  </ol>
+\`;
+
+=====================================output=====================================
+const t = html\`
+  <ol>
+    \${items.map(
+      (entry) => html\`
+        <li>
+          \${
+            entry.children
+              ? html\`
+                  <ol>
+                    \${entry.children.map(
+                      (child) => html\`<li>\${child.title}</li>\`,
+                    )}
+                  </ol>
+                \`
+              : entry.title
+          }
+        </li>
+      \`,
+    )}
+  </ol>
+\`;
+
+================================================================================
+`;
+
 exports[`indention.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]

--- a/tests/format/js/template-literals/html-map-ternary.js
+++ b/tests/format/js/template-literals/html-map-ternary.js
@@ -1,0 +1,19 @@
+const t = html`
+  <ol>
+    ${items.map(
+      (entry) => html`
+        <li>
+          ${entry.children
+            ? html`
+                <ol>
+                  ${entry.children.map(
+                    (child) => html`<li>${child.title}</li>`,
+                  )}
+                </ol>
+              `
+            : entry.title}
+        </li>
+      `,
+    )}
+  </ol>
+`;


### PR DESCRIPTION
## Description

Fixes #19518.

This keeps repeated formatting stable for nested JavaScript expressions inside formatted `html` template literals. The regression happened when the embedded HTML formatter printed expression docs using the original template quasi indentation, which could make the second formatting pass adjust nested `.map()` indentation again.

AI-assisted: yes. I used AI assistance to investigate and draft the change, then manually reviewed the diff and ran the tests below.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

## Tests

- `FULL_TEST=1 corepack yarn jest tests/format/js/template-literals/format.test.js --runInBand`
- `corepack yarn lint:prettier src/language-js/embed/html.js src/language-js/print/template-literal.js tests/format/js/template-literals/html-map-ternary.js changelog_unreleased/javascript/19520.md`
- `corepack yarn lint:eslint src/language-js/embed/html.js src/language-js/print/template-literal.js tests/format/js/template-literals/format.test.js`
- `corepack yarn lint:changelog`
- `git diff --check`
