### PR TITLE
Fix CSS attr type multiplier spacing

### DIFF
--- a/changelog_unreleased/css/19509.md
+++ b/changelog_unreleased/css/19509.md
@@ -1,0 +1,19 @@
+#### Preserve CSS `attr()` type multipliers (#19509 by @1cbyc)
+
+<!-- prettier-ignore -->
+```css
+/* Input */
+div {
+  border-radius: attr(data-size type(<length> +));
+}
+
+/* Prettier stable */
+div {
+  border-radius: attr(data-size type(<length> +));
+}
+
+/* Prettier main */
+div {
+  border-radius: attr(data-size type(<length>+));
+}
+```

--- a/src/language-css/print/comma-separated-value-group.js
+++ b/src/language-css/print/comma-separated-value-group.js
@@ -332,6 +332,12 @@ function printCommaSeparatedValueGroup(path, options, print) {
       continue;
     }
 
+    // CSS `attr()` type syntax embeds CSS value-definition grammar, where
+    // multipliers are suffixes rather than math operators (e.g. `<length>+`).
+    if (insideValueFunctionNode(path, "type") && isAdditionNode(iNextNode)) {
+      continue;
+    }
+
     // Space before unary minus followed by a function call.
     if (
       options.parser === "scss" &&

--- a/tests/format/css/parens/__snapshots__/format.test.js.snap
+++ b/tests/format/css/parens/__snapshots__/format.test.js.snap
@@ -271,6 +271,8 @@ a {
     20
     )
     ;
+    prop26: attr(data-size type(<length>+));
+    prop27: attr(data-size type(<length> +));
 }
 
 .bar {
@@ -434,6 +436,8 @@ a {
   prop23: attr(data-size em, 20);
   prop24: attr(data-size em, 20);
   prop25: attr(data-size em, 20);
+  prop26: attr(data-size type(<length>+));
+  prop27: attr(data-size type(<length>+));
 }
 
 .bar {

--- a/tests/format/css/parens/parens.css
+++ b/tests/format/css/parens/parens.css
@@ -234,6 +234,8 @@ a {
     20
     )
     ;
+    prop26: attr(data-size type(<length>+));
+    prop27: attr(data-size type(<length> +));
 }
 
 .bar {


### PR DESCRIPTION
## Description

Fixes #19509.

Prettier was treating the `+` multiplier in CSS `attr()` type syntax, such as `type(<length>+)`, like a math operator and printing a space before it. This keeps the multiplier attached inside `type()` and adds a regression fixture plus changelog entry.

## Test Plan

- `node .yarn/releases/yarn-4.17.0.cjs jest tests/format/css/parens --runInBand`
- `node .yarn/releases/yarn-4.17.0.cjs eslint src/language-css/print/comma-separated-value-group.js tests/format/css/parens/format.test.js --format friendly`
- `node .yarn/releases/yarn-4.17.0.cjs lint:changelog`
- `node .yarn/releases/yarn-4.17.0.cjs lint:format-test`

## Checklist

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
