### PR TITLE
fix(utilities): use Unicode property escapes for combining marks in getStringWidth (#19535)

### DIFF
--- a/src/utilities/get-string-width.js
+++ b/src/utilities/get-string-width.js
@@ -8,6 +8,7 @@ import {
 import { isNarrowEmojiCharacter } from "narrow-emojis";
 
 const notAsciiRegex = /[^\x20-\x7F]/;
+const combiningMarksRegex = /[\p{Mn}\p{Me}]/u;
 
 // Similar to https://github.com/sindresorhus/string-width
 // We don't strip ansi, always treat ambiguous width characters as having narrow width.
@@ -43,7 +44,7 @@ function getStringWidth(text) {
     }
 
     // Ignore combining characters
-    if (codePoint >= 0x300 && codePoint <= 0x36f) {
+    if (combiningMarksRegex.test(character)) {
       continue;
     }
 


### PR DESCRIPTION
Fixes #19535.

### What problem does this PR solve?
Previously, `getStringWidth` in `src/utilities/get-string-width.js` was hardcoded to only ignore combining diacritical marks in the basic Latin block (`\u0300..\u036F`). Consequently, non-spacing combining marks from other scripts (such as Tibetan subjoined letters like `U+0FB3`, Arabic, or Devanagari) were counted as visible columns, inflating calculated string widths and causing Prettier to force unwanted line wraps when formatted text actually fit within `printWidth`.

### What changes did you make?
Replaced the hardcoded hex range check `codePoint >= 0x300 && codePoint <= 0x36f` with the stateless ES2018 Unicode Property Escape `/[\p{Mn}\p{Me}]/u`. This ensures that all Unicode Nonspacing Marks (`\p{Mn}`) and Enclosing Marks (`\p{Me}`) across all world scripts are correctly evaluated as 0-width columns.

### Verification
Verified against Tibetan test string from #19535 (`"ཟླ་1_ཟླ་2_ཟླ་3..."`):
- Before: evaluated width = `62`
- After: evaluated width = `50` (12 subjoined marks `U+0FB3` correctly evaluated as 0-width).
