### PR TITLE
Allow import.meta in non-module <script> tags in HTML

### DIFF
--- a/changelog_unreleased/html/19590.md
+++ b/changelog_unreleased/html/19590.md
@@ -1,0 +1,21 @@
+#### Format `import.meta` correctly in non-module `<script>` tags (#19590 by @Socialpranker)
+
+Previously, a `<script>` tag without `type="module"` that contained `import.meta` was left completely unformatted, because Babel rejected `import.meta` outside of module code and Prettier silently gave up on the whole embed.
+
+<!-- prettier-ignore -->
+```html
+<!-- Input -->
+<script>
+console.log(import.meta.url)
+</script>
+
+<!-- Prettier stable -->
+<script>
+console.log(import.meta.url)
+</script>
+
+<!-- Prettier main -->
+<script>
+  console.log(import.meta.url);
+</script>
+```

--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -229,6 +229,18 @@ const allowedReasonCodesArray = [
   https://github.com/babel/babel/pull/17949
   */
   "DecoratorAbstractMethod",
+
+  /*
+  Allow `import.meta` in a non-module `<script>` embedded in HTML
+  https://github.com/prettier/prettier/issues/15999
+
+  ```html
+  <script>
+    console.log(import.meta.url);
+  </script>
+  ```
+  */
+  "ImportMetaOutsideModule",
 ];
 const allowedReasonCodes = new Set(allowedReasonCodesArray);
 

--- a/tests/format/html/script/__snapshots__/format.test.js.snap
+++ b/tests/format/html/script/__snapshots__/format.test.js.snap
@@ -49,6 +49,33 @@ alert(1)
 ================================================================================
 `;
 
+exports[`import-meta.html format 1`] = `
+====================================options=====================================
+parsers: ["html"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+<!-- https://github.com/prettier/prettier/issues/15999 -->
+<script>
+  console.log(import.meta.url)
+</script>
+
+<script type="module">
+  console.log(import.meta.url)
+</script>
+
+=====================================output=====================================
+<!-- https://github.com/prettier/prettier/issues/15999 -->
+<script>
+  console.log(import.meta.url);
+</script>
+
+<script type="module">
+  console.log(import.meta.url);
+</script>
+
+================================================================================
+`;
+
 exports[`legacy.html format 1`] = `
 ====================================options=====================================
 parsers: ["html"]

--- a/tests/format/html/script/import-meta.html
+++ b/tests/format/html/script/import-meta.html
@@ -1,0 +1,8 @@
+<!-- https://github.com/prettier/prettier/issues/15999 -->
+<script>
+  console.log(import.meta.url)
+</script>
+
+<script type="module">
+  console.log(import.meta.url)
+</script>


### PR DESCRIPTION
Prettier formats a `<script>` tag's content as sourceType "script" unless it has `type="module"`. `import.meta` inside such a script makes Babel raise `ImportMetaOutsideModule`, and since the HTML embed logic silently drops any embed that throws, the whole script block was left completely unformatted instead of showing a clear error.

`import.meta` shows up in classic scripts all the time, for example inline scripts in custom elements or code emitted by bundlers, so this isn't really invalid code Prettier needs to reject. I added `ImportMetaOutsideModule` to the existing `allowedReasonCodesArray` list in `src/language-js/parse/babel.js`, which already treats several other technically-invalid-but-safe-to-format syntax cases the same way (`DeclarationMissingInitializer`, `NonAbstractClassHasAbstractMethod`, etc). Babel's error recovery still builds a normal AST node for `import.meta`, so nothing else changes.

Added a fixture at `tests/format/html/script/import-meta.html` covering both a plain `<script>` and a `<script type="module">` with `import.meta`, and confirmed the snapshot now shows both fully formatted instead of the module-less one passing through untouched. Ran the full `tests/format/html`, `tests/format/js`, `tests/format/vue`, and `tests/format/misc` suites locally and everything passes.

Fixes #15999

Written with Claude Code; I reviewed and tested the change before submitting.