### PR TITLE
Add vueIndentTemplate option to control base indentation for Vue template content

### DIFF
--- a/changelog_unreleased/vue/19224.md
+++ b/changelog_unreleased/vue/19224.md
@@ -1,0 +1,21 @@
+#### Add `vueIndentTemplate` option to control base indentation for Vue `<template>` content (#19224 by @antigravity-ai)
+
+Add `vueIndentTemplate` boolean option (default: `true`) to allow disabling base indentation of `<template>` content.
+
+<!-- prettier-ignore -->
+```vue
+<!-- Input -->
+<template>
+  <div>Hello</div>
+</template>
+
+<!-- Prettier stable / Prettier main with vueIndentTemplate: true -->
+<template>
+  <div>Hello</div>
+</template>
+
+<!-- Prettier main with vueIndentTemplate: false -->
+<template>
+<div>Hello</div>
+</template>
+```

--- a/docs/options.md
+++ b/docs/options.md
@@ -501,6 +501,21 @@ Valid options:
 | ------- | ------------------------------- | --------------------------------- |
 | `false` | `--vue-indent-script-and-style` | `vueIndentScriptAndStyle: <bool>` |
 
+## Vue files template tags indentation
+
+_First available in v3.10.0_
+
+Whether or not to indent the code inside `<template>` tags in Vue files.
+
+Valid options:
+
+- `true` - Indent template tags in Vue files.
+- `false` - Do not indent template tags in Vue files.
+
+| Default | CLI Override               | API Override                |
+| ------- | -------------------------- | --------------------------- |
+| `true`  | `--no-vue-indent-template` | `vueIndentTemplate: <bool>` |
+
 ## End of Line
 
 _First available in v1.15.0, default value changed from `auto` to `lf` in v2.0.0_

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -425,6 +425,11 @@ export interface RequiredOptions extends doc.printer.Options {
    */
   vueIndentScriptAndStyle: boolean;
   /**
+   * Whether or not to indent the code inside <template> tags in Vue files.
+   * @default true
+   */
+  vueIndentTemplate: boolean;
+  /**
    * Control whether Prettier formats quoted code embedded in the file.
    * @default "auto"
    */

--- a/src/language-html/options.js
+++ b/src/language-html/options.js
@@ -32,6 +32,12 @@ const options = {
     default: false,
     description: "Indent script and style tags in Vue files.",
   },
+  vueIndentTemplate: {
+    category: CATEGORY_HTML,
+    type: "boolean",
+    default: true,
+    description: "Indent template tags in Vue files.",
+  },
 };
 
 export default options;

