### PR TITLE
Markdown: Safely encode character references in URLs

### DIFF
--- a/changelog_unreleased/markdown/19617.md
+++ b/changelog_unreleased/markdown/19617.md
@@ -1,0 +1,15 @@
+#### Preserve character references in Markdown link URLs (#19617 by @paranoa233)
+
+Prettier now safely serializes character references in Markdown link destinations so repeated formatting does not decode them into different URLs.
+
+<!-- prettier-ignore -->
+```markdown
+<!-- Input -->
+[link](/?value=&quot\;)
+
+<!-- Prettier stable -->
+[link](/?value=&quot;)
+
+<!-- Prettier main -->
+[link](/?value=\&quot;)
+```

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "micromark-extension-gfm": "3.0.0",
     "micromark-extension-math": "3.1.0",
     "micromark-util-character": "2.1.1",
+    "micromark-util-decode-string": "2.0.1",
     "micromark-util-symbol": "2.0.1",
     "micromark-util-types": "2.0.2",
     "micromatch": "4.0.8",

--- a/src/language-markdown/print/mdast.js
+++ b/src/language-markdown/print/mdast.js
@@ -1,5 +1,6 @@
 import collapseWhiteSpace from "collapse-white-space";
 import escapeStringRegexp from "escape-string-regexp";
+import { decodeString } from "micromark-util-decode-string";
 import {
   align,
   DOC_TYPE_STRING,
@@ -518,12 +519,27 @@ const encodeUrl = (url, characters) => {
   return url;
 };
 
+const characterReferenceRegex =
+  /(\\*)&(?:#(?:\d{1,7}|x[\da-f]{1,6})|[\da-z]{1,31});/gi;
+
+// `url` already contains decoded Markdown escapes. Escape only sequences that
+// micromark would decode as character references on the next formatting pass.
+const escapeCharacterReferences = (url) =>
+  url.replaceAll(characterReferenceRegex, (match, backslashes) => {
+    const reference = match.slice(backslashes.length);
+    return decodeString(reference) === reference
+      ? match
+      : `${backslashes.replaceAll("\\", "\\\\")}\\${reference}`;
+  });
+
 /**
  * @param {string} url
  * @param {string[] | string} [dangerousCharOrChars]
  * @returns {string}
  */
 function printUrl(url, dangerousCharOrChars = []) {
+  url = escapeCharacterReferences(url);
+
   const dangerousChars = [
     " ",
     ...(Array.isArray(dangerousCharOrChars)

--- a/tests/format/markdown/link/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/link/__snapshots__/format.test.js.snap
@@ -129,6 +129,60 @@ proseWrap: "always"
 ================================================================================
 `;
 
+exports[`escaped-character-reference.md - {"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+proseWrap: "always"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+[named](/hello?foo=&quot\\;bar)
+
+[decoded-named](/hello?foo=&quot;bar)
+
+[decimal](/hello?foo=&#34\\;bar)
+
+[hexadecimal](/hello?foo=&#x22\\;bar)
+
+[multiple](/hello?foo=&quot\\;&amp\\;bar)
+
+[preceded-by-backslash](/hello?foo=\\\\\\&quot;bar)
+
+[unknown](/hello?foo=&unknown\\;bar)
+
+[overlong-numeric](/hello?foo=&#12345678\\;bar)
+
+[angle](</hello?foo=&quot\\;bar baz>)
+
+![image](/hello?foo=&quot\\;bar)
+
+[definition]: /hello?foo=&quot\\;bar
+
+=====================================output=====================================
+[named](/hello?foo=\\&quot;bar)
+
+[decoded-named](/hello?foo="bar)
+
+[decimal](/hello?foo=\\&#34;bar)
+
+[hexadecimal](/hello?foo=\\&#x22;bar)
+
+[multiple](/hello?foo=\\&quot;\\&amp;bar)
+
+[preceded-by-backslash](/hello?foo=\\\\\\&quot;bar)
+
+[unknown](/hello?foo=&unknown;bar)
+
+[overlong-numeric](/hello?foo=&#12345678;bar)
+
+[angle](</hello?foo=\\&quot;bar baz>)
+
+![image](/hello?foo=\\&quot;bar)
+
+[definition]: /hello?foo=\\&quot;bar
+
+================================================================================
+`;
+
 exports[`long.md - {"proseWrap":"always"} format 1`] = `
 ====================================options=====================================
 parsers: ["markdown"]

--- a/tests/format/markdown/link/escaped-character-reference.md
+++ b/tests/format/markdown/link/escaped-character-reference.md
@@ -1,0 +1,21 @@
+[named](/hello?foo=&quot\;bar)
+
+[decoded-named](/hello?foo=&quot;bar)
+
+[decimal](/hello?foo=&#34\;bar)
+
+[hexadecimal](/hello?foo=&#x22\;bar)
+
+[multiple](/hello?foo=&quot\;&amp\;bar)
+
+[preceded-by-backslash](/hello?foo=\\\&quot;bar)
+
+[unknown](/hello?foo=&unknown\;bar)
+
+[overlong-numeric](/hello?foo=&#12345678\;bar)
+
+[angle](</hello?foo=&quot\;bar baz>)
+
+![image](/hello?foo=&quot\;bar)
+
+[definition]: /hello?foo=&quot\;bar

--- a/yarn.lock
+++ b/yarn.lock
@@ -7272,7 +7272,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromark-util-decode-string@npm:^2.0.0":
+"micromark-util-decode-string@npm:2.0.1, micromark-util-decode-string@npm:^2.0.0":
   version: 2.0.1
   resolution: "micromark-util-decode-string@npm:2.0.1"
   dependencies:
@@ -8347,6 +8347,7 @@ __metadata:
     micromark-extension-gfm: "npm:3.0.0"
     micromark-extension-math: "npm:3.1.0"
     micromark-util-character: "npm:2.1.1"
+    micromark-util-decode-string: "npm:2.0.1"
     micromark-util-symbol: "npm:2.0.1"
     micromark-util-types: "npm:2.0.2"
     micromatch: "npm:4.0.8"


### PR DESCRIPTION
## Description

Fixes #19588.

Markdown parsers correctly remove the backslash from inputs such as `&quot\;` and expose the resulting URL as `&quot;`. The Markdown printer previously emitted that value verbatim, so a second parse decoded it to `"` and formatting was not idempotent.

This change safely serializes character references in link destinations: it uses micromark's decoder to identify only references that a subsequent parse would decode, then escapes their leading `&`. Unknown entities, ordinary query parameters, and overlong numeric references are left unchanged. The approach matches `mdast-util-to-markdown` behavior and avoids the shape-based false positives discussed in the earlier attempts.

Regression coverage includes named, decimal, hexadecimal, multiple and pre-escaped references, unknown and overlong references, angle-bracket destinations, images, and definitions.

Previous attempt https://github.com/prettier/prettier/pull/19589

## Checklist

- [x] I've added tests to confirm my change works.
- [x] (If changing the API or CLI) Not applicable.
- [x] (If the change is user-facing) I've added `changelog_unreleased/markdown/19617.md` following the template.
- [x] I've read the contributing guidelines.
- [ ] I did _not_ use AI to generate this PR.
- [x] I have reviewed the AI-generated content before submitting.
