### PR TITLE
Fix Markdown task list indentation drift

### DIFF
--- a/changelog_unreleased/markdown/19647.md
+++ b/changelog_unreleased/markdown/19647.md
@@ -1,0 +1,24 @@
+#### Prevent indentation drift in task-list code blocks (#19647 by @Austin1serb)
+
+Indented code blocks inside task-list items no longer gain four spaces on each formatting pass.
+
+<!-- prettier-ignore -->
+```markdown
+<!-- Input -->
+- [x] short first line.
+
+      second paragraph at six spaces that wraps
+      onto another line here.
+
+<!-- Prettier stable -->
+- [x] short first line.
+
+      second paragraph at six spaces that wraps
+          onto another line here.
+
+<!-- Prettier main -->
+- [x] short first line.
+
+      second paragraph at six spaces that wraps
+      onto another line here.
+```

--- a/src/language-markdown/print/list.js
+++ b/src/language-markdown/print/list.js
@@ -99,10 +99,7 @@ function printListItem(path, options, print, listPrefix) {
     prefix,
     printChildren(path, options, print, {
       processor({ node, isFirst }) {
-        if (
-          (isFirst && node.type !== "list") ||
-          (node.type === "code" && node.isIndented)
-        ) {
+        if (isFirst && node.type !== "list") {
           return align(" ".repeat(prefix.length), print());
         }
 

--- a/tests/format/markdown/list/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/list/__snapshots__/format.test.js.snap
@@ -679,6 +679,26 @@ proseWrap: "always"
 ================================================================================
 `;
 
+exports[`issue-19644.md - {"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+proseWrap: "always"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+- [x] short first line.
+
+      second paragraph at six spaces that wraps
+      onto another line here.
+
+=====================================output=====================================
+- [x] short first line.
+
+      second paragraph at six spaces that wraps
+      onto another line here.
+
+================================================================================
+`;
+
 exports[`long-paragraph.md - {"proseWrap":"always"} format 1`] = `
 ====================================options=====================================
 parsers: ["markdown"]

--- a/tests/format/markdown/list/issue-19644.md
+++ b/tests/format/markdown/list/issue-19644.md
@@ -1,0 +1,4 @@
+- [x] short first line.
+
+      second paragraph at six spaces that wraps
+      onto another line here.


### PR DESCRIPTION
## Description

Avoid applying the task-list checkbox alignment a second time to indented code blocks. This prevents wrapped lines from gaining four spaces on every formatting pass.

Fixes #19644.

## Tests

- `yarn test tests/format/markdown/list`
- `FULL_TEST=1 yarn test tests/format/markdown/list`
- `yarn eslint src/language-markdown/print/list.js`
- Prettier checks for the changed source, fixture, snapshot, and changelog
- `yarn lint:changelog`

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
