### PR TITLE
Fix comment moved before `:` in property signature

### DIFF
--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -1011,7 +1011,7 @@ function handlePropertySignatureComments(context) {
   if (
     !followingNode ||
     (enclosingNode?.type !== "TSPropertySignature" &&
-      enclosingNode.type !== "ObjectTypeProperty")
+      enclosingNode?.type !== "ObjectTypeProperty")
   ) {
     return false;
   }

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -1024,7 +1024,12 @@ function handlePropertySignatureComments(context) {
     return true;
   }
 
-  if (isBlockComment(comment)) {
+  const typeNode =
+    enclosingNode.type === "TSPropertySignature"
+      ? enclosingNode.typeAnnotation
+      : enclosingNode.value;
+
+  if (typeNode && isBlockComment(comment)) {
     const colonTokenIndex = stripComments(options).indexOf(
       ":",
       locEnd(enclosingNode.key),

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -147,6 +147,7 @@ function handleRemainingComment(context) {
     handleFunctionNameComments,
     handleTSFunctionTrailingComments,
     handleParenthesizedExpressionTrailingComment,
+    handlePropertySignatureComments,
     handleBinaryCastExpressionComment,
     handleUnionTypeLeadingComments,
   ].some((fn) => fn(context));
@@ -1003,20 +1004,38 @@ function handleLastBinaryOperatorOperand({
   return false;
 }
 
-function handlePropertySignatureComments({
-  enclosingNode,
-  followingNode,
-  comment,
-}) {
+/** @param {CommentContext} context */
+function handlePropertySignatureComments(context) {
+  const { enclosingNode, followingNode, comment, options, placement } = context;
+
   if (
-    enclosingNode &&
-    (enclosingNode.type === "TSPropertySignature" ||
-      enclosingNode.type === "ObjectTypeProperty") &&
+    !followingNode ||
+    (enclosingNode?.type !== "TSPropertySignature" &&
+      enclosingNode.type !== "ObjectTypeProperty")
+  ) {
+    return false;
+  }
+
+  if (
+    placement === "endOfLine" &&
     (isUnionType(followingNode) || isIntersectionType(followingNode))
   ) {
     addLeadingComment(followingNode, comment);
     return true;
   }
+
+  if (!isBlockComment(comment)) {
+    return false;
+  }
+
+  const colonTokenIndex = stripComments(options).indexOf(
+    ":",
+    locEnd(enclosingNode.key),
+  );
+
+  return colonTokenIndex !== -1 && colonTokenIndex < locStart(comment)
+    ? addLeadingCommentToPossibleUnionType(followingNode, context)
+    : false;
 }
 
 function handleBinaryCastExpressionComment({

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -1024,17 +1024,17 @@ function handlePropertySignatureComments(context) {
     return true;
   }
 
-  const typeNode =
-    enclosingNode.type === "TSPropertySignature"
-      ? enclosingNode.typeAnnotation
-      : enclosingNode.value;
-
-  if (typeNode && isBlockComment(comment)) {
+  if (
+    ((enclosingNode.type === "TSPropertySignature" &&
+      enclosingNode.typeAnnotation) ||
+      (enclosingNode.type === "ObjectTypeProperty" && enclosingNode.value)) &&
+    isBlockComment(comment)
+  ) {
     const colonTokenIndex = stripComments(options).indexOf(
       ":",
       locEnd(enclosingNode.key),
     );
-    if (colonTokenIndex !== -1 && colonTokenIndex < locStart(comment)) {
+    if (colonTokenIndex < locStart(comment)) {
       return addLeadingCommentToPossibleUnionType(followingNode, context);
     }
   }

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -1024,18 +1024,17 @@ function handlePropertySignatureComments(context) {
     return true;
   }
 
-  if (!isBlockComment(comment)) {
-    return false;
+  if (isBlockComment(comment)) {
+    const colonTokenIndex = stripComments(options).indexOf(
+      ":",
+      locEnd(enclosingNode.key),
+    );
+    if (colonTokenIndex !== -1 && colonTokenIndex < locStart(comment)) {
+      return addLeadingCommentToPossibleUnionType(followingNode, context);
+    }
   }
 
-  const colonTokenIndex = stripComments(options).indexOf(
-    ":",
-    locEnd(enclosingNode.key),
-  );
-
-  return colonTokenIndex !== -1 && colonTokenIndex < locStart(comment)
-    ? addLeadingCommentToPossibleUnionType(followingNode, context)
-    : false;
+  return false;
 }
 
 function handleBinaryCastExpressionComment({

--- a/tests/format/typescript/property-signature/consistent-with-flow/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/property-signature/consistent-with-flow/__snapshots__/format.test.js.snap
@@ -14,6 +14,24 @@ interface A {
   property: /* Comment */ B
 }
 
+interface A {
+  property: /** Comment */
+    B
+}
+
+interface A {
+  property /** Comment */
+    : B
+}
+
+interface A {
+  property: /** Comment */ | B
+}
+
+interface A {
+  property /** Comment */: B | C
+}
+
 =====================================output=====================================
 interface A {
   property: B; // Comment
@@ -21,6 +39,23 @@ interface A {
 
 interface A {
   property: /* Comment */ B;
+}
+
+interface A {
+  property: /** Comment */
+  B;
+}
+
+interface A {
+  property /** Comment */: B;
+}
+
+interface A {
+  property: /** Comment */ B;
+}
+
+interface A {
+  property /** Comment */: B | C;
 }
 
 ================================================================================

--- a/tests/format/typescript/property-signature/consistent-with-flow/comments.ts
+++ b/tests/format/typescript/property-signature/consistent-with-flow/comments.ts
@@ -6,3 +6,21 @@ interface A {
 interface A {
   property: /* Comment */ B
 }
+
+interface A {
+  property: /** Comment */
+    B
+}
+
+interface A {
+  property /** Comment */
+    : B
+}
+
+interface A {
+  property: /** Comment */ | B
+}
+
+interface A {
+  property /** Comment */: B | C
+}


### PR DESCRIPTION
<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

Fix #19443 

<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
