### PR TITLE
Preserving comments' `placement` property

### DIFF
--- a/changelog_unreleased/misc/19567.md
+++ b/changelog_unreleased/misc/19567.md
@@ -1,29 +1,3 @@
-<!--
-
-1. Choose a folder based on which language your PR is for.
-
-   - For JavaScript, choose `javascript/` etc.
-   - For TypeScript specific syntax, choose `typescript/`.
-   - If your PR applies to multiple languages, such as TypeScript/Flow, choose one folder and mention which languages it applies to.
-
-2. In your chosen folder, create a file with your PR number: `XXXX.md`. For example: `typescript/6728.md`.
-
-3. Copy the content below and paste it in your new file.
-
-4. Fill in a title, the PR number and your user name.
-
-5. Optionally write a description. Many times it’s enough with just sample code.
-
-6. Change ```jsx to your language. For example, ```yaml.
-
-7. Change the `// Input` and `// Prettier` comments to the comment syntax of your language. For example, `# Input`.
-
-8. Choose some nice input example code. Paste it along with the output before and after your PR.
-
--->
-
 #### preserving comments' `placement` property (#19567 by @Janther)
-
-<!-- Optional description if it makes sense. -->
 
 `comment.placement` is now available within the `print` function. It was wrongfully deleted at `prettier@3.9.0` release.

--- a/changelog_unreleased/misc/19567.md
+++ b/changelog_unreleased/misc/19567.md
@@ -1,3 +1,3 @@
-#### preserving comments' `placement` property (#19567 by @Janther)
+#### Preserving comments' `placement` property (#19567 by @Janther)
 
-`comment.placement` is now available within the `print` function. It was wrongfully deleted at `prettier@3.9.0` release.
+Prettier@3.9.0 deleted an undocumented property on comments, which was already used by plugins, `comment.placement` is now available again after comment attach.

--- a/changelog_unreleased/misc/19567.md
+++ b/changelog_unreleased/misc/19567.md
@@ -1,0 +1,29 @@
+<!--
+
+1. Choose a folder based on which language your PR is for.
+
+   - For JavaScript, choose `javascript/` etc.
+   - For TypeScript specific syntax, choose `typescript/`.
+   - If your PR applies to multiple languages, such as TypeScript/Flow, choose one folder and mention which languages it applies to.
+
+2. In your chosen folder, create a file with your PR number: `XXXX.md`. For example: `typescript/6728.md`.
+
+3. Copy the content below and paste it in your new file.
+
+4. Fill in a title, the PR number and your user name.
+
+5. Optionally write a description. Many times it’s enough with just sample code.
+
+6. Change ```jsx to your language. For example, ```yaml.
+
+7. Change the `// Input` and `// Prettier` comments to the comment syntax of your language. For example, `# Input`.
+
+8. Choose some nice input example code. Paste it along with the output before and after your PR.
+
+-->
+
+#### preserving comments' `placement` property (#19567 by @Janther)
+
+<!-- Optional description if it makes sense. -->
+
+`comment.placement` is now available within the `print` function. It was wrongfully deleted at `prettier@3.9.0` release.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -522,7 +522,7 @@ function ownLine(comment, text, options, ast, isLastComment) {
 }
 ```
 
-Nodes with comments are expected to have a `comments` property containing an array of comments. Each comment is expected to have the following properties: `leading`, `trailing`, `printed`.
+Nodes with comments are expected to have a `comments` property containing an array of comments. Each comment is expected to have the following properties: `leading`, `trailing`, `placement`, and `printed`.
 
 <!-- TODO: add a note that this might change in the future -->
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -522,7 +522,7 @@ function ownLine(comment, text, options, ast, isLastComment) {
 }
 ```
 
-Nodes with comments are expected to have a `comments` property containing an array of comments. Each comment is expected to have the following properties: `leading`, `trailing`, `placement`, and `printed`.
+Nodes with comments are expected to have a `comments` property containing an array of comments. Each comment is expected to have the following properties: `leading`, `trailing`, `printed`.
 
 <!-- TODO: add a note that this might change in the future -->
 

--- a/src/main/comments/attach.js
+++ b/src/main/comments/attach.js
@@ -256,7 +256,6 @@ function attachComments(ast, options) {
       delete comment.precedingNode;
       delete comment.enclosingNode;
       delete comment.followingNode;
-      delete comment.placement;
     }
   }
 }

--- a/src/main/comments/attach.js
+++ b/src/main/comments/attach.js
@@ -174,11 +174,11 @@ function attachComments(ast, options) {
     }
 
     if (attachPropertiesToComment) {
-      comment.placement = placement;
       comment.enclosingNode = enclosingNode;
       comment.precedingNode = precedingNode;
       comment.followingNode = followingNode;
     }
+    comment.placement = placement;
 
     if (placement === "ownLine") {
       // If a comment exists on its own line, prefer a leading comment.

--- a/src/main/comments/attach.js
+++ b/src/main/comments/attach.js
@@ -256,6 +256,10 @@ function attachComments(ast, options) {
       delete comment.precedingNode;
       delete comment.enclosingNode;
       delete comment.followingNode;
+
+      // The `placement` property already used by plugins, can't delete
+      // https://github.com/prettier-solidity/prettier-plugin-solidity/blob/6986134753d72095bde41fe8e9a3c795830282ea/src/slang-nodes/IfStatement.ts#L56
+      // https://github.com/dangmai/prettier-plugin-apex/blob/ff35044e53e0ba30423e1f2030161d096e99ae99/packages/prettier-plugin-apex/src/printer.ts#L251
     }
   }
 }

--- a/tests/integration/__tests__/__snapshots__/debug-print-comments.js.snap
+++ b/tests/integration/__tests__/__snapshots__/debug-print-comments.js.snap
@@ -12,6 +12,7 @@ exports[`prints information for debugging comment attachment with --debug-print-
       "start": { "line": 1, "column": 0, "index": 0 },
       "end": { "line": 1, "column": 7, "index": 7 }
     },
+    "placement": "endOfLine",
     "leading": true,
     "trailing": false,
     "nodeDescription": "ExpressionStatement"
@@ -25,6 +26,7 @@ exports[`prints information for debugging comment attachment with --debug-print-
       "start": { "line": 2, "column": 16, "index": 24 },
       "end": { "line": 2, "column": 23, "index": 31 }
     },
+    "placement": "remaining",
     "leading": false,
     "trailing": true,
     "nodeDescription": "Identifier foo"
@@ -38,6 +40,7 @@ exports[`prints information for debugging comment attachment with --debug-print-
       "start": { "line": 2, "column": 26, "index": 34 },
       "end": { "line": 2, "column": 30, "index": 38 }
     },
+    "placement": "remaining",
     "leading": false,
     "trailing": true,
     "nodeDescription": "ExpressionStatement"


### PR DESCRIPTION
<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

Fixes prettier/prettier#19515.

Avoid deleting `comment.placement` since it might be used by plugins.
Updated the documentation to reflect this change.
Updated a snapshot that conveniently checked this particular property so no need for further tests to be added.

<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [X] I’ve added tests to confirm my change works.
- [X] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [X] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [X] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.
