### PR TITLE
Avoid extra parens for nullish coalescing in JSX ternaries

### DIFF
--- a/changelog_unreleased/javascript/19680.md
+++ b/changelog_unreleased/javascript/19680.md
@@ -1,0 +1,25 @@
+#### Avoid extra parentheses for nullish coalescing in JSX-mode ternaries (#19680 by @kushalsacharya)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
+
+// Prettier stable
+condition ? (
+  <Example /> // comment
+) : (
+  ("alpha" ?? "bravo")
+);
+
+// Prettier main
+condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
+```

--- a/src/language-js/parentheses/needs-parentheses.js
+++ b/src/language-js/parentheses/needs-parentheses.js
@@ -32,7 +32,7 @@ import { parentNeedsParentheses } from "./parent-needs-parentheses.js";
  * @param {AstPath} path
  * @returns {boolean}
  */
-function needsParentheses(path, options) {
+function needsParentheses(path, options, args) {
   if (path.isRoot) {
     return false;
   }
@@ -200,7 +200,11 @@ function needsParentheses(path, options) {
           return !isBinaryCastExpression(node);
 
         case "ConditionalExpression":
-          return isBinaryCastExpression(node) || isNullishCoalescing(node);
+          return (
+            isBinaryCastExpression(node) ||
+            (isNullishCoalescing(node) &&
+              !args?.skipNullishCoalescingParensInConditionalExpression)
+          );
 
         case "CallExpression":
         case "NewExpression":

--- a/src/language-js/print/index.js
+++ b/src/language-js/print/index.js
@@ -83,7 +83,7 @@ function print(path, options, print, args) {
       ? printDecorators(path, options, print)
       : "";
 
-  const needsParens = needsParentheses(path, options);
+  const needsParens = needsParentheses(path, options, args);
 
   if (!decoratorsDoc && !needsParens) {
     return doc;

--- a/src/language-js/print/ternary-old.js
+++ b/src/language-js/print/ternary-old.js
@@ -243,9 +243,14 @@ function printTernaryOld(path, options, print) {
     // Even though they don't need parens, we wrap (almost) everything in
     // parens when using ?: within JSX, because the parens are analogous to
     // curly braces in an if statement.
-    const wrap = (doc) => [
+    const printWrappedBranch = (nodePropertyName) => [
       ifBreak("("),
-      indent([softline, doc]),
+      indent([
+        softline,
+        print(nodePropertyName, {
+          skipNullishCoalescingParensInConditionalExpression: true,
+        }),
+      ]),
       softline,
       ifBreak(")"),
     ];
@@ -263,11 +268,11 @@ function printTernaryOld(path, options, print) {
       " ? ",
       isNil(consequentNode)
         ? print(consequentNodePropertyName)
-        : wrap(print(consequentNodePropertyName)),
+        : printWrappedBranch(consequentNodePropertyName),
       " : ",
       alternateNode.type === node.type || isNil(alternateNode)
         ? print(alternateNodePropertyName)
-        : wrap(print(alternateNodePropertyName)),
+        : printWrappedBranch(alternateNodePropertyName),
     );
   } else {
     /*

--- a/tests/format/js/nullish-coalescing/__snapshots__/format.test.js.snap
+++ b/tests/format/js/nullish-coalescing/__snapshots__/format.test.js.snap
@@ -87,7 +87,7 @@ _ = (
            * with zero data rows, the DataTable
            * displays the empty component.
            */
-          (empty ?? null)
+          empty ?? null
         ) : (
           /**
            * After the initial load, if the data for the list

--- a/tests/format/jsx/jsx/__snapshots__/format.test.js.snap
+++ b/tests/format/jsx/jsx/__snapshots__/format.test.js.snap
@@ -1436,6 +1436,12 @@ jsxModeFromElementBreaking ? (
   "a"
 );
 
+jsxModeFromElementBreaking ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
+
 // This ConditionalExpression prints in JSX mode because its alternate is a
 // JSXElement. It is breaking.
 jsxModeFromElementBreaking ? (
@@ -1582,6 +1588,12 @@ jsxModeFromElementBreaking ? (
   </div>
 ) : (
   "a"
+);
+
+jsxModeFromElementBreaking ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
 );
 
 // This ConditionalExpression prints in JSX mode because its alternate is a
@@ -1752,6 +1764,12 @@ jsxModeFromElementBreaking ? (
   "a"
 );
 
+jsxModeFromElementBreaking ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
+
 // This ConditionalExpression prints in JSX mode because its alternate is a
 // JSXElement. It is breaking.
 jsxModeFromElementBreaking ? (
@@ -1898,6 +1916,12 @@ jsxModeFromElementBreaking ? (
   </div>
 ) : (
   "a"
+);
+
+jsxModeFromElementBreaking ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
 );
 
 // This ConditionalExpression prints in JSX mode because its alternate is a
@@ -2068,6 +2092,12 @@ jsxModeFromElementBreaking ? (
   "a"
 );
 
+jsxModeFromElementBreaking ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
+
 // This ConditionalExpression prints in JSX mode because its alternate is a
 // JSXElement. It is breaking.
 jsxModeFromElementBreaking ? (
@@ -2214,6 +2244,12 @@ jsxModeFromElementBreaking ? (
   </div>
 ) : (
   'a'
+);
+
+jsxModeFromElementBreaking ? (
+  <Example /> // comment
+) : (
+  'alpha' ?? 'bravo'
 );
 
 // This ConditionalExpression prints in JSX mode because its alternate is a
@@ -2384,6 +2420,12 @@ jsxModeFromElementBreaking ? (
   "a"
 );
 
+jsxModeFromElementBreaking ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
+
 // This ConditionalExpression prints in JSX mode because its alternate is a
 // JSXElement. It is breaking.
 jsxModeFromElementBreaking ? (
@@ -2530,6 +2572,12 @@ jsxModeFromElementBreaking ? (
   </div>
 ) : (
   'a'
+);
+
+jsxModeFromElementBreaking ? (
+  <Example /> // comment
+) : (
+  'alpha' ?? 'bravo'
 );
 
 // This ConditionalExpression prints in JSX mode because its alternate is a

--- a/tests/format/jsx/jsx/conditional-expression.js
+++ b/tests/format/jsx/jsx/conditional-expression.js
@@ -67,6 +67,12 @@ jsxModeFromElementBreaking ? (
   "a"
 );
 
+jsxModeFromElementBreaking ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
+
 // This ConditionalExpression prints in JSX mode because its alternate is a
 // JSXElement. It is breaking.
 jsxModeFromElementBreaking ? (


### PR DESCRIPTION
## Description

Fixes #19533.

Avoid printing duplicate parentheses around nullish coalescing expressions in JSX-mode ternary branches. The JSX-mode ternary printer already wraps non-nil branches in parentheses when the ternary breaks, so this passes print context through to skip the additional nullish-coalescing parentheses only inside that branch wrapper.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.