### PR TITLE
Fix embedded template literal interpolation idempotency

### DIFF
--- a/changelog_unreleased/javascript/19580.md
+++ b/changelog_unreleased/javascript/19580.md
@@ -1,0 +1,27 @@
+#### Fix non-idempotent formatting of embedded template interpolations ([#19580] by @ychampion)
+
+Prettier no longer needs a second format pass to settle the indentation of multiline JavaScript expressions inside embedded template literals.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+const a = html`
+          ${{
+              c: y,
+          }}
+`;
+
+// Prettier stable
+const a = html`
+  ${{
+              c: y,
+          }}
+`;
+
+// Prettier main
+const a = html`
+  ${{
+    c: y,
+  }}
+`;
+```

--- a/src/language-js/embed/css.js
+++ b/src/language-js/embed/css.js
@@ -26,7 +26,9 @@ async function printEmbedCss(textToDoc, print, path, options) {
     text += raw;
   }
   const quasisDoc = await textToDoc(text, { parser: "scss" });
-  const expressionDocs = printTemplateExpressions(path, options, print);
+  const expressionDocs = printTemplateExpressions(path, options, print, {
+    isEmbeddedLanguage: true,
+  });
   const newDoc = replacePlaceholders(quasisDoc, expressionDocs);
   /* c8 ignore next 3 */
   if (!newDoc) {

--- a/src/language-js/embed/graphql.js
+++ b/src/language-js/embed/graphql.js
@@ -10,7 +10,9 @@ async function printEmbedGraphQL(textToDoc, print, path, options) {
 
   const numQuasis = node.quasis.length;
 
-  const expressionDocs = printTemplateExpressions(path, options, print);
+  const expressionDocs = printTemplateExpressions(path, options, print, {
+    isEmbeddedLanguage: true,
+  });
   const parts = [];
 
   for (let i = 0; i < numQuasis; i++) {

--- a/src/language-js/embed/html.js
+++ b/src/language-js/embed/html.js
@@ -30,7 +30,9 @@ async function printEmbedHtmlLike(parser, textToDoc, print, path, options) {
     )
     .join("");
 
-  const expressionDocs = printTemplateExpressions(path, options, print);
+  const expressionDocs = printTemplateExpressions(path, options, print, {
+    isEmbeddedLanguage: true,
+  });
 
   const placeholderRegex = new RegExp(
     composePlaceholder(String.raw`(\d+)`),

--- a/src/language-js/print/template-literal.js
+++ b/src/language-js/print/template-literal.js
@@ -203,7 +203,12 @@ function getTemplateLiteralExpressionIndent(path, options) {
 - `TemplateLiteral`
 - `TSTemplateLiteralType` (TypeScript)
 */
-function printTemplateExpression(path, options, print) {
+function printTemplateExpression(
+  path,
+  options,
+  print,
+  { isEmbeddedLanguage = false } = {},
+) {
   const { node, index } = path;
   let expressionDoc = print();
 
@@ -268,17 +273,19 @@ function printTemplateExpression(path, options, print) {
   if (options.__inJestEach) {
     indentSize = Math.max(indentSize, options.tabWidth);
   }
-  expressionDoc =
-    indentSize === 0 && previousQuasiText.endsWith("\n")
-      ? align(Number.NEGATIVE_INFINITY, expressionDoc)
-      : addAlignmentToDoc(expressionDoc, indentSize, options.tabWidth);
+  if (!isEmbeddedLanguage) {
+    expressionDoc =
+      indentSize === 0 && previousQuasiText.endsWith("\n")
+        ? align(Number.NEGATIVE_INFINITY, expressionDoc)
+        : addAlignmentToDoc(expressionDoc, indentSize, options.tabWidth);
+  }
 
   return group(["${", expressionDoc, lineSuffixBoundary, "}"]);
 }
 
-function printTemplateExpressions(path, options, print) {
+function printTemplateExpressions(path, options, print, args) {
   return path.map(
-    () => printTemplateExpression(path, options, print),
+    () => printTemplateExpression(path, options, print, args),
     path.node.type === "TSTemplateLiteralType" ? "types" : "expressions",
   );
 }

--- a/tests/format/js/multiparser-html/__snapshots__/format.test.js.snap
+++ b/tests/format/js/multiparser-html/__snapshots__/format.test.js.snap
@@ -39,6 +39,12 @@ setFoo(
   secondArgument
 );
 
+const idempotentInterpolation = html\`
+          \${{
+              c: y,
+          }}
+\`;
+
 // Attribute quotes
 a = /* HTML */ \`<div
     double-quoted="\${foo}"
@@ -99,6 +105,12 @@ setFoo(
   secondArgument,
 );
 
+const idempotentInterpolation = html\`
+  \${{
+    c: y,
+  }}
+\`;
+
 // Attribute quotes
 a = /* HTML */ \`
   <div double-quoted="\${foo}" single-quoted="\${foo}" unquoted=\${foo}></div>
@@ -148,6 +160,12 @@ setFoo(
   secondArgument
 );
 
+const idempotentInterpolation = html\`
+          \${{
+              c: y,
+          }}
+\`;
+
 // Attribute quotes
 a = /* HTML */ \`<div
     double-quoted="\${foo}"
@@ -193,6 +211,12 @@ setFoo(
   </div>\`,
   secondArgument,
 );
+
+const idempotentInterpolation = html\`
+  \${{
+    c: y,
+  }}
+\`;
 
 // Attribute quotes
 a = /* HTML */ \`<div

--- a/tests/format/js/multiparser-html/html-template-literals.js
+++ b/tests/format/js/multiparser-html/html-template-literals.js
@@ -31,6 +31,12 @@ setFoo(
   secondArgument
 );
 
+const idempotentInterpolation = html`
+          ${{
+              c: y,
+          }}
+`;
+
 // Attribute quotes
 a = /* HTML */ `<div
     double-quoted="${foo}"


### PR DESCRIPTION
## Description

Fixes #19518.

Avoid applying source indentation to interpolation docs before reinserting them into embedded-language template literals. The embedded formatter already reindents the surrounding template content, so using the original quasi indentation can make the first and second format passes differ.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory). (Not applicable.)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

Validation:
- `yarn install --immutable`
- `yarn test tests/format/js/multiparser-html -u`
- `yarn test tests/format/js/multiparser-html`
- `FULL_TEST=1 yarn test tests/format/js/multiparser-html`
- `yarn test tests/format/js/multiparser-css tests/format/js/multiparser-graphql`
- `FULL_TEST=1 yarn test tests/format/js/multiparser-css tests/format/js/multiparser-graphql`
- `yarn prettier --check src/language-js/embed/css.js src/language-js/embed/graphql.js src/language-js/embed/html.js src/language-js/print/template-literal.js tests/format/js/multiparser-html/html-template-literals.js tests/format/js/multiparser-html/__snapshots__/format.test.js.snap`
- `yarn eslint src/language-js/embed/css.js src/language-js/embed/graphql.js src/language-js/embed/html.js src/language-js/print/template-literal.js --format friendly`
- `yarn lint:changelog`
- `yarn prettier --check changelog_unreleased/javascript/19580.md`
- `git diff --check`