### PR TITLE
fix(markdown): keep escaped semicolon in link URLs to preserve idempotency

### DIFF
--- a/changelog_unreleased/markdown/19611.md
+++ b/changelog_unreleased/markdown/19611.md
@@ -1,0 +1,18 @@
+#### Preserve escaped semicolons that guard character references in Markdown link URLs (#19611 by @AysajanE)
+
+An escaped semicolon terminating an HTML character reference in a link/image URL
+(e.g. `&quot\;`) previously lost its backslash on the first format, producing a
+real entity that a second format then resolved — breaking idempotency. Prettier
+now keeps the escape so the URL round-trips.
+
+<!-- prettier-ignore -->
+```markdown
+<!-- Input -->
+[test](/hello?foo&quot\;bar)
+
+<!-- Prettier stable -->
+[test](/hello?foo&quot;bar)
+
+<!-- Prettier main -->
+[test](/hello?foo&quot\;bar)
+```

--- a/src/language-markdown/print/mdast.js
+++ b/src/language-markdown/print/mdast.js
@@ -531,11 +531,18 @@ function printUrl(url, dangerousCharOrChars = []) {
       : [dangerousCharOrChars]),
   ];
 
-  return new RegExp(
+  const printedUrl = new RegExp(
     dangerousChars.map((x) => escapeStringRegexp(x)).join("|"),
   ).test(url)
     ? `<${encodeUrl(url, "<>")}>`
     : url;
+
+  // An escaped semicolon is decoded by the parser. Escape it again when it
+  // would otherwise turn the preceding text into a character reference.
+  return printedUrl.replaceAll(
+    /&(?:#\d{1,7}|#x[0-9A-F]{1,6}|[A-Z][A-Z0-9]{1,30});/gi,
+    (reference) => String.raw`${reference.slice(0, -1)}\;`,
+  );
 }
 
 function printTitle(title, options, printSpace = true) {

--- a/tests/format/markdown/link/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/link/__snapshots__/format.test.js.snap
@@ -129,6 +129,56 @@ proseWrap: "always"
 ================================================================================
 `;
 
+exports[`escaped-entity-semicolon.md - {"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+proseWrap: "always"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+[test](/hello?foo&quot\\;bar)
+
+[test](/hello?foo&quot;bar)
+
+![image](/hello?foo&amp\\;bar)
+
+[decimal](/hello?foo&#123\\;bar)
+
+[hex-lowercase](/hello?foo&#xAB\\;bar)
+
+[hex-uppercase](/hello?foo&#XAB\\;bar)
+
+[non-entity](/hello?foo;a;b)
+
+[wrapped](</hello?foo=&quot\\;bar baz>)
+
+[reference][entity]
+
+[entity]: /hello?foo&#123\\;bar
+
+=====================================output=====================================
+[test](/hello?foo&quot\\;bar)
+
+[test](/hello?foo"bar)
+
+![image](/hello?foo&amp\\;bar)
+
+[decimal](/hello?foo&#123\\;bar)
+
+[hex-lowercase](/hello?foo&#xAB\\;bar)
+
+[hex-uppercase](/hello?foo&#XAB\\;bar)
+
+[non-entity](/hello?foo;a;b)
+
+[wrapped](</hello?foo=&quot\\;bar baz>)
+
+[reference][entity]
+
+[entity]: /hello?foo&#123\\;bar
+
+================================================================================
+`;
+
 exports[`long.md - {"proseWrap":"always"} format 1`] = `
 ====================================options=====================================
 parsers: ["markdown"]

--- a/tests/format/markdown/link/escaped-entity-semicolon.md
+++ b/tests/format/markdown/link/escaped-entity-semicolon.md
@@ -1,0 +1,19 @@
+[test](/hello?foo&quot\;bar)
+
+[test](/hello?foo&quot;bar)
+
+![image](/hello?foo&amp\;bar)
+
+[decimal](/hello?foo&#123\;bar)
+
+[hex-lowercase](/hello?foo&#xAB\;bar)
+
+[hex-uppercase](/hello?foo&#XAB\;bar)
+
+[non-entity](/hello?foo;a;b)
+
+[wrapped](</hello?foo=&quot\;bar baz>)
+
+[reference][entity]
+
+[entity]: /hello?foo&#123\;bar


### PR DESCRIPTION
Fixes #19588.

In a Markdown link/image URL, an escaped semicolon that terminates an HTML character reference (e.g. `&quot\;`) lost its backslash on the first format — producing a real entity that a second format then resolved (`&quot\;` → `&quot;` → `"`). That broke Prettier's idempotency guarantee.

`printUrl` now re-escapes a `;` that would complete a character reference (named, decimal `&#123;`, or hex `&#xAB;`), so such URLs round-trip. Only the terminating `;` of a reference-shaped sequence is escaped — a plain `;` and over-long numeric forms are left untouched.

Added `tests/format/markdown/link/escaped-entity-semicolon.md` covering named/decimal/hex references, a non-entity `;`, a `<>`-wrapped URL, and a reference definition, plus the changelog entry. The full `tests/format/markdown` suite passes with no other snapshot changes.

Note: entity-shaped names are matched lexically (by shape), not against the full HTML named-reference registry — happy to switch to a shared decoder if you'd prefer registry-only recognition.

---
Disclosure: prepared with AI assistance and reviewed by me before submitting. I ran the markdown suite in a network-isolated container and published a signed, re-runnable record: https://northset-oss.github.io/verification-pilot/. Contributor self-run — not a maintainer verification.
