### PR TITLE
Exclude `prettier` license from plugins

### DIFF
--- a/scripts/build/builders/dependencies-license.js
+++ b/scripts/build/builders/dependencies-license.js
@@ -45,6 +45,8 @@ function getDependencies(results) {
 function getLicenseText(packageConfig, dependencies, packageDisplayName) {
   dependencies = dependencies.filter(
     (dependency, index) =>
+      // Exclude Prettier
+      dependency.name !== "prettier" &&
       // Exclude self
       dependency.name !== packageConfig.packageName &&
       // Unique by `name` and `version`


### PR DESCRIPTION
<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.
