### PR TITLE
Fix generic zero-argument member chain breaks

### DIFF
--- a/changelog_unreleased/typescript/19642.md
+++ b/changelog_unreleased/typescript/19642.md
@@ -1,0 +1,21 @@
+#### Break long member chains before zero-argument generic calls (#19642 by @iamdhrv)
+
+Zero-argument generic calls at the end of long member chains now use the expanded member-chain layout instead of breaking only the type arguments.
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+const response = await TheBackendEndpoint.EligibleCategories.get().json<
+  IApiPaymentResponse<IApiEligibleCategories>
+>();
+
+// Prettier stable
+const response =
+  await TheBackendEndpoint.EligibleCategories.get().json<
+    IApiPaymentResponse<IApiEligibleCategories>
+  >();
+
+// Prettier main
+const response = await TheBackendEndpoint.EligibleCategories.get()
+  .json<IApiPaymentResponse<IApiEligibleCategories>>();
+```

--- a/src/language-js/print/member-chain.js
+++ b/src/language-js/print/member-chain.js
@@ -6,6 +6,7 @@ import {
   indent,
   join,
   label,
+  removeLines,
   willBreak,
 } from "../../document/index.js";
 import { printComments } from "../../main/comments/print.js";
@@ -31,7 +32,7 @@ import { printOptionalToken } from "./miscellaneous.js";
 
 /**
  * @import {Doc} from "../../document/index.js"
- * @typedef {{ node: any, printed: Doc, shouldInline?: boolean, hasTrailingEmptyLine?: boolean }} PrintedNode
+ * @typedef {{ node: any, printed: Doc, printedWithTypeArgumentsFlat?: Doc, shouldInline?: boolean, hasTrailingEmptyLine?: boolean }} PrintedNode
  */
 
 // We detect calls on member expressions specially to format a
@@ -96,21 +97,30 @@ function printMemberChain(path, options, print) {
       !needsParentheses(path, options)
     ) {
       const hasTrailingEmptyLine = shouldInsertEmptyLineAfter(node);
+      const optional = printOptionalToken(path);
+      const typeArguments = print("typeArguments");
+      const callArguments = printCallArguments(path, options, print);
+      const trailingEmptyLine = hasTrailingEmptyLine ? hardline : "";
       printedNodes.unshift({
         node,
         hasTrailingEmptyLine,
         printed: [
           printComments(
             path,
-            [
-              printOptionalToken(path),
-              print("typeArguments"),
-              printCallArguments(path, options, print),
-            ],
+            [optional, typeArguments, callArguments],
             options,
           ),
-          hasTrailingEmptyLine ? hardline : "",
+          trailingEmptyLine,
         ],
+        printedWithTypeArgumentsFlat:
+          node.typeArguments && node.arguments.length === 0 && !hasComment(node)
+            ? [
+                optional,
+                removeLines(typeArguments),
+                callArguments,
+                trailingEmptyLine,
+              ]
+            : undefined,
       });
       path.call(rec, "callee");
     } else if (isMemberish(node) && !needsParentheses(path, options)) {
@@ -150,13 +160,18 @@ function printMemberChain(path, options, print) {
   // need to extract this first call without printing them as they would
   // if handled inside of the recursive call.
   const { node } = path;
+  const optional = printOptionalToken(path);
+  const typeArguments = print("typeArguments");
+  const callArguments = printCallArguments(path, options, print);
   printedNodes.unshift({
     node,
-    printed: [
-      printOptionalToken(path),
-      print("typeArguments"),
-      printCallArguments(path, options, print),
-    ],
+    printed: [optional, typeArguments, callArguments],
+    printedWithTypeArgumentsFlat:
+      node.typeArguments &&
+      node.arguments.length === 0 &&
+      !hasComment(node.typeArguments)
+        ? [optional, removeLines(typeArguments), callArguments]
+        : undefined,
   });
 
   if (node.callee) {
@@ -314,8 +329,12 @@ function printMemberChain(path, options, print) {
     !hasComment(groups[1][0].node) &&
     shouldNotWrap(groups);
 
-  function printGroup(printedGroup) {
-    return printedGroup.map((tuple) => tuple.printed);
+  function printGroup(printedGroup, flattenTypeArguments = false) {
+    return printedGroup.map((tuple) =>
+      flattenTypeArguments && tuple.printedWithTypeArgumentsFlat
+        ? tuple.printedWithTypeArgumentsFlat
+        : tuple.printed,
+    );
   }
 
   function printIndentedGroup(groups) {
@@ -323,14 +342,23 @@ function printMemberChain(path, options, print) {
     if (groups.length === 0) {
       return "";
     }
-    return indent([hardline, join(hardline, groups.map(printGroup))]);
+    return indent([
+      hardline,
+      join(
+        hardline,
+        groups.map((group) => printGroup(group)),
+      ),
+    ]);
   }
 
-  const printedGroups = groups.map(printGroup);
-  const oneLine = printedGroups;
+  const printedGroups = groups.map((group) => printGroup(group));
+  const oneLine = groups.map((group) => printGroup(group, true));
 
   const cutoff = shouldMerge ? 3 : 2;
   const flatGroups = groups.flat();
+  const hasTypeArgumentsToFlatten = flatGroups.some(
+    (node) => node.printedWithTypeArgumentsFlat,
+  );
 
   const nodeHasComment =
     flatGroups
@@ -346,6 +374,7 @@ function printMemberChain(path, options, print) {
   // render everything concatenated together.
   if (
     groups.length <= cutoff &&
+    !hasTypeArgumentsToFlatten &&
     !nodeHasComment &&
     groups.every((g) => !g.at(-1).hasTrailingEmptyLine)
   ) {
@@ -364,7 +393,7 @@ function printMemberChain(path, options, print) {
 
   const expanded = [
     printGroup(groups[0]),
-    shouldMerge ? groups.slice(1, 2).map(printGroup) : "",
+    shouldMerge ? groups.slice(1, 2).map((group) => printGroup(group)) : "",
     shouldHaveEmptyLineBeforeIndent ? hardline : "",
     printIndentedGroup(groups.slice(shouldMerge ? 2 : 1)),
   ];

--- a/tests/format/typescript/break-calls/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/break-calls/__snapshots__/format.test.js.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`issue-5399.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+const response = await TheBackendEndpoint.EligibleCategories.get().json<
+  IApiPaymentResponse<IApiEligibleCategories>
+>();
+
+const shortResponse = await endpoint.get().json<Response>();
+
+=====================================output=====================================
+const response = await TheBackendEndpoint.EligibleCategories.get()
+  .json<IApiPaymentResponse<IApiEligibleCategories>>();
+
+const shortResponse = await endpoint.get().json<Response>();
+
+================================================================================
+`;
+
 exports[`type_args.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/break-calls/issue-5399.ts
