### PR TITLE
Preserve comment placement for plugin printers

### DIFF
--- a/changelog_unreleased/api/19521.md
+++ b/changelog_unreleased/api/19521.md
@@ -1,0 +1,15 @@
+#### Preserve `comment.placement` for plugin printers ([#19521](https://github.com/prettier/prettier/pull/19521) by [@ishaanlabs-gg](https://github.com/ishaanlabs-gg))
+
+Plugin printers can once again inspect the `placement` assigned to attached comments.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+foo(); // comment
+
+// Prettier stable
+// `comment.placement` is undefined in plugin printers.
+
+// Prettier main
+// `comment.placement` remains available in plugin printers.
+```

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -522,7 +522,7 @@ function ownLine(comment, text, options, ast, isLastComment) {
 }
 ```
 
-Nodes with comments are expected to have a `comments` property containing an array of comments. Each comment is expected to have the following properties: `leading`, `trailing`, `printed`.
+Nodes with comments are expected to have a `comments` property containing an array of comments. Each comment is expected to have the following properties: `leading`, `trailing`, `printed`, and `placement`. `placement` is one of `ownLine`, `endOfLine`, or `remaining`.
 
 <!-- TODO: add a note that this might change in the future -->
 

--- a/src/main/comments/attach.js
+++ b/src/main/comments/attach.js
@@ -256,7 +256,6 @@ function attachComments(ast, options) {
       delete comment.precedingNode;
       delete comment.enclosingNode;
       delete comment.followingNode;
-      delete comment.placement;
     }
   }
 }

--- a/tests/integration/__tests__/plugin-override-builtin-printers.js
+++ b/tests/integration/__tests__/plugin-override-builtin-printers.js
@@ -1,4 +1,5 @@
 import prettier from "../../config/prettier-entry.js";
+import { estree } from "../../../src/language-js/printers.js";
 
 /**
 If plugin matched by parser:
@@ -43,5 +44,54 @@ describe("Allow plugin to override printer if the plugin does not provide one", 
         parser: "babel",
       }),
     ).toBe(expectedOutput);
+  });
+
+  test("keeps comment placement available for plugin printers", async () => {
+    const collectComments = (node, seen = new Set()) => {
+      if (!node || typeof node !== "object" || seen.has(node)) {
+        return [];
+      }
+
+      seen.add(node);
+
+      const comments = Array.isArray(node.comments) ? node.comments : [];
+      for (const comment of comments) {
+        comment.printed = true;
+      }
+      return [
+        ...comments.map(
+          (comment) => `${comment.value.trim()}:${comment.placement}`,
+        ),
+        ...Object.entries(node).flatMap(([key, value]) =>
+          key === "comments" || key === "tokens"
+            ? []
+            : Array.isArray(value)
+              ? value.flatMap((child) => collectComments(child, seen))
+              : collectComments(value, seen),
+        ),
+      ];
+    };
+
+    const output = await prettier.format("// own\nfoo();\nfoo(); // end", {
+      plugins: [
+        {
+          printers: {
+            estree: {
+              ...estree,
+              print(path) {
+                return collectComments(path.node).sort().join("\n");
+              },
+            },
+          },
+        },
+      ],
+      parser: "babel",
+    });
+
+    expect(output).toMatchInlineSnapshot(`
+      "end:remaining
+      own:endOfLine"
+    `);
+    expect(output).not.toContain("undefined");
   });
 });


### PR DESCRIPTION
## Description

Fixes prettier/prettier#19515.

`comment.placement` was assigned during comment attachment, but then deleted before plugin printers could inspect attached comments. This keeps the placement string available while still removing the temporary node-reference fields that can create AST cycles.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

Verification:

- `node .yarn/releases/yarn-4.17.0.cjs jest tests/integration/__tests__/plugin-override-builtin-printers.js --no-watchman`
- `node .yarn/releases/yarn-4.17.0.cjs prettier src/main/comments/attach.js tests/integration/__tests__/plugin-override-builtin-printers.js --check`
- `git diff --check`
