### PR TITLE
Add an example for how to force comment-only array or object to keep multiple line in blog post

### DIFF
--- a/website/blog/2026-06-27-3.9.0.md
+++ b/website/blog/2026-06-27-3.9.0.md
@@ -557,6 +557,18 @@ const array = [/* comment */];
 const object = {/* comment */};
 ```
 
+*You can use line comment to force the array and object break into multiple lines.*
+
+<!-- prettier-ignore -->
+```js
+const array = [
+  // comment
+];
+const object = {
+  // comment
+};
+```
+
 #### Fix dangling comment print in function parameters ([#18623](https://github.com/prettier/prettier/pull/18623) by [@fisker](https://github.com/fisker)) {#change-18623}
 
 <!-- prettier-ignore -->

--- a/website/blog/2026-06-27-3.9.0.md
+++ b/website/blog/2026-06-27-3.9.0.md
@@ -557,7 +557,7 @@ const array = [/* comment */];
 const object = {/* comment */};
 ```
 
-_You can use line comment to force the array and object break into multiple lines._
+_You can use line comment or multiline comment to force the array and object to break._
 
 <!-- prettier-ignore -->
 ```js
@@ -566,6 +566,16 @@ const array = [
 ];
 const object = {
   // comment
+};
+const array2 = [
+  /*
+  comment
+  */
+];
+const object2 = {
+  /*
+  comment
+  */
 };
 ```
 

--- a/website/blog/2026-06-27-3.9.0.md
+++ b/website/blog/2026-06-27-3.9.0.md
@@ -557,7 +557,7 @@ const array = [/* comment */];
 const object = {/* comment */};
 ```
 
-*You can use line comment to force the array and object break into multiple lines.*
+_You can use line comment to force the array and object break into multiple lines._
 
 <!-- prettier-ignore -->
 ```js


### PR DESCRIPTION


<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

<!-- Please provide a brief summary of your changes -->

https://deploy-preview-19605--prettier.netlify.app/blog/2026/06/27/3.9.0#change-18617

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.
