### PR TITLE
Preserve detached comments after YAML anchors

### DIFF
--- a/changelog_unreleased/yaml/10518.md
+++ b/changelog_unreleased/yaml/10518.md
@@ -1,0 +1,21 @@
+#### Preserve newlines between YAML anchors and comments (#10518 by @Sushanth012)
+
+YAML comments on a later line after an anchor are no longer moved onto the anchor's line.
+
+<!-- prettier-ignore -->
+```yaml
+# Input
+key1: &default
+
+  # This key ...
+  subkey1: value1
+
+# Prettier stable
+key1: &default # This key ...
+  subkey1: value1
+
+# Prettier main
+key1: &default
+  # This key ...
+  subkey1: value1
+```

--- a/src/language-yaml/printer-yaml.js
+++ b/src/language-yaml/printer-yaml.js
@@ -81,7 +81,13 @@ function genericPrint(path, options, print) {
   }
 
   if (tag || anchor) {
-    if (isNode(node, ["sequence", "mapping"]) && !hasMiddleComments(node)) {
+    if (
+      isNode(node, ["sequence", "mapping"]) &&
+      (!hasMiddleComments(node) ||
+        (anchor &&
+          anchor.position.end.line <
+            node.middleComments[0].position.start.line))
+    ) {
       parts.push(hardline);
     } else {
       parts.push(" ");

--- a/tests/format/yaml/mapping/__snapshots__/format.test.js.snap
+++ b/tests/format/yaml/mapping/__snapshots__/format.test.js.snap
@@ -35,12 +35,27 @@ key1: &default
 key2:
   <<: *default
 
+key3: &detached-comment
+
+  # This key has a detached comment.
+  subkey1: value1
+
+key4: &inline-comment # This key has an inline comment.
+  subkey1: value1
+
 =====================================output=====================================
 key1: &default
     subkey1: value1
 
 key2:
     <<: *default
+
+key3: &detached-comment
+    # This key has a detached comment.
+    subkey1: value1
+
+key4: &inline-comment # This key has an inline comment.
+    subkey1: value1
 
 ================================================================================
 `;
@@ -57,12 +72,27 @@ key1: &default
 key2:
   <<: *default
 
+key3: &detached-comment
+
+  # This key has a detached comment.
+  subkey1: value1
+
+key4: &inline-comment # This key has an inline comment.
+  subkey1: value1
+
 =====================================output=====================================
 key1: &default
   subkey1: value1
 
 key2:
   <<: *default
+
+key3: &detached-comment
+  # This key has a detached comment.
+  subkey1: value1
+
+key4: &inline-comment # This key has an inline comment.
+  subkey1: value1
 
 ================================================================================
 `;
@@ -82,7 +112,8 @@ key2:
   <<: *default
 
 =====================================output=====================================
-key1: &default # This key ...
+key1: &default
+    # This key ...
     subkey1: value1
 
 key2:
@@ -105,7 +136,8 @@ key2:
   <<: *default
 
 =====================================output=====================================
-key1: &default # This key ...
+key1: &default
+  # This key ...
   subkey1: value1
 
 key2:
@@ -128,7 +160,8 @@ key2:
   <<: *default
 
 =====================================output=====================================
-key1: &default # This key
+key1: &default
+    # This key
     subkey1: value1
 
 key2:
@@ -150,7 +183,8 @@ key2:
   <<: *default
 
 =====================================output=====================================
-key1: &default # This key
+key1: &default
+  # This key
   subkey1: value1
 
 key2:

--- a/tests/format/yaml/mapping/anchor.yml
+++ b/tests/format/yaml/mapping/anchor.yml
@@ -4,3 +4,11 @@ key1: &default
 
 key2:
   <<: *default
+
+key3: &detached-comment
+
+  # This key has a detached comment.
+  subkey1: value1
+
+key4: &inline-comment # This key has an inline comment.
+  subkey1: value1


### PR DESCRIPTION
## Description

Fixes #10518.

Preserve comments that originally appear on a later line after a YAML anchor instead of moving them onto the anchor line. The YAML parser attaches both inline and detached comments as middle comments, so the printer now compares source positions and uses a hard line only when the comment begins after the anchor's source line.

Compact comments written on the same line as an anchor retain their existing formatting. Regression coverage includes both detached and inline forms.

## Validation

- FULL_TEST=1 YAML mapping suite: 290 tests and 50 snapshots passed
- ESLint on the changed source file
- Prettier check on changed source, fixture, and changelog files
- Changelog lint
- Format-test lint
- git diff --check

## Checklist

- [x] I've added tests to confirm my change works.
- [x] (If changing the API or CLI) I've documented the changes I've made (not applicable).
- [x] (If the change is user-facing) I've added my changes to a changelog_unreleased entry.
- [x] I've read the contributing guidelines.
- [ ] I did not use AI to generate this PR.
- [x] I have reviewed the AI-generated content before submitting.