### PR TITLE
Fix extra space before multiplier in CSS type() syntax strings

### DIFF
--- a/changelog_unreleased/css/19526.md
+++ b/changelog_unreleased/css/19526.md
@@ -1,0 +1,19 @@
+#### Fix extra space before multiplier in CSS `type()` syntax strings (#19526 by @koreahghg)
+
+<!-- prettier-ignore -->
+```css
+/* Input */
+div {
+  border-radius: attr(br type(<length>+));
+}
+
+/* Prettier stable */
+div {
+  border-radius: attr(br type(<length> +));
+}
+
+/* Prettier main */
+div {
+  border-radius: attr(br type(<length>+));
+}
+```

--- a/src/language-css/print/comma-separated-value-group.js
+++ b/src/language-css/print/comma-separated-value-group.js
@@ -300,6 +300,18 @@ function printCommaSeparatedValueGroup(path, options, print) {
     const isMathOperator = isMathOperatorNode(iNode);
     const isNextMathOperator = isMathOperatorNode(iNextNode);
 
+    // Don't print a space before a multiplier (e.g. `+`, `*`) in a CSS Values
+    // `type()` syntax string, since a space there is invalid syntax
+    // (i.e. `type(<length>+)`, `type(<color>*)`)
+    // https://drafts.csswg.org/css-values-5/#typedef-syntax
+    if (
+      isNextMathOperator &&
+      hasEmptyRawBefore(iNextNode) &&
+      insideValueFunctionNode(path, "type")
+    ) {
+      continue;
+    }
+
     // Print spaces before and after math operators beside SCSS interpolation as is
     // (i.e. `#{$var}+5`, `#{$var} +5`, `#{$var}+ 5`, `#{$var} + 5`)
     // (i.e. `5+#{$var}`, `5 +#{$var}`, `5+ #{$var}`, `5 + #{$var}`)

--- a/tests/format/css/type-function/__snapshots__/format.test.js.snap
+++ b/tests/format/css/type-function/__snapshots__/format.test.js.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`type-function.css format 1`] = `
+====================================options=====================================
+parsers: ["css"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+@property --foo {
+  syntax: "<length>+";
+  inherits: false;
+  initial-value: 0px;
+}
+
+div {
+  border-radius: attr(br type(<length>+));
+  width: attr(data-x type(<length>*));
+  height: attr(data-x type(<number>#));
+  margin: attr(data-x type(<length>?));
+  padding: attr(data-x type(<length>!));
+  top: attr(data-x type(<length>+), 10px);
+  left: attr(data-x type(<length>+ <percentage>+));
+}
+
+=====================================output=====================================
+@property --foo {
+  syntax: "<length>+";
+  inherits: false;
+  initial-value: 0px;
+}
+
+div {
+  border-radius: attr(br type(<length>+));
+  width: attr(data-x type(<length>*));
+  height: attr(data-x type(<number>#));
+  margin: attr(data-x type(<length>?));
+  padding: attr(data-x type(<length>!));
+  top: attr(data-x type(<length>+), 10px);
+  left: attr(data-x type(<length>+ <percentage>+));
+}
+
+================================================================================
+`;

--- a/tests/format/css/type-function/format.test.js
+++ b/tests/format/css/type-function/format.test.js
@@ -1,0 +1,1 @@
+runFormatTest(import.meta, ["css"]);

--- a/tests/format/css/type-function/type-function.css
+++ b/tests/format/css/type-function/type-function.css
@@ -1,0 +1,15 @@
+@property --foo {
+  syntax: "<length>+";
+  inherits: false;
+  initial-value: 0px;
+}
+
+div {
+  border-radius: attr(br type(<length>+));
+  width: attr(data-x type(<length>*));
+  height: attr(data-x type(<number>#));
+  margin: attr(data-x type(<length>?));
+  padding: attr(data-x type(<length>!));
+  top: attr(data-x type(<length>+), 10px);
+  left: attr(data-x type(<length>+ <percentage>+));
+}


### PR DESCRIPTION
## Description

Fixes #19509

`type(<length>+)` (a CSS Values-5 `<syntax>` string, used e.g. as an `attr()` fallback type or `@property` `syntax` descriptor) was being formatted as `type(<length> +)`, which is invalid syntax per https://drafts.csswg.org/css-values-5/#typedef-syntax — no whitespace is allowed before a multiplier (`+`, `*`, `#`, `?`, `!`, `{A,B}`).

The formatter's generic "add a space before a math operator" rule in `printCommaSeparatedValueGroup` didn't distinguish real arithmetic operators (as in `calc()`) from multiplier symbols inside a `type()` syntax string, so it inserted a space before `+`/`*` that wasn't in the original source.

The fix adds a guard so no space is inserted before a math-operator-like symbol inside `type(...)` when the original source didn't have one there.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.