### PR TITLE
fix(css): preserve sign spacing in relative color syntax

### DIFF
--- a/changelog_unreleased/css/18320.md
+++ b/changelog_unreleased/css/18320.md
@@ -1,0 +1,21 @@
+#### Keep sign attached to channel values in CSS relative color syntax (#18320 by @xianjianlf2)
+
+In the [relative color syntax](https://www.w3.org/TR/css-color-5/#relative-colors), a leading `+`/`-` on a channel value is a sign, not a math operator. Prettier was inserting a space after it, which changes the meaning of the value because the sign makes the channel adjustment relative instead of absolute.
+
+<!-- prettier-ignore -->
+```css
+/* Input */
+:root {
+  --color: oklch(from rgb(255, 0, 0) l c +130);
+}
+
+/* Prettier stable */
+:root {
+  --color: oklch(from rgb(255, 0, 0) l c + 130);
+}
+
+/* Prettier main */
+:root {
+  --color: oklch(from rgb(255, 0, 0) l c +130);
+}
+```

--- a/src/language-css/print/comma-separated-value-group.js
+++ b/src/language-css/print/comma-separated-value-group.js
@@ -34,6 +34,7 @@ import {
   isParenGroupNode,
   isPostcssSimpleVarNode,
   isRelationalOperatorNode,
+  isRelativeColorSyntaxNode,
   isRightCurlyBraceNode,
   isSCSSControlDirectiveNode,
   isSubtractionNode,
@@ -366,6 +367,20 @@ function printCommaSeparatedValueGroup(path, options, print) {
       parentParentNode &&
       isColorAdjusterFuncNode(parentParentNode) &&
       !hasEmptyRawBefore(iNextNode);
+
+    // Keep a sign attached to a channel value in the relative color syntax
+    // (e.g. `oklch(from red l c +130)`). The `+`/`-` here is a sign, not a math
+    // operator, so printing a space (`+ 130`) would change the value.
+    if (
+      (isAdditionNode(iNode) || isSubtractionNode(iNode)) &&
+      iNextNode?.type === "value-number" &&
+      !hasEmptyRawBefore(iNode) &&
+      hasEmptyRawBefore(iNextNode) &&
+      isRelativeColorSyntaxNode(node, parentParentNode)
+    ) {
+      continue;
+    }
+
     const requireSpaceBeforeOperator =
       iNextNextNode?.type === "value-func" ||
       (iNextNextNode && isWordNode(iNextNextNode)) ||

--- a/src/language-css/utilities/index.js
+++ b/src/language-css/utilities/index.js
@@ -371,6 +371,40 @@ function isColorAdjusterFuncNode(node) {
   return colorAdjusterFunctions.has(node.value.toLowerCase());
 }
 
+// CSS color functions that accept the relative color syntax,
+// e.g. `oklch(from red l c h)`. https://www.w3.org/TR/css-color-5/#relative-colors
+const relativeColorFunctions = new Set([
+  "rgb",
+  "rgba",
+  "hsl",
+  "hsla",
+  "hwb",
+  "lab",
+  "lch",
+  "oklab",
+  "oklch",
+  "color",
+]);
+
+// In the relative color syntax a leading `+`/`-` directly attached to a channel
+// value is a sign, not a math operator (e.g. `oklch(from red l c +130)`).
+// Printing a space (`+ 130`) would change the meaning of the value, so such a
+// sign must stay attached to the number.
+function isRelativeColorSyntaxNode(commaGroupNode, funcNode) {
+  if (
+    funcNode?.type !== "value-func" ||
+    !relativeColorFunctions.has(funcNode.value.toLowerCase()) ||
+    commaGroupNode?.type !== "value-comma_group"
+  ) {
+    return false;
+  }
+
+  const firstNode = commaGroupNode.groups?.[0];
+  return (
+    firstNode?.type === "value-word" && firstNode.value.toLowerCase() === "from"
+  );
+}
+
 function lastLineHasInlineComment(text) {
   return /\/\//.test(text.split(/[\n\r]/).pop());
 }
@@ -444,6 +478,7 @@ export {
   isParenGroupNode,
   isPostcssSimpleVarNode,
   isRelationalOperatorNode,
+  isRelativeColorSyntaxNode,
   isRightCurlyBraceNode,
   isSCSSControlDirectiveNode,
   isSCSSMapItemNode,

--- a/tests/format/css/color/__snapshots__/format.test.js.snap
+++ b/tests/format/css/color/__snapshots__/format.test.js.snap
@@ -380,6 +380,47 @@ parsers: ["css"]
 ================================================================================
 `;
 
+exports[`relative-color-syntax.css format 1`] = `
+====================================options=====================================
+parsers: ["css"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+/* https://www.w3.org/TR/css-color-5/#relative-colors */
+/* A leading \`+\`/\`-\` on a channel value is a sign, not a math operator, so it
+   must stay attached to the number (\`+ 130\` would change the value). */
+:root {
+  --a: oklch(from rgb(255, 0, 0) l c +130);
+  --b: oklch(from red l c -130);
+  --c: oklab(from var(--base) l a +0.1);
+  --d: color(from red srgb r g +0.2);
+  --e: hsl(from red h s +10%);
+  --f: rgb(from red r g +20);
+  --g: lab(from teal l a +12);
+  --h: hwb(from red h +10% +5%);
+  --i: lch(from blue calc(l + 10%) c h);
+  --j: calc(1px + 2px);
+}
+
+=====================================output=====================================
+/* https://www.w3.org/TR/css-color-5/#relative-colors */
+/* A leading \`+\`/\`-\` on a channel value is a sign, not a math operator, so it
+   must stay attached to the number (\`+ 130\` would change the value). */
+:root {
+  --a: oklch(from rgb(255, 0, 0) l c +130);
+  --b: oklch(from red l c -130);
+  --c: oklab(from var(--base) l a +0.1);
+  --d: color(from red srgb r g +0.2);
+  --e: hsl(from red h s +10%);
+  --f: rgb(from red r g +20);
+  --g: lab(from teal l a +12);
+  --h: hwb(from red h +10% +5%);
+  --i: lch(from blue calc(l + 10%) c h);
+  --j: calc(1px + 2px);
+}
+
+================================================================================
+`;
+
 exports[`whitespace-syntax.css format 1`] = `
 ====================================options=====================================
 parsers: ["css"]

--- a/tests/format/css/color/relative-color-syntax.css
+++ b/tests/format/css/color/relative-color-syntax.css
@@ -1,0 +1,15 @@
+/* https://www.w3.org/TR/css-color-5/#relative-colors */
+/* A leading `+`/`-` on a channel value is a sign, not a math operator, so it
+   must stay attached to the number (`+ 130` would change the value). */
+:root {
+  --a: oklch(from rgb(255, 0, 0) l c +130);
+  --b: oklch(from red l c -130);
+  --c: oklab(from var(--base) l a +0.1);
+  --d: color(from red srgb r g +0.2);
+  --e: hsl(from red h s +10%);
+  --f: rgb(from red r g +20);
+  --g: lab(from teal l a +12);
+  --h: hwb(from red h +10% +5%);
+  --i: lch(from blue calc(l + 10%) c h);
+  --j: calc(1px + 2px);
+}


### PR DESCRIPTION
**Description**

Fixes #18320 — a CSS **correctness** bug (not a style preference): a leading `+`/`-` sign attached to a channel value in relative color syntax is reformatted with a space, which changes the CSS meaning.

```css
/* input */
--a: oklch(from red l c +130);
/* Prettier output before this PR */
--a: oklch(from red l c + 130);
```

In relative color syntax, `+130` is a *sign* on the channel value (a relative adjustment); `+ 130` is parsed by browsers as an absolute value. So the formatted output is no longer semantically equivalent to the input.

postcss-values-parser tokenizes `+130` as operator `+` + number `130`. In `printCommaSeparatedValueGroup`, the "Formatting sign" branch sets `requireSpaceAfterOperator = true` because the preceding token is a channel keyword (a word node), so the operator falls through to the default `line` separator and prints `+ 130`. (`-0.1` was unaffected — it tokenizes as a single negative-number token.)

**Fix**

- `src/language-css/utilities/index.js`: new `isRelativeColorSyntaxNode(commaGroupNode, funcNode)` helper + a `relativeColorFunctions` set (CSS Color 5), detecting a color function whose first argument is the `from` keyword.
- `src/language-css/print/comma-separated-value-group.js`: when a `+`/`-` sign is attached to a `value-number` inside relative color syntax, emit no space. `calc(...)` and ordinary math are untouched (their nested function isn't a relative-color function).

Output is idempotent (re-formatting the output is stable).

**Tests**

New fixture `tests/format/css/color/relative-color-syntax.css` (9 relative-color cases + `calc` controls). `jest tests/format/css tests/format/scss tests/format/less` → 558 passed, 0 failed. Coverage proof: disabling the guard fails the `oklch(... c +130)` case; restoring passes. Changelog entry added under `changelog_unreleased/css/`.

Closes #18320