--- a/src/language-html/print/element.js
+++ b/src/language-html/print/element.js
@@ -88,13 +88,16 @@ function printElement(path, options, print) {
     if (shouldHugContent) {
       return indentIfBreak(childrenDoc, { groupId: attrGroupId });
     }
-    if (
-      (isScriptLikeTag(node, options) || isVueCustomBlock(node, options)) &&
-      node.parent.kind === "root" &&
-      options.parser === "vue" &&
-      !options.vueIndentScriptAndStyle
-    ) {
-      return childrenDoc;
+    if (node.parent.kind === "root" && options.parser === "vue") {
+      if (
+        (isScriptLikeTag(node, options) || isVueCustomBlock(node, options)) &&
+        !options.vueIndentScriptAndStyle
+      ) {
+        return childrenDoc;
+      }
+      if (node.fullName === "template" && !options.vueIndentTemplate) {
+        return childrenDoc;
+      }
     }
     return indent(childrenDoc);
   };

--- a/tests/format/vue/indent/__snapshots__/format.test.js.snap
+++ b/tests/format/vue/indent/__snapshots__/format.test.js.snap
@@ -112,6 +112,118 @@ vueIndentScriptAndStyle: true
 ================================================================================
 `;
 
+exports[`inside-template.vue - {"vueIndentTemplate":false} format 1`] = `
+====================================options=====================================
+parsers: ["vue"]
+vueIndentTemplate: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+<template>
+    <style>
+        br {
+            background: #00abc9;
+        }
+
+    div {
+        background: #00abc9;
+    }
+    </style>
+
+    <script>
+        console.log('hello');
+    console.log('hello');
+    </script>
+
+    <br />
+    <footer>
+        foo
+        <br/>
+    </footer>
+</template>
+
+=====================================output=====================================
+<template>
+<style>
+  br {
+    background: #00abc9;
+  }
+
+  div {
+    background: #00abc9;
+  }
+</style>
+
+<script>
+  console.log("hello");
+  console.log("hello");
+</script>
+
+<br />
+<footer>
+  foo
+  <br />
+</footer>
+</template>
+
+================================================================================
+`;
+
+exports[`inside-template.vue - {"vueIndentTemplate":true} format 1`] = `
+====================================options=====================================
+parsers: ["vue"]
+vueIndentTemplate: true
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+<template>
+    <style>
+        br {
+            background: #00abc9;
+        }
+
+    div {
+        background: #00abc9;
+    }
+    </style>
+
+    <script>
+        console.log('hello');
+    console.log('hello');
+    </script>
+
+    <br />
+    <footer>
+        foo
+        <br/>
+    </footer>
+</template>
+
+=====================================output=====================================
+<template>
+  <style>
+    br {
+      background: #00abc9;
+    }
+
+    div {
+      background: #00abc9;
+    }
+  </style>
+
+  <script>
+    console.log("hello");
+    console.log("hello");
+  </script>
+
+  <br />
+  <footer>
+    foo
+    <br />
+  </footer>
+</template>
+
+================================================================================
+`;
+
 exports[`vue-tag-indent.vue - {"vueIndentScriptAndStyle":false} format 1`] = `
 ====================================options=====================================
 parsers: ["vue"]
@@ -211,6 +323,118 @@ footer {
   footer {
     background: #00abc9;
   }
+</style>
+
+<template>
+  <br />
+  <footer>
+    foo
+    <br />
+  </footer>
+</template>
+
+================================================================================
+`;
+
+exports[`vue-tag-indent.vue - {"vueIndentTemplate":false} format 1`] = `
+====================================options=====================================
+parsers: ["vue"]
+vueIndentTemplate: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+<script>
+  console.log('hello');
+console.log('hello');
+</script>
+
+<style lang="scss">
+  footer {
+    background: #00abc9;
+  }
+
+footer {
+  background: #00abc9;
+}
+</style>
+
+<template>
+  <br />
+  <footer>
+    foo
+    <br/>
+  </footer>
+</template>
+
+=====================================output=====================================
+<script>
+console.log("hello");
+console.log("hello");
+</script>
+
+<style lang="scss">
+footer {
+  background: #00abc9;
+}
+
+footer {
+  background: #00abc9;
+}
+</style>
+
+<template>
+<br />
+<footer>
+  foo
+  <br />
+</footer>
+</template>
+
+================================================================================
+`;
+
+exports[`vue-tag-indent.vue - {"vueIndentTemplate":true} format 1`] = `
+====================================options=====================================
+parsers: ["vue"]
+vueIndentTemplate: true
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+<script>
+  console.log('hello');
+console.log('hello');
+</script>
+
+<style lang="scss">
+  footer {
+    background: #00abc9;
+  }
+
+footer {
+  background: #00abc9;
+}
+</style>
+
+<template>
+  <br />
+  <footer>
+    foo
+    <br/>
+  </footer>
+</template>
+
+=====================================output=====================================
+<script>
+console.log("hello");
+console.log("hello");
+</script>
+
+<style lang="scss">
+footer {
+  background: #00abc9;
+}
+
+footer {
+  background: #00abc9;
+}
 </style>
 
 <template>

--- a/tests/format/vue/indent/format.test.js
+++ b/tests/format/vue/indent/format.test.js
@@ -1,2 +1,4 @@
 runFormatTest(import.meta, ["vue"], { vueIndentScriptAndStyle: true });
 runFormatTest(import.meta, ["vue"], { vueIndentScriptAndStyle: false });
+runFormatTest(import.meta, ["vue"], { vueIndentTemplate: true });
+runFormatTest(import.meta, ["vue"], { vueIndentTemplate: false });


### PR DESCRIPTION
### Summary
This pull request adds a new configuration option `vueIndentTemplate` (boolean, default: `true`) to allow users to control the base indentation of `<template>` content in Vue Single File Components (SFCs).

Currently, Prettier always indents top-level `<template>` block contents by 2 spaces. This behavior cannot be disabled, unlike `<script>` and `<style>` blocks which can start at column 1 using the `vueIndentScriptAndStyle` option. Adding `vueIndentTemplate` provides consistency across all three top-level SFC blocks and prevents simple template elements from wrapping excessively when print width limits are reached.

---

### Proposed Changes

#### 1. Option Definition
- **File**: `src/language-html/options.js`
- **Change**: Defined `vueIndentTemplate` under the HTML category options as a boolean option defaulting to `true` (preserving backward compatibility).
- **File**: `src/index.d.ts`
- **Change**: Added the corresponding property definition in Prettier's TypeScript types.

#### 2. Element Indentation Printing
- **File**: `src/language-html/print/element.js`
- **Change**: Updated `printChildrenDoc` to check if we are parsing a Vue file, the current node is a top-level `<template>` tag (`node.fullName === "template"` and `node.parent.kind === "root"`), and `vueIndentTemplate` is `false`. If these conditions are met, the children are printed without adding indentation.

#### 3. Documentation
- **File**: `docs/options.md`
- **Change**: Documented the new option under "Vue files template tags indentation", specifying its default value (`true`), CLI override (`--no-vue-indent-template`), and API override.

#### 4. Test Coverage
- **File**: `tests/format/vue/indent/format.test.js`
- **Change**: Added test configurations to run formatting checks with `vueIndentTemplate: true` and `vueIndentTemplate: false`.

---

### Before and After Formatting Examples

#### With `vueIndentTemplate: false`
**Input:**
```vue
<template>
  <nav id="nav" class="sticky" @vue:mounted="handleMounted" @click="handleClick">
    ...
  </nav>
  <aside>...</aside>
</template>
```
**Before:**
```vue
<template>
  <nav
    id="nav"
    class="sticky"
    @vue:mounted="handleMounted"
    @click="handleClick"
  >
    ...
  </nav>
  <aside>...</aside>
</template>
```
**After:**
```vue
<template>
<nav id="nav" class="sticky" @vue:mounted="handleMounted" @click="handleClick">
  ...
</nav>
<aside>...</aside>
</template>
```

---

### Verification Results
All Vue indentation tests passed successfully, and snapshots were verified. The codebase passed all ESLint checks and Prettier code formatting requirements.