### PR TITLE
Avoid redundant nullish parens in JSX ternaries

### DIFF
--- a/changelog_unreleased/javascript/19533.md
+++ b/changelog_unreleased/javascript/19533.md
@@ -1,0 +1,25 @@
+#### Avoid extra parentheses around nullish coalescing in JSX-mode ternaries (#19533 by @barry166)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+const value = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
+
+// Prettier stable
+const value = condition ? (
+  <Example /> // comment
+) : (
+  ("alpha" ?? "bravo")
+);
+
+// Prettier main
+const value = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
+```

--- a/src/language-js/parentheses/needs-parentheses.js
+++ b/src/language-js/parentheses/needs-parentheses.js
@@ -12,6 +12,7 @@ import {
   isCallOrNewExpression,
   isConditionalType,
   isIntersectionType,
+  isJsxElement,
   isMemberExpression,
   isNumericLiteral,
   isObjectExpression,
@@ -200,7 +201,12 @@ function needsParentheses(path, options) {
           return !isBinaryCastExpression(node);
 
         case "ConditionalExpression":
-          return isBinaryCastExpression(node) || isNullishCoalescing(node);
+          return (
+            isBinaryCastExpression(node) ||
+            (isNullishCoalescing(node) &&
+              (key === "test" ||
+                !conditionalExpressionChainContainsJsx(parent)))
+          );
 
         case "CallExpression":
         case "NewExpression":
@@ -955,6 +961,26 @@ function isPathInForStatementInitializer(path) {
       return true;
     }
     node = parent;
+  }
+
+  return false;
+}
+
+function conditionalExpressionChainContainsJsx(node) {
+  const conditionalExpressions = [node];
+  for (let index = 0; index < conditionalExpressions.length; index++) {
+    const conditionalExpression = conditionalExpressions[index];
+    for (const property of ["test", "consequent", "alternate"]) {
+      const child = conditionalExpression[property];
+
+      if (isJsxElement(child)) {
+        return true;
+      }
+
+      if (child.type === "ConditionalExpression") {
+        conditionalExpressions.push(child);
+      }
+    }
   }
 
   return false;

--- a/tests/format/jsx/jsx/__snapshots__/format.test.js.snap
+++ b/tests/format/jsx/jsx/__snapshots__/format.test.js.snap
@@ -1510,6 +1510,13 @@ cable ? (
 foo ? <span>loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong jsx</span> :
 undefined
 
+// #19533
+const value = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
+
 =====================================output=====================================
 // There are two ways to print ConditionalExpressions: "normal mode" and
 // "JSX mode". This is normal mode (when breaking):
@@ -1673,6 +1680,13 @@ foo ? (
   </span>
 ) : undefined;
 
+// #19533
+const value = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
+
 ================================================================================
 `;
 
@@ -1825,6 +1839,13 @@ cable ? (
 // #3552
 foo ? <span>loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong jsx</span> :
 undefined
+
+// #19533
+const value = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
 
 =====================================output=====================================
 // There are two ways to print ConditionalExpressions: "normal mode" and
@@ -1989,6 +2010,13 @@ foo ? (
   </span>
 ) : undefined;
 
+// #19533
+const value = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
+
 ================================================================================
 `;
 
@@ -2141,6 +2169,13 @@ cable ? (
 // #3552
 foo ? <span>loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong jsx</span> :
 undefined
+
+// #19533
+const value = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
 
 =====================================output=====================================
 // There are two ways to print ConditionalExpressions: "normal mode" and
@@ -2305,6 +2340,13 @@ foo ? (
   </span>
 ) : undefined;
 
+// #19533
+const value = condition ? (
+  <Example /> // comment
+) : (
+  'alpha' ?? 'bravo'
+);
+
 ================================================================================
 `;
 
@@ -2457,6 +2499,13 @@ cable ? (
 // #3552
 foo ? <span>loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong jsx</span> :
 undefined
+
+// #19533
+const value = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
 
 =====================================output=====================================
 // There are two ways to print ConditionalExpressions: "normal mode" and
@@ -2620,6 +2669,13 @@ foo ? (
     loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong jsx
   </span>
 ) : undefined;
+
+// #19533
+const value = condition ? (
+  <Example /> // comment
+) : (
+  'alpha' ?? 'bravo'
+);
 
 ================================================================================
 `;

--- a/tests/format/jsx/jsx/conditional-expression.js
+++ b/tests/format/jsx/jsx/conditional-expression.js
@@ -140,3 +140,10 @@ cable ? (
 // #3552
 foo ? <span>loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong jsx</span> :
 undefined
+
+// #19533
+const value = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);


### PR DESCRIPTION
## Description

Fixes #19533.

This avoids adding a second set of parentheses around nullish coalescing expressions when JSX-mode ternary formatting already wraps a broken branch.

AI-assisted: prepared with Codex and manually reviewed before submission.

## Tests

- `node .yarn/releases/yarn-4.17.0.cjs jest tests/format/jsx/jsx/format.test.js tests/format/js/nullish-coalescing/format.test.js --runInBand`
- `node .yarn/releases/yarn-4.17.0.cjs lint:eslint src/language-js/parentheses/needs-parentheses.js tests/format/jsx/jsx/format.test.js`
- `node .yarn/releases/yarn-4.17.0.cjs lint:changelog`
- `node .yarn/releases/yarn-4.17.0.cjs prettier src/language-js/parentheses/needs-parentheses.js tests/format/jsx/jsx/conditional-expression.js tests/format/jsx/jsx/__snapshots__/format.test.js.snap changelog_unreleased/javascript/19533.md --check`
- `git diff --check`

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
