### PR TITLE
Preserve quotes for `TSMethodSignature` nodes named `new`

### DIFF
--- a/changelog_unreleased/typescript/19621.md
+++ b/changelog_unreleased/typescript/19621.md
@@ -1,0 +1,19 @@
+#### Preserve quotes for methods named `new` (#19621 by @kovsu)
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+interface Container {
+  "new"(id: string): number;
+}
+
+// Prettier stable
+interface Container {
+  new(id: string): number;
+}
+
+// Prettier main
+interface Container {
+  "new"(id: string): number;
+}
+```

--- a/src/language-js/print/key.js
+++ b/src/language-js/print/key.js
@@ -96,6 +96,10 @@ function isKeySafeToUnquote(node, options) {
     return false;
   }
 
+  if (node.type === "TSMethodSignature" && value === "new") {
+    return false;
+  }
+
   // Safe to unquote as identifier
   if (
     // With `--strictPropertyInitialization`, TS treats properties with quoted names differently than unquoted ones.

--- a/tests/format/typescript/quote-props/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/quote-props/__snapshots__/format.test.js.snap
@@ -240,6 +240,96 @@ interface I2 {
 ================================================================================
 `;
 
+exports[`issue-19618.ts - {"quoteProps":"as-needed"} format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+quoteProps: "as-needed"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+interface Container {
+  "new"(id: string): number;
+  "method"(): void;
+}
+
+type ContainerType = {
+  'new'(id: string): number;
+  'method'(): void;
+};
+
+=====================================output=====================================
+interface Container {
+  "new"(id: string): number;
+  method(): void;
+}
+
+type ContainerType = {
+  "new"(id: string): number;
+  method(): void;
+};
+
+================================================================================
+`;
+
+exports[`issue-19618.ts - {"quoteProps":"consistent"} format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+quoteProps: "consistent"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+interface Container {
+  "new"(id: string): number;
+  "method"(): void;
+}
+
+type ContainerType = {
+  'new'(id: string): number;
+  'method'(): void;
+};
+
+=====================================output=====================================
+interface Container {
+  "new"(id: string): number;
+  "method"(): void;
+}
+
+type ContainerType = {
+  "new"(id: string): number;
+  "method"(): void;
+};
+
+================================================================================
+`;
+
+exports[`issue-19618.ts - {"quoteProps":"preserve"} format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+quoteProps: "preserve"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+interface Container {
+  "new"(id: string): number;
+  "method"(): void;
+}
+
+type ContainerType = {
+  'new'(id: string): number;
+  'method'(): void;
+};
+
+=====================================output=====================================
+interface Container {
+  "new"(id: string): number;
+  "method"(): void;
+}
+
+type ContainerType = {
+  "new"(id: string): number;
+  "method"(): void;
+};
+
+================================================================================
+`;
+
 exports[`type-literal.ts - {"quoteProps":"as-needed"} format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/quote-props/issue-19618.ts
+++ b/tests/format/typescript/quote-props/issue-19618.ts
@@ -1,0 +1,9 @@
+interface Container {
+  "new"(id: string): number;
+  "method"(): void;
+}
+
+type ContainerType = {
+  'new'(id: string): number;
+  'method'(): void;
+};


### PR DESCRIPTION
<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

Fix #19618 
Ref: https://github.com/microsoft/TypeScript/pull/55750/changes#diff-1516c8349f7a625a2e4a2aa60f6bbe84e4b1a499128e8705d3087d893e01d367

```ts
interface Container {
  "new"(id: string): number; //  ----> TSMethodSignature
  new(id: string): number;    //  ----> TSConstructSignatureDeclaration
}
```

<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
