### PR TITLE
Ignore dangling comments when checking type parameter comments

### DIFF
--- a/changelog_unreleased/typescript/19572.md
+++ b/changelog_unreleased/typescript/19572.md
@@ -1,0 +1,24 @@
+#### Ignore comments inside mapped type when checking type parameter comments (#19572 by @fisker)
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+foo<{
+  // comment
+  [key in keyof Foo]: number
+}>();
+
+// Prettier stable
+foo<
+  {
+    // comment
+    [key in keyof Foo]: number;
+  }
+>();
+
+// Prettier main
+foo<{
+  // comment
+  [key in keyof Foo]: number;
+}>();
+```

--- a/src/language-js/print/type-parameters.js
+++ b/src/language-js/print/type-parameters.js
@@ -11,7 +11,12 @@ import {
 import { printDanglingComments } from "../../main/comments/print.js";
 import hasNewline from "../../utilities/has-newline.js";
 import { locEnd } from "../location/index.js";
-import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
+import { isLineComment } from "../utilities/comment-types.js";
+import {
+  CommentCheckFlags,
+  getComments,
+  hasComment,
+} from "../utilities/comments.js";
 import { getFunctionParameters } from "../utilities/function-parameters.js";
 import { isObjectType } from "../utilities/node-types.js";
 import { isTestCall } from "../utilities/test-libraries.js";
@@ -83,15 +88,19 @@ function printTypeParameters(path, options, print, paramsKey) {
         (parameters.length === 1 &&
           (parameters[0].type === "NullableTypeAnnotation" ||
             shouldHugType(parameters[0])))) &&
-      !parameters.some(
-        (node) =>
-          hasComment(node, CommentCheckFlags.Line) ||
-          // This condition base on existing one in class-body.js
-          // It is not really correct, but we don't have a way to check how comments are printed
-          hasComment(node, CommentCheckFlags.Last, (comment) =>
-            hasNewline(options.originalText, locEnd(comment)),
-          ),
-      ));
+      !parameters.some((node) => {
+        const comments = getComments(
+          node,
+          (comment) => comment.leading || comment.trailing,
+        );
+        return (
+          comments.length > 0 &&
+          (comments.some((comment) => isLineComment(comment)) ||
+            // This condition base on existing one in class-body.js
+            // It is not really correct, but we don't have a way to check how comments are printed
+            hasNewline(options.originalText, locEnd(comments.at(-1))))
+        );
+      }));
 
   if (shouldInline) {
     return [

--- a/tests/format/typescript/type-parameters-arguments/19505.ts
+++ b/tests/format/typescript/type-parameters-arguments/19505.ts
@@ -15,3 +15,11 @@ createObject<
     }
 // comment
 >()
+
+foo<{
+  // comment
+}>();
+
+foo<[
+  // comment
+]>();

--- a/tests/format/typescript/type-parameters-arguments/19505.ts
+++ b/tests/format/typescript/type-parameters-arguments/19505.ts
@@ -1,17 +1,17 @@
 createObject<{
         // dangling comment
         [key in keyof Function]: TypeInfo | null
-    }>
+    }>()
 
 createObject<
 // comment
 {
         [key in keyof Function]: TypeInfo | null
-    }>
+    }>()
 
 createObject<
 {
         [key in keyof Function]: TypeInfo | null
     }
 // comment
->
+>()

--- a/tests/format/typescript/type-parameters-arguments/19505.ts
+++ b/tests/format/typescript/type-parameters-arguments/19505.ts
@@ -1,0 +1,17 @@
+createObject<{
+        // dangling comment
+        [key in keyof Function]: TypeInfo | null
+    }>
+
+createObject<
+// comment
+{
+        [key in keyof Function]: TypeInfo | null
+    }>
+
+createObject<
+{
+        [key in keyof Function]: TypeInfo | null
+    }
+// comment
+>

--- a/tests/format/typescript/type-parameters-arguments/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/type-parameters-arguments/__snapshots__/format.test.js.snap
@@ -130,6 +130,52 @@ foo</* Comment */ Type>(/* Comment */ value);
 ================================================================================
 `;
 
+exports[`19505.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+createObject<{
+        // dangling comment
+        [key in keyof Function]: TypeInfo | null
+    }>
+
+createObject<
+// comment
+{
+        [key in keyof Function]: TypeInfo | null
+    }>
+
+createObject<
+{
+        [key in keyof Function]: TypeInfo | null
+    }
+// comment
+>
+
+=====================================output=====================================
+createObject<{
+  // dangling comment
+  [key in keyof Function]: TypeInfo | null;
+}>;
+
+createObject<
+  // comment
+  {
+    [key in keyof Function]: TypeInfo | null;
+  }
+>;
+
+createObject<
+  {
+    [key in keyof Function]: TypeInfo | null;
+  }
+  // comment
+>;
+
+================================================================================
+`;
+
 exports[`class-method.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/type-parameters-arguments/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/type-parameters-arguments/__snapshots__/format.test.js.snap
@@ -138,40 +138,40 @@ parsers: ["typescript"]
 createObject<{
         // dangling comment
         [key in keyof Function]: TypeInfo | null
-    }>
+    }>()
 
 createObject<
 // comment
 {
         [key in keyof Function]: TypeInfo | null
-    }>
+    }>()
 
 createObject<
 {
         [key in keyof Function]: TypeInfo | null
     }
 // comment
->
+>()
 
 =====================================output=====================================
 createObject<{
   // dangling comment
   [key in keyof Function]: TypeInfo | null;
-}>;
+}>();
 
 createObject<
   // comment
   {
     [key in keyof Function]: TypeInfo | null;
   }
->;
+>();
 
 createObject<
   {
     [key in keyof Function]: TypeInfo | null;
   }
   // comment
->;
+>();
 
 ================================================================================
 `;

--- a/tests/format/typescript/type-parameters-arguments/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/type-parameters-arguments/__snapshots__/format.test.js.snap
@@ -153,6 +153,14 @@ createObject<
 // comment
 >()
 
+foo<{
+  // comment
+}>();
+
+foo<[
+  // comment
+]>();
+
 =====================================output=====================================
 createObject<{
   // dangling comment
@@ -171,6 +179,16 @@ createObject<
     [key in keyof Function]: TypeInfo | null;
   }
   // comment
+>();
+
+foo<{
+  // comment
+}>();
+
+foo<
+  [
+    // comment
+  ]
 >();
 
 ================================================================================


### PR DESCRIPTION
<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

<!-- Please provide a brief summary of your changes -->

Fixes #19505

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.
