### PR TITLE
Fix Markdown escaped character reference idempotency

### DIFF
--- a/changelog_unreleased/markdown/19589.md
+++ b/changelog_unreleased/markdown/19589.md
@@ -1,0 +1,15 @@
+#### Preserve escaped semicolons in Markdown link destinations (#19589 by @paranoa233)
+
+Prettier now preserves an escaped semicolon after a character-reference-like sequence in a Markdown link destination. This prevents a second formatting pass from decoding the sequence and changing the URL.
+
+<!-- prettier-ignore -->
+```markdown
+<!-- Input -->
+[test](/hello?foo&quot\;bar)
+
+<!-- Prettier stable -->
+[test](/hello?foo&quot;bar)
+
+<!-- Prettier main -->
+[test](/hello?foo&quot\;bar)
+```

--- a/src/language-markdown/parse/parse-markdown.js
+++ b/src/language-markdown/parse/parse-markdown.js
@@ -12,6 +12,9 @@ import {
   liquidSyntax,
 } from "./micromark/micromark-extension-liquid.js";
 
+const escapedCharacterReferenceRegex =
+  /&(?:#x[\da-f]+|#\d+|[a-z][a-z\d]*)\\;/gi;
+
 let markdownParseOptions;
 function getMarkdownParseOptions() {
   return (markdownParseOptions ??= {
@@ -32,8 +35,47 @@ function getMarkdownParseOptions() {
       mathFromMarkdown(),
       wikiLinkFromMarkdown(),
       liquidFromMarkdown(),
+      preserveEscapedCharacterReferences(),
     ],
   });
+}
+
+function preserveEscapedCharacterReferences() {
+  return {
+    exit: {
+      definitionDestinationString: exitUrl,
+      resourceDestinationString: exitUrl,
+    },
+  };
+
+  /** @type {import("mdast-util-from-markdown").Handle} */
+  function exitUrl(token) {
+    let url = this.resume();
+    const rawUrl = this.sliceSerialize(token);
+    let searchIndex = 0;
+
+    for (const { 0: escapedCharacterReference } of rawUrl.matchAll(
+      escapedCharacterReferenceRegex,
+    )) {
+      const characterReference = escapedCharacterReference.slice(0, -2) + ";";
+      const index = url.indexOf(characterReference, searchIndex);
+      if (index === -1) {
+        continue;
+      }
+
+      url =
+        url.slice(0, index) +
+        escapedCharacterReference +
+        url.slice(index + characterReference.length);
+      searchIndex = index + escapedCharacterReference.length;
+    }
+
+    const node =
+      /** @type {import("mdast").Definition | import("mdast").Link | import("mdast").Image} */ (
+        this.stack.at(-1)
+      );
+    node.url = url;
+  }
 }
 
 function parseMarkdown(text) {

--- a/src/language-markdown/print/preprocess.js
+++ b/src/language-markdown/print/preprocess.js
@@ -10,7 +10,6 @@ function preprocess(ast, options) {
     ast = restoreUnescapedCharacter(ast, options);
   } else {
     ast = addRawToText(ast, options);
-    ast = restoreEscapedCharacterReferencesInUrls(ast, options);
   }
   ast = mergeContinuousTexts(ast);
   if (options.parser === "mdx") {
@@ -75,115 +74,6 @@ function addRawToText(ast, options) {
     }
     return node;
   });
-}
-
-const escapedCharacterReferenceRegex =
-  /&(?:#x[\da-f]+|#\d+|[a-z][a-z\d]*)\\;/gi;
-
-function restoreEscapedCharacterReferencesInUrls(ast, options) {
-  return mapAst(ast, (node) => {
-    if (
-      (node.type !== "link" &&
-        node.type !== "image" &&
-        node.type !== "definition") ||
-      !node.url
-    ) {
-      return node;
-    }
-
-    const rawUrl = getRawUrl(node, options.originalText);
-    if (!rawUrl) {
-      return node;
-    }
-
-    // The parser removes the backslash from `&name\;`. If we don't restore it,
-    // the next parse decodes the newly formed `&name;` character reference.
-    let { url } = node;
-    let searchIndex = 0;
-    for (const { 0: escapedCharacterReference } of rawUrl.matchAll(
-      escapedCharacterReferenceRegex,
-    )) {
-      const characterReference = escapedCharacterReference.slice(0, -2) + ";";
-      const index = url.indexOf(characterReference, searchIndex);
-      if (index === -1) {
-        continue;
-      }
-
-      url =
-        url.slice(0, index) +
-        escapedCharacterReference +
-        url.slice(index + characterReference.length);
-      searchIndex = index + escapedCharacterReference.length;
-    }
-
-    node.url = url;
-    return node;
-  });
-}
-
-function getRawUrl(node, text) {
-  const bracketRange = getBracketRange(
-    text,
-    node.position.start.offset,
-    node.position.end.offset,
-  );
-  if (!bracketRange) {
-    return;
-  }
-
-  let index = bracketRange.end + 1;
-  if (node.type === "definition") {
-    if (text[index] !== ":") {
-      return;
-    }
-  } else if (text[index] !== "(") {
-    return;
-  }
-  index++;
-
-  while (/\s/.test(text[index])) {
-    index++;
-  }
-
-  const start = index;
-  if (text[index] === "<") {
-    index++;
-    while (index < node.position.end.offset) {
-      if (text[index] === "\\") {
-        index += 2;
-      } else if (text[index] === ">") {
-        return text.slice(start + 1, index);
-      } else {
-        index++;
-      }
-    }
-    return;
-  }
-
-  let parenthesisDepth = 0;
-  while (index < node.position.end.offset) {
-    const character = text[index];
-    if (character === "\\") {
-      index += 2;
-      continue;
-    }
-    if (/\s/.test(character)) {
-      break;
-    }
-    if (node.type !== "definition") {
-      if (character === "(") {
-        parenthesisDepth++;
-      } else if (character === ")") {
-        if (parenthesisDepth === 0) {
-          break;
-        }
-        parenthesisDepth--;
-      }
-    }
-    index++;
-  }
-
-  return text.slice(start, index);
 }
 
 function mergeChildren(ast, shouldMerge, mergeNode) {
@@ -453,11 +343,6 @@ function markOriginalImageAndLinkAlt(ast, options) {
 }
 
 function getBracketContent(text, startOffset, endOffset) {
-  const bracketRange = getBracketRange(text, startOffset, endOffset);
-  return bracketRange ? text.slice(bracketRange.start, bracketRange.end) : null;
-}
-
-function getBracketRange(text, startOffset, endOffset) {
   const firstBracket = text.indexOf("[", startOffset);
 
   if (firstBracket === -1 || firstBracket >= endOffset) {
@@ -480,7 +365,7 @@ function getBracketRange(text, startOffset, endOffset) {
     } else if (char === "]") {
       depth--;
       if (depth === 0) {
-        return { start: firstBracket + 1, end: index };
+        return text.slice(firstBracket + 1, index);
       }
     }
 

--- a/src/language-markdown/print/preprocess.js
+++ b/src/language-markdown/print/preprocess.js
@@ -10,6 +10,7 @@ function preprocess(ast, options) {
     ast = restoreUnescapedCharacter(ast, options);
   } else {
     ast = addRawToText(ast, options);
+    ast = restoreEscapedCharacterReferencesInUrls(ast, options);
   }
   ast = mergeContinuousTexts(ast);
   if (options.parser === "mdx") {
@@ -74,6 +75,115 @@ function addRawToText(ast, options) {
     }
     return node;
   });
+}
+
+const escapedCharacterReferenceRegex =
+  /&(?:#x[\da-f]+|#\d+|[a-z][a-z\d]*)\\;/gi;
+
+function restoreEscapedCharacterReferencesInUrls(ast, options) {
+  return mapAst(ast, (node) => {
+    if (
+      (node.type !== "link" &&
+        node.type !== "image" &&
+        node.type !== "definition") ||
+      !node.url
+    ) {
+      return node;
+    }
+
+    const rawUrl = getRawUrl(node, options.originalText);
+    if (!rawUrl) {
+      return node;
+    }
+
+    // The parser removes the backslash from `&name\;`. If we don't restore it,
+    // the next parse decodes the newly formed `&name;` character reference.
+    let { url } = node;
+    let searchIndex = 0;
+    for (const { 0: escapedCharacterReference } of rawUrl.matchAll(
+      escapedCharacterReferenceRegex,
+    )) {
+      const characterReference = escapedCharacterReference.slice(0, -2) + ";";
+      const index = url.indexOf(characterReference, searchIndex);
+      if (index === -1) {
+        continue;
+      }
+
+      url =
+        url.slice(0, index) +
+        escapedCharacterReference +
+        url.slice(index + characterReference.length);
+      searchIndex = index + escapedCharacterReference.length;
+    }
+
+    node.url = url;
+    return node;
+  });
+}
+
+function getRawUrl(node, text) {
+  const bracketRange = getBracketRange(
+    text,
+    node.position.start.offset,
+    node.position.end.offset,
+  );
+  if (!bracketRange) {
+    return;
+  }
+
+  let index = bracketRange.end + 1;
+  if (node.type === "definition") {
+    if (text[index] !== ":") {
+      return;
+    }
+  } else if (text[index] !== "(") {
+    return;
+  }
+  index++;
+
+  while (/\s/.test(text[index])) {
+    index++;
+  }
+
+  const start = index;
+  if (text[index] === "<") {
+    index++;
+    while (index < node.position.end.offset) {
+      if (text[index] === "\\") {
+        index += 2;
+      } else if (text[index] === ">") {
+        return text.slice(start + 1, index);
+      } else {
+        index++;
+      }
+    }
+    return;
+  }
+
+  let parenthesisDepth = 0;
+  while (index < node.position.end.offset) {
+    const character = text[index];
+    if (character === "\\") {
+      index += 2;
+      continue;
+    }
+    if (/\s/.test(character)) {
+      break;
+    }
+    if (node.type !== "definition") {
+      if (character === "(") {
+        parenthesisDepth++;
+      } else if (character === ")") {
+        if (parenthesisDepth === 0) {
+          break;
+        }
+        parenthesisDepth--;
+      }
+    }
+    index++;
+  }
+
+  return text.slice(start, index);
 }
 
 function mergeChildren(ast, shouldMerge, mergeNode) {
@@ -343,6 +453,11 @@ function markOriginalImageAndLinkAlt(ast, options) {
 }
 
 function getBracketContent(text, startOffset, endOffset) {
+  const bracketRange = getBracketRange(text, startOffset, endOffset);
+  return bracketRange ? text.slice(bracketRange.start, bracketRange.end) : null;
+}
+
+function getBracketRange(text, startOffset, endOffset) {
   const firstBracket = text.indexOf("[", startOffset);
 
   if (firstBracket === -1 || firstBracket >= endOffset) {
@@ -365,7 +480,7 @@ function getBracketContent(text, startOffset, endOffset) {
     } else if (char === "]") {
       depth--;
       if (depth === 0) {
-        return text.slice(firstBracket + 1, index);
+        return { start: firstBracket + 1, end: index };
       }
     }
 

--- a/tests/format/markdown/link/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/link/__snapshots__/format.test.js.snap
@@ -129,6 +129,48 @@ proseWrap: "always"
 ================================================================================
 `;
 
+exports[`escaped-character-reference.md - {"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+proseWrap: "always"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+[named](/hello?foo=&quot\\;bar)
+
+[decimal](/hello?foo=&#34\\;bar)
+
+[hexadecimal](/hello?foo=&#x22\\;bar)
+
+[multiple](/hello?foo=&quot\\;&amp\\;bar)
+
+[angle](</hello?foo=&quot\\;bar>)
+
+![image](/hello?foo=&quot\\;bar)
+
+[definition]: /hello?foo=&quot\\;bar
+
+[&unknown\\;](/hello?foo=&unknown; "&unknown\\;")
+
+=====================================output=====================================
+[named](/hello?foo=&quot\\;bar)
+
+[decimal](/hello?foo=&#34\\;bar)
+
+[hexadecimal](/hello?foo=&#x22\\;bar)
+
+[multiple](/hello?foo=&quot\\;&amp\\;bar)
+
+[angle](/hello?foo=&quot\\;bar)
+
+![image](/hello?foo=&quot\\;bar)
+
+[definition]: /hello?foo=&quot\\;bar
+
+[&unknown\\;](/hello?foo=&unknown; "&unknown;")
+
+================================================================================
+`;
+
 exports[`long.md - {"proseWrap":"always"} format 1`] = `
 ====================================options=====================================
 parsers: ["markdown"]

--- a/tests/format/markdown/link/escaped-character-reference.md
+++ b/tests/format/markdown/link/escaped-character-reference.md
@@ -1,0 +1,15 @@
+[named](/hello?foo=&quot\;bar)
+
+[decimal](/hello?foo=&#34\;bar)
+
+[hexadecimal](/hello?foo=&#x22\;bar)
+
+[multiple](/hello?foo=&quot\;&amp\;bar)
+
+[angle](</hello?foo=&quot\;bar>)
+
+![image](/hello?foo=&quot\;bar)
+
+[definition]: /hello?foo=&quot\;bar
+
+[&unknown\;](/hello?foo=&unknown; "&unknown\;")


### PR DESCRIPTION
## Description

Fixes #19588.

Preserve backslash-escaped semicolons in character-reference-like Markdown link destinations. The Markdown parser removes the backslash from inputs such as `&quot\;`, which previously caused the first formatted output to contain `&quot;`; a second parse then decoded that as `"`, breaking idempotency.

The Markdown parser now restores these escapes while compiling resource and definition destination tokens, where both the decoded URL and the raw token text are available. Regression coverage includes named, decimal, and hexadecimal references, multiple references, angle-bracket destinations, images, and link definitions.

Validation:

- `FULL_TEST=1 yarn test tests/format/markdown/link --runInBand`
- `yarn test tests/format/markdown --runInBand`
- `yarn lint:typecheck`
- targeted ESLint, Prettier, changelog, and format-test lint checks

## Checklist

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (not applicable).
- [x] (If the change is user-facing) I’ve added my changes to a `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
