### PR TITLE
Fix JSDoc cast placement in nullish ternaries

### DIFF
--- a/changelog_unreleased/javascript/19648.md
+++ b/changelog_unreleased/javascript/19648.md
@@ -1,0 +1,21 @@
+#### Preserve JSDoc casts in nullish ternary branches (#19648 by @Austin1serb)
+
+JSDoc type cast comments now remain inside the parentheses Prettier adds around nullish-coalescing expressions in ternary branches.
+
+<!-- prettier-ignore -->
+```js
+// Input
+var target = condition
+  ? value
+  : /** @type {Document} */ (root).head ?? fallback;
+
+// Prettier stable
+var target = condition
+  ? value
+  : /** @type {Document} */ ((root).head ?? fallback);
+
+// Prettier main
+var target = condition
+  ? value
+  : (/** @type {Document} */ (root).head ?? fallback);
+```

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -15,9 +15,11 @@ import { isBlockComment, isLineComment } from "../utilities/comment-types.js";
 import { createTypeCheckFunction } from "../utilities/create-type-check-function.js";
 import { getFunctionParameters } from "../utilities/function-parameters.js";
 import { isMethod } from "../utilities/is-method.js";
+import { isNullishCoalescing } from "../utilities/is-nullish-coalescing.js";
 import { isObjectProperty } from "../utilities/is-object-property.js";
 import { isPrettierIgnoreComment } from "../utilities/is-prettier-ignore-comment.js";
 import { isTypeCastComment } from "../utilities/is-type-cast-comment.js";
+import { getLeftSide, hasNakedLeftSide } from "../utilities/left-side.js";
 import {
   isArrayType,
   isBinaryCastExpression,
@@ -134,6 +136,7 @@ function handleEndOfLineComment(context) {
 function handleRemainingComment(context) {
   return [
     handleCommentInEmptyParens,
+    handleClosureTypeCastCommentInNullishCoalescing,
     handleIgnoreComments,
     handleIfStatementComments,
     handleWhileLikeComments,
@@ -157,6 +160,35 @@ function handleClosureTypeCastComments({ comment, followingNode }) {
     addLeadingComment(followingNode, comment);
     return true;
   }
+  return false;
+}
+
+function handleClosureTypeCastCommentInNullishCoalescing({
+  comment,
+  followingNode,
+}) {
+  if (
+    !followingNode ||
+    !isNullishCoalescing(followingNode) ||
+    !isTypeCastComment(comment)
+  ) {
+    return false;
+  }
+
+  let leftMost = followingNode;
+  while (hasNakedLeftSide(leftMost)) {
+    const nextLeftMost = getLeftSide(leftMost);
+    if (!nextLeftMost || locStart(nextLeftMost) !== locStart(leftMost)) {
+      return false;
+    }
+
+    leftMost = nextLeftMost;
+    if (leftMost.type === "ParenthesizedExpression") {
+      addLeadingComment(leftMost, comment);
+      return true;
+    }
+  }
+
   return false;
 }
 

--- a/tests/format/js/comments-closure-typecast/__snapshots__/format.test.js.snap
+++ b/tests/format/js/comments-closure-typecast/__snapshots__/format.test.js.snap
@@ -477,6 +477,24 @@ const fooooba4 =
 ================================================================================
 `;
 
+exports[`issue-19645.js format 1`] = `
+====================================options=====================================
+parsers: ["babel"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+var target = /** @type {ShadowRoot} */ (root).host
+  ? /** @type {ShadowRoot} */ (root)
+  : /** @type {Document} */ (root).head ?? /** @type {Document} */ (root.ownerDocument).head;
+
+=====================================output=====================================
+var target = /** @type {ShadowRoot} */ (root).host
+  ? /** @type {ShadowRoot} */ (root)
+  : (/** @type {Document} */ (root).head ??
+    /** @type {Document} */ (root.ownerDocument).head);
+
+================================================================================
+`;
+
 exports[`member.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel"]

--- a/tests/format/js/comments-closure-typecast/issue-19645.js
+++ b/tests/format/js/comments-closure-typecast/issue-19645.js
@@ -1,0 +1,3 @@
+var target = /** @type {ShadowRoot} */ (root).host
+  ? /** @type {ShadowRoot} */ (root)
+  : /** @type {Document} */ (root).head ?? /** @type {Document} */ (root.ownerDocument).head;


### PR DESCRIPTION
## Description

Attach Closure-style type cast comments to the parenthesized left operand when they precede a nullish-coalescing expression. This keeps the cast inside the parentheses Prettier adds around a ternary branch, preserving the original cast target.

Fixes #19645.

## Tests

- `yarn test tests/format/js/comments-closure-typecast tests/format/js/nullish-coalescing --runInBand`
- `FULL_TEST=1 yarn test tests/format/js/comments-closure-typecast tests/format/js/nullish-coalescing --runInBand`
- `yarn test tests/format/js/comments --runInBand`
- `yarn eslint src/language-js/comments/handle-comments.js`
- Prettier formatting checks for changed files
- `yarn lint:format-test`
- `git diff --check`

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