+++ b/tests/format/typescript/break-calls/issue-5399.ts
@@ -1,0 +1,5 @@
+const response = await TheBackendEndpoint.EligibleCategories.get().json<
+  IApiPaymentResponse<IApiEligibleCategories>
+>();
+
+const shortResponse = await endpoint.get().json<Response>();


### PR DESCRIPTION
## Description

Fixes #5399.

Member chains ending in a zero-argument generic call could satisfy the compact chain layout by breaking only the type arguments. In assignment contexts, that produced a break after `=` while keeping the full member chain on one line and splitting the generic type.

This change flattens soft lines in type arguments only while measuring the compact chain alternative. If that compact form does not fit, the existing expanded member-chain layout is selected instead. The expanded alternative retains the original type-argument document, so independently long type arguments can still wrap.

The behavior is limited to zero-argument generic calls. Generic calls with arguments retain their existing argument-expansion strategy, and short generic chains remain on one line.

Validation:

- `FULL_TEST=1 yarn jest tests/format/js/method-chain tests/format/typescript/break-calls --runInBand` (1,074 tests, 37 snapshots)
- `yarn lint:typecheck`
- targeted ESLint
- Prettier check on all changed files
- `yarn lint:format-test`
- `git diff --check`

AI assistance was used to investigate and prepare this change. I reviewed the implementation and snapshots and ran the validation above.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) Not applicable; no API or CLI change.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
