### PR TITLE
Add `glimmer` to the list of parsers in docs

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -326,6 +326,7 @@ Valid options:
 - `"angular"` (same parser as `"html"`, but also formats angular-specific syntax via [angular-estree-parser](https://github.com/ikatyang/angular-estree-parser)) _First available in 1.15.0_
 - `"lwc"` (same parser as `"html"`, but also formats LWC-specific syntax for unquoted template attributes) _First available in 1.17.0_
 - `"mjml"` (same parser as `"html"`, but also formats MJML-specific syntax) _First available in 3.6.0_
+- `"glimmer"` (Ember / Handlebars, via [@glimmer/syntax](https://github.com/glimmerjs/glimmer-vm/tree/main/packages/%40glimmer/syntax)) _First available in 2.3.0_
 - `"yaml"` (via [yaml](https://github.com/eemeli/yaml) and [yaml-unist-parser](https://github.com/ikatyang/yaml-unist-parser)) _First available in 1.14.0_
 
 | Default | CLI Override        | API Override         |

--- a/docs/options.md
+++ b/docs/options.md
@@ -326,7 +326,7 @@ Valid options:
 - `"angular"` (same parser as `"html"`, but also formats angular-specific syntax via [angular-estree-parser](https://github.com/ikatyang/angular-estree-parser)) _First available in 1.15.0_
 - `"lwc"` (same parser as `"html"`, but also formats LWC-specific syntax for unquoted template attributes) _First available in 1.17.0_
 - `"mjml"` (same parser as `"html"`, but also formats MJML-specific syntax) _First available in 3.6.0_
-- `"glimmer"` (Ember / Handlebars, via [@glimmer/syntax](https://github.com/glimmerjs/glimmer-vm/tree/main/packages/%40glimmer/syntax)) _First available in 2.3.0_
+- `"glimmer"` (Ember / Handlebars, via [@glimmer/syntax](https://github.com/glimmerjs/glimmer-vm/tree/main/packages/%40glimmer/syntax)) _First available in 1.10.0_
 - `"yaml"` (via [yaml](https://github.com/eemeli/yaml) and [yaml-unist-parser](https://github.com/ikatyang/yaml-unist-parser)) _First available in 1.14.0_
 
 | Default | CLI Override        | API Override         |

--- a/website/versioned_docs/version-stable/options.md
+++ b/website/versioned_docs/version-stable/options.md
@@ -326,6 +326,7 @@ Valid options:
 - `"angular"` (same parser as `"html"`, but also formats angular-specific syntax via [angular-estree-parser](https://github.com/ikatyang/angular-estree-parser)) _First available in 1.15.0_
 - `"lwc"` (same parser as `"html"`, but also formats LWC-specific syntax for unquoted template attributes) _First available in 1.17.0_
 - `"mjml"` (same parser as `"html"`, but also formats MJML-specific syntax) _First available in 3.6.0_
+- `"glimmer"` (Ember / Handlebars, via [@glimmer/syntax](https://github.com/glimmerjs/glimmer-vm/tree/main/packages/%40glimmer/syntax)) _First available in 1.10.0_
 - `"yaml"` (via [yaml](https://github.com/eemeli/yaml) and [yaml-unist-parser](https://github.com/ikatyang/yaml-unist-parser)) _First available in 1.14.0_
 
 | Default | CLI Override        | API Override         |


### PR DESCRIPTION
## Description

The options page lists every parser Prettier ships with, but `glimmer` isn't there. That's the one for Ember / Handlebars templates. As the issue mentions, if you're trying to format Handlebars there's no way to find that name from the docs alone. It only shows up in the playground or the source. This adds it next to the other markup parsers.

Fixes #19659

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.
