### PR TITLE
Avoid extra parens for nullish JSX ternary branches

### DIFF
--- a/changelog_unreleased/javascript/19563.md
+++ b/changelog_unreleased/javascript/19563.md
@@ -1,0 +1,25 @@
+#### Avoid extra parentheses for nullish coalescing in JSX ternaries (#19563 by @sjh9714)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+const value = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
+
+// Prettier stable
+const value = condition ? (
+  <Example /> // comment
+) : (
+  ("alpha" ?? "bravo")
+);
+
+// Prettier main
+const value = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
+```

--- a/src/language-js/print/index.js
+++ b/src/language-js/print/index.js
@@ -83,7 +83,12 @@ function print(path, options, print, args) {
       ? printDecorators(path, options, print)
       : "";
 
-  const needsParens = needsParentheses(path, options);
+  const needsParens =
+    args?.shouldOmitJsxModeConditionalBranchParens &&
+    node.type === "LogicalExpression" &&
+    node.operator === "??"
+      ? false
+      : needsParentheses(path, options);
 
   if (!decoratorsDoc && !needsParens) {
     return doc;

--- a/src/language-js/print/ternary-old.js
+++ b/src/language-js/print/ternary-old.js
@@ -14,6 +14,7 @@ import {
   isJsxElement,
   isMemberExpression,
 } from "../utilities/node-types.js";
+import { isNullishCoalescing } from "../utilities/is-nullish-coalescing.js";
 
 /**
  * @import {Doc} from "../../document/index.js"
@@ -259,15 +260,26 @@ function printTernaryOld(path, options, print) {
       (node.type === "Literal" && node.value === null) ||
       (node.type === "Identifier" && node.name === "undefined");
 
+    const printJsxModeBranch = (nodePropertyName) => {
+      const branchNode = node[nodePropertyName];
+      if (!isNullishCoalescing(branchNode)) {
+        return print(nodePropertyName);
+      }
+
+      return print(nodePropertyName, {
+        shouldOmitJsxModeConditionalBranchParens: true,
+      });
+    };
+
     parts.push(
       " ? ",
       isNil(consequentNode)
         ? print(consequentNodePropertyName)
-        : wrap(print(consequentNodePropertyName)),
+        : wrap(printJsxModeBranch(consequentNodePropertyName)),
       " : ",
       alternateNode.type === node.type || isNil(alternateNode)
         ? print(alternateNodePropertyName)
-        : wrap(print(alternateNodePropertyName)),
+        : wrap(printJsxModeBranch(alternateNodePropertyName)),
     );
   } else {
     /*

--- a/tests/format/jsx/jsx/__snapshots__/format.test.js.snap
+++ b/tests/format/jsx/jsx/__snapshots__/format.test.js.snap
@@ -1446,6 +1446,13 @@ jsxModeFromElementBreaking ? (
   </div>
 );
 
+// #19533
+const nullishInJsxModeAlternate = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
+
 // This chain of ConditionalExpressions prints in JSX mode because the parent of
 // the outermost ConditionalExpression is a JSXExpressionContainer. It is
 // non-breaking.
@@ -1594,6 +1601,13 @@ jsxModeFromElementBreaking ? (
       thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo
     </span>
   </div>
+);
+
+// #19533
+const nullishInJsxModeAlternate = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
 );
 
 // This chain of ConditionalExpressions prints in JSX mode because the parent of
@@ -1762,6 +1776,13 @@ jsxModeFromElementBreaking ? (
   </div>
 );
 
+// #19533
+const nullishInJsxModeAlternate = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
+
 // This chain of ConditionalExpressions prints in JSX mode because the parent of
 // the outermost ConditionalExpression is a JSXExpressionContainer. It is
 // non-breaking.
@@ -1910,6 +1931,13 @@ jsxModeFromElementBreaking ? (
       thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo
     </span>
   </div>
+);
+
+// #19533
+const nullishInJsxModeAlternate = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
 );
 
 // This chain of ConditionalExpressions prints in JSX mode because the parent of
@@ -2078,6 +2106,13 @@ jsxModeFromElementBreaking ? (
   </div>
 );
 
+// #19533
+const nullishInJsxModeAlternate = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
+
 // This chain of ConditionalExpressions prints in JSX mode because the parent of
 // the outermost ConditionalExpression is a JSXExpressionContainer. It is
 // non-breaking.
@@ -2226,6 +2261,13 @@ jsxModeFromElementBreaking ? (
       thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo
     </span>
   </div>
+);
+
+// #19533
+const nullishInJsxModeAlternate = condition ? (
+  <Example /> // comment
+) : (
+  'alpha' ?? 'bravo'
 );
 
 // This chain of ConditionalExpressions prints in JSX mode because the parent of
@@ -2394,6 +2436,13 @@ jsxModeFromElementBreaking ? (
   </div>
 );
 
+// #19533
+const nullishInJsxModeAlternate = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
+
 // This chain of ConditionalExpressions prints in JSX mode because the parent of
 // the outermost ConditionalExpression is a JSXExpressionContainer. It is
 // non-breaking.
@@ -2542,6 +2591,13 @@ jsxModeFromElementBreaking ? (
       thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo
     </span>
   </div>
+);
+
+// #19533
+const nullishInJsxModeAlternate = condition ? (
+  <Example /> // comment
+) : (
+  'alpha' ?? 'bravo'
 );
 
 // This chain of ConditionalExpressions prints in JSX mode because the parent of

--- a/tests/format/jsx/jsx/conditional-expression.js
+++ b/tests/format/jsx/jsx/conditional-expression.js
@@ -77,6 +77,13 @@ jsxModeFromElementBreaking ? (
   </div>
 );
 
+// #19533
+const nullishInJsxModeAlternate = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
+
 // This chain of ConditionalExpressions prints in JSX mode because the parent of
 // the outermost ConditionalExpression is a JSXExpressionContainer. It is
 // non-breaking.


### PR DESCRIPTION
## Description

Fixes #19533.

JSX-mode ternaries already wrap non-nil branches in parentheses when they break. This avoids adding a second, inner pair around a nullish coalescing branch by letting that JSX branch wrapper own the parentheses.

Testing:

- `yarn install --immutable`
- `node bin/prettier.cjs /tmp/prettier-19533.jsx --parser babel --no-config`
- `yarn test tests/format/jsx/jsx -u`
- `yarn test tests/format/jsx/jsx`
- `node bin/prettier.cjs src/language-js/print/index.js src/language-js/print/ternary-old.js tests/format/jsx/jsx/conditional-expression.js changelog_unreleased/TEMPLATE.md --check --no-config`
- `git diff --check`

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
