### PR TITLE
Keep parentheses around object expressions starting a superClass chain

### DIFF
--- a/changelog_unreleased/javascript/19539.md
+++ b/changelog_unreleased/javascript/19539.md
@@ -1,0 +1,13 @@
+#### Keep parentheses around object expressions starting a superClass chain (#19539 by @MahinAnowar)
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+class A extends ({}).Foo {}
+
+// Prettier stable
+class A extends {}.Foo {}
+
+// Prettier main
+class A extends ({}).Foo {}
+```

--- a/src/language-js/parentheses/needs-parentheses.js
+++ b/src/language-js/parentheses/needs-parentheses.js
@@ -20,6 +20,7 @@ import {
 } from "../utilities/node-types.js";
 import { shouldFlatten } from "../utilities/should-flatten.js";
 import { startsWithNoLookaheadToken } from "../utilities/starts-with-no-lookahead-token.js";
+import { stripChainElementWrappers } from "../utilities/strip-chain-element-wrappers.js";
 import { shouldAddParenthesesToChainElement } from "./chain-expression.js";
 import { shouldAddParenthesesToIdentifier } from "./identifier.js";
 import { parentNeedsParentheses } from "./parent-needs-parentheses.js";
@@ -71,6 +72,28 @@ function needsParentheses(path, options) {
       expression &&
       startsWithNoLookaheadToken(
         expression,
+        (leftmostNode) => leftmostNode === node,
+      )
+    ) {
+      return true;
+    }
+  }
+
+  if (node.type === "ObjectExpression") {
+    // `class A extends ({}).Foo {}` — without parentheses the leading `{`
+    // reads as the class body and some parsers reject the output. When the
+    // object (modulo chain element wrappers) is the entire `superClass`, the
+    // `ClassDeclaration` check in `parent-needs-parentheses.js` already
+    // parenthesizes it.
+    const superClass = path.findAncestor(
+      (node) =>
+        node.type === "ClassDeclaration" || node.type === "ClassExpression",
+    )?.superClass;
+    if (
+      superClass &&
+      stripChainElementWrappers(superClass) !== node &&
+      startsWithNoLookaheadToken(
+        superClass,
         (leftmostNode) => leftmostNode === node,
       )
     ) {

--- a/tests/format/js/class-extends/__snapshots__/format.test.js.snap
+++ b/tests/format/js/class-extends/__snapshots__/format.test.js.snap
@@ -127,6 +127,12 @@ function* f2() {
 
 x = class extends (++b) {}
 
+// "MemberExpression" chains starting with "ObjectExpression" (#18653)
+class a18 extends ({}).Foo {}
+class a19 extends ({}.Foo) {}
+class a20 extends ({}).Foo.Bar {}
+class a21 extends ({}.Foo()) {}
+
 =====================================output=====================================
 // "ArrowFunctionExpression"
 class a1 extends (() => {}) {}
@@ -185,6 +191,12 @@ function* f2() {
 }
 
 x = class extends (++b) {};
+
+// "MemberExpression" chains starting with "ObjectExpression" (#18653)
+class a18 extends ({}).Foo {}
+class a19 extends ({}).Foo {}
+class a20 extends ({}).Foo.Bar {}
+class a21 extends ({}).Foo() {}
 
 ================================================================================
 `;

--- a/tests/format/js/class-extends/extends.js
+++ b/tests/format/js/class-extends/extends.js
@@ -55,3 +55,9 @@ function* f2() {
 }
 
 x = class extends (++b) {}
+
+// "MemberExpression" chains starting with "ObjectExpression" (#18653)
+class a18 extends ({}).Foo {}
+class a19 extends ({}.Foo) {}
+class a20 extends ({}).Foo.Bar {}
+class a21 extends ({}.Foo()) {}


### PR DESCRIPTION
## Description

Fixes #18653

`class A extends ({}).Foo {}` lost its parentheses and printed as `class A extends {}.Foo {}` — output that TypeScript refuses to re-parse (the leading `{` reads as the class body) and that other parsers interpret confusingly.

The `ClassDeclaration`/`ClassExpression` check in `parent-needs-parentheses.js` already parenthesizes a `superClass` that *is* an `ObjectExpression` (modulo chain element wrappers), but not one that merely *starts with* an object at the leftmost position of a member/call chain.

This adds a check in `needs-parentheses.js` mirroring the existing `ExpressionStatement` leading-`{` ambiguity handling: an `ObjectExpression` that is the leftmost node (via `startsWithNoLookaheadToken`) of a class's `superClass` keeps its parentheses. A `stripChainElementWrappers(superClass) !== node` guard prevents double parentheses where the existing superClass rule already applies (e.g. `class a extends ({}!) {}` still prints single parens).

Output matches the first expected form from the issue:

```tsx
// Input
class A extends ({}).Foo {}
// Prettier stable
class A extends {}.Foo {}   // SyntaxError when re-parsed
// Prettier this PR
class A extends ({}).Foo {}
```

Verified idempotent on `babel`, `flow`, and `typescript` parsers; the full format suite passes (12,147 snapshots), and the new fixtures fail without the source change.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
