### PR TITLE
Fix comments moved in TSConstructorType

### DIFF
--- a/changelog_unreleased/typescript/19669.md
+++ b/changelog_unreleased/typescript/19669.md
@@ -1,0 +1,12 @@
+#### Fix comments moved in `TSConstructorType` (#19669 by @ehsaan-qazi)
+
+<!-- prettier-ignore -->
+```ts
+// Input
+let foo: new /* foo */ (/* bar */) /* baz */ => string;
+
+// Prettier stable
+let foo: new (/* bar */) /* foo */ /* baz */ => string;
+
+// Prettier main
+let foo: new /* foo */ (/* bar */) /* baz */ => string;

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -69,6 +69,7 @@ import {
 function handleOwnLineComment(context) {
   return [
     handleCommentInEmptyParens,
+    handleCommentAroundEmptyConstructorTypeParameters,
     handleIgnoreComments,
     handleConditionalExpressionComments,
     handleLastFunctionParameterComments,
@@ -101,6 +102,7 @@ function handleOwnLineComment(context) {
 function handleEndOfLineComment(context) {
   return [
     handleCommentInEmptyParens,
+    handleCommentAroundEmptyConstructorTypeParameters,
     handleClosureTypeCastComments,
     handleLastFunctionParameterComments,
     handleConditionalExpressionComments,
@@ -134,6 +136,7 @@ function handleEndOfLineComment(context) {
 function handleRemainingComment(context) {
   return [
     handleCommentInEmptyParens,
+    handleCommentAroundEmptyConstructorTypeParameters,
     handleIgnoreComments,
     handleIfStatementComments,
     handleWhileLikeComments,
@@ -516,6 +519,42 @@ function handleCommentInEmptyParens({ comment, enclosingNode, options }) {
   }
 
   return false;
+}
+
+const isConstructorType = createTypeCheckFunction([
+  "TSConstructorType",
+  "TSConstructSignatureDeclaration",
+]);
+
+function handleCommentAroundEmptyConstructorTypeParameters({
+  comment,
+  enclosingNode,
+  text,
+}) {
+  if (
+    !isConstructorType(enclosingNode) ||
+    getFunctionParameters(enclosingNode).length > 0
+  ) {
+    return false;
+  }
+
+  const nextCharacter = getNextNonSpaceNonCommentCharacter(
+    text,
+    locEnd(comment),
+  );
+  const marker =
+    nextCharacter === "("
+      ? "commentBeforeParameters"
+      : nextCharacter === ":" || nextCharacter === "="
+        ? "commentAfterParameters"
+        : undefined;
+
+  if (!marker) {
+    return false;
+  }
+
+  addDanglingComment(enclosingNode, comment, marker);
+  return true;
 }
 
 function handleLastFunctionParameterComments({

--- a/src/language-js/print/function-parameters.js
+++ b/src/language-js/print/function-parameters.js
@@ -34,7 +34,9 @@ import {
 
 // `ArrowFunctionExpression` has other dangling comments
 const functionParameterDanglingCommentFilter = (comment) =>
-  comment.mark !== "commentBeforeArrow";
+  comment.marker !== "commentBeforeArrow" &&
+  comment.marker !== "commentBeforeParameters" &&
+  comment.marker !== "commentAfterParameters";
 
 /*
 - `ArrowFunctionExpression`

--- a/src/language-js/print/function-type.js
+++ b/src/language-js/print/function-type.js
@@ -1,5 +1,7 @@
-import { group } from "../../document/index.js";
+import { group, hardline } from "../../document/index.js";
+import { printDanglingComments } from "../../main/comments/print.js";
 import { hasSameLocStart } from "../location/index.js";
+import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
 import { isFlowObjectTypePropertyAFunction } from "../utilities/is-flow-object-type-property-a-function.js";
 import { printClassMemberSemicolon } from "./class.js";
 import {
@@ -35,6 +37,20 @@ function printFunctionType(path, options, print) {
     parts.push("new ");
   }
 
+  const beforeParametersDoc = printMarkedDanglingComments(
+    path,
+    options,
+    "commentBeforeParameters",
+  );
+  if (beforeParametersDoc) {
+    parts.push(
+      beforeParametersDoc,
+      hasMarkedLineComment(path.node, "commentBeforeParameters")
+        ? hardline
+        : " ",
+    );
+  }
+
   let parametersDoc = printFunctionParameters(
     path,
     options,
@@ -43,6 +59,10 @@ function printFunctionType(path, options, print) {
     /* shouldPrintTypeParameters */ true,
   );
 
+  const hasLineCommentAfterParameters = hasMarkedLineComment(
+    path.node,
+    "commentAfterParameters",
+  );
   const returnTypeDoc = [];
   // `flow` doesn't wrap the `returnType` with `TypeAnnotation`, so the colon
   // needs to be added separately.
@@ -51,6 +71,11 @@ function printFunctionType(path, options, print) {
       isFlowArrowFunctionTypeAnnotation(path) ? " => " : ": ",
       print("returnType"),
     );
+  } else if (hasLineCommentAfterParameters) {
+    // Mark the type annotation as checked without putting its leading space at
+    // the beginning of the line following a line comment.
+    printTypeAnnotationProperty(path, print, "returnType");
+    returnTypeDoc.push(print("returnType"));
   } else {
     returnTypeDoc.push(printTypeAnnotationProperty(path, print, "returnType"));
   }
@@ -59,7 +84,22 @@ function printFunctionType(path, options, print) {
     parametersDoc = group(parametersDoc);
   }
 
-  parts.push(parametersDoc, returnTypeDoc);
+  parts.push(parametersDoc);
+
+  const afterParametersDoc = printMarkedDanglingComments(
+    path,
+    options,
+    "commentAfterParameters",
+  );
+  if (afterParametersDoc) {
+    parts.push(
+      " ",
+      afterParametersDoc,
+      hasLineCommentAfterParameters ? hardline : "",
+    );
+  }
+
+  parts.push(returnTypeDoc);
 
   return [
     group(parts),
@@ -68,6 +108,18 @@ function printFunctionType(path, options, print) {
       ? printClassMemberSemicolon(path, options)
       : "",
   ];
+}
+
+function printMarkedDanglingComments(path, options, marker) {
+  return printDanglingComments(path, options, { marker });
+}
+
+function hasMarkedLineComment(node, marker) {
+  return hasComment(
+    node,
+    CommentCheckFlags.Dangling | CommentCheckFlags.Line,
+    (comment) => comment.marker === marker,
+  );
 }
 
 /*

--- a/tests/format/typescript/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/comments/__snapshots__/format.test.js.snap
@@ -1251,6 +1251,12 @@ type foo8 = /* foo */ (a: /* bar */ string) /* baz */ => void
 
 let foo9: new /* foo */ (/* bar */) /* baz */ => string;
 
+let foo11: new // foo
+() => string;
+
+let foo12: new () // foo
+=> string;
+
 let foo10: new /* foo */ (a: /* bar */ string) /* baz */ => string;
 
 abstract class Test {
@@ -1283,14 +1289,20 @@ interface foo5 {
 }
 
 interface foo6 {
-  /* foo */ new (/* baz */) /* bar */ : /* bat */ string;
+  /* foo */ new /* bar */ (/* baz */): /* bat */ string;
 }
 
 type foo7 = /* foo */ (/* bar */) /* baz */ => void;
 
 type foo8 = /* foo */ (a: /* bar */ string) /* baz */ => void;
 
-let foo9: new (/* bar */) /* foo */ /* baz */ => string;
+let foo9: new /* foo */ (/* bar */) /* baz */ => string;
+
+let foo11: new // foo
+() => string;
+
+let foo12: new () // foo
+=> string;
 
 let foo10: new (/* foo */ a: /* bar */ string) /* baz */ => string;
 

--- a/tests/format/typescript/comments/method_types.ts
+++ b/tests/format/typescript/comments/method_types.ts
@@ -30,6 +30,12 @@ type foo8 = /* foo */ (a: /* bar */ string) /* baz */ => void
 
 let foo9: new /* foo */ (/* bar */) /* baz */ => string;
 
+let foo11: new // foo
+() => string;
+
+let foo12: new () // foo
+=> string;
+
 let foo10: new /* foo */ (a: /* bar */ string) /* baz */ => string;
 
 abstract class Test {


### PR DESCRIPTION
Fixes #18838.

Preserves comments before and after empty TypeScript constructor-type parameter lists.

Also adds regression coverage for block comments, line comments, and construct signatures.

Tests:
- yarn.cmd test tests/format/typescript --runInBand
- ESLint on changed source files