### PR TITLE
Fix SCSS compound comparison line breaks

### DIFF
--- a/changelog_unreleased/scss/19687.md
+++ b/changelog_unreleased/scss/19687.md
@@ -1,0 +1,22 @@
+#### Keep SCSS compound comparisons together (#19687 by @aland-omed)
+
+Comparison operands in compound SCSS control conditions are now kept on the
+same line when possible, with line breaks occurring at logical operators.
+
+<!-- prettier-ignore -->
+```scss
+// Input
+@if $something == $something-else and $another-thing == $another-thing-with-long-name {}
+
+// Prettier stable
+@if $something ==
+  $something-else and
+  $another-thing ==
+  $another-thing-with-long-name
+{}
+
+// Prettier main
+@if $something == $something-else and
+  $another-thing == $another-thing-with-long-name
+{}
+```

--- a/changelog_unreleased/scss/19687.md
+++ b/changelog_unreleased/scss/19687.md
@@ -1,7 +1,4 @@
-#### Keep SCSS compound comparisons together (#19687 by @aland-omed)
-
-Comparison operands in compound SCSS control conditions are now kept on the
-same line when possible, with line breaks occurring at logical operators.
+#### Keep compound comparisons together (#19687 by @aland-omed)
 
 <!-- prettier-ignore -->
 ```scss

--- a/src/language-css/print/comma-separated-value-group.js
+++ b/src/language-css/print/comma-separated-value-group.js
@@ -67,6 +67,8 @@ function printCommaSeparatedValueGroup(path, options, print) {
   const isControlDirective =
     atRuleAncestorNode &&
     isSCSSControlDirectiveNode(atRuleAncestorNode, options);
+  const hasLogicalOperator =
+    isControlDirective && node.groups.some(isIfElseKeywordNode);
   const hasInlineComment = node.groups.some((node) =>
     isInlineValueCommentNode(node),
   );
@@ -422,6 +424,8 @@ function printCommaSeparatedValueGroup(path, options, print) {
       isControlDirective &&
       (isEqualityOperatorNode(iNextNode) ||
         isRelationalOperatorNode(iNextNode) ||
+        (hasLogicalOperator &&
+          (isEqualityOperatorNode(iNode) || isRelationalOperatorNode(iNode))) ||
         isIfElseKeywordNode(iNextNode) ||
         isEachKeywordNode(iNode) ||
         isForKeywordNode(iNode))

--- a/tests/format/scss/atrule/__snapshots__/format.test.js.snap
+++ b/tests/format/scss/atrule/__snapshots__/format.test.js.snap
@@ -557,6 +557,7 @@ p {
     @if $very-very-very-long-var == 0 and $very-very-very-long-var == 0 {}
     @if $very-very-very-very-very-very-long-var == 0 and $very-very-very-long-var == 0 {}
     @if $very-very-very-very-very-very-very-very-very-very-very-long-var == 0 and $very-very-very-very-very-very-very-very-very-very-very-long-var == 0 {}
+    @if $something == $something-else and $another-thing == $another-thing-with-long-name {}
     @if $base-font-size != 16px or $base-line-height != 24px or $base-unit != 'em' or $h1-font-size != 2 * $base-font-size or $h2-font-size != 1.5 * $base-font-size or $h3-font-size != 1.17 * $base-font-size or $h4-font-size != 1 * $base-font-size or $h5-font-size != 0.83 * $base-font-size or $h6-font-size != 0.67 * $base-font-size or $indent-amount != 40px {}
     @if (str-slice($item, 0, 1) == ":") {}
     @if (str-slice($item, 0, 3) == " : ") {}
@@ -645,44 +646,34 @@ p {
   }
   @if $very-very-very-long-var == 0 and $very-very-very-long-var == 0 {
   }
-  @if $very-very-very-very-very-very-long-var ==
-    0 and
-    $very-very-very-long-var ==
-    0
+  @if $very-very-very-very-very-very-long-var == 0 and
+    $very-very-very-long-var == 0
   {
   }
-  @if $very-very-very-very-very-very-very-very-very-very-very-long-var ==
-    0 and
-    $very-very-very-very-very-very-very-very-very-very-very-long-var ==
-    0
+  @if $very-very-very-very-very-very-very-very-very-very-very-long-var == 0 and
+    $very-very-very-very-very-very-very-very-very-very-very-long-var == 0
   {
   }
-  @if $base-font-size !=
-    16px or
-    $base-line-height !=
-    24px or
-    $base-unit !=
-    "em" or
-    $h1-font-size !=
-    2 *
+  @if $something == $something-else and
+    $another-thing == $another-thing-with-long-name
+  {
+  }
+  @if $base-font-size != 16px or
+    $base-line-height != 24px or
+    $base-unit != "em" or
+    $h1-font-size != 2 *
     $base-font-size or
-    $h2-font-size !=
-    1.5 *
+    $h2-font-size != 1.5 *
     $base-font-size or
-    $h3-font-size !=
-    1.17 *
+    $h3-font-size != 1.17 *
     $base-font-size or
-    $h4-font-size !=
-    1 *
+    $h4-font-size != 1 *
     $base-font-size or
-    $h5-font-size !=
-    0.83 *
+    $h5-font-size != 0.83 *
     $base-font-size or
-    $h6-font-size !=
-    0.67 *
+    $h6-font-size != 0.67 *
     $base-font-size or
-    $indent-amount !=
-    40px
+    $indent-amount != 40px
   {
   }
   @if (str-slice($item, 0, 1) == ":") {

--- a/tests/format/scss/atrule/if-else.scss
+++ b/tests/format/scss/atrule/if-else.scss
@@ -138,6 +138,7 @@ p {
     @if $very-very-very-long-var == 0 and $very-very-very-long-var == 0 {}
     @if $very-very-very-very-very-very-long-var == 0 and $very-very-very-long-var == 0 {}
     @if $very-very-very-very-very-very-very-very-very-very-very-long-var == 0 and $very-very-very-very-very-very-very-very-very-very-very-long-var == 0 {}
+    @if $something == $something-else and $another-thing == $another-thing-with-long-name {}
     @if $base-font-size != 16px or $base-line-height != 24px or $base-unit != 'em' or $h1-font-size != 2 * $base-font-size or $h2-font-size != 1.5 * $base-font-size or $h3-font-size != 1.17 * $base-font-size or $h4-font-size != 1 * $base-font-size or $h5-font-size != 0.83 * $base-font-size or $h6-font-size != 0.67 * $base-font-size or $indent-amount != 40px {}
     @if (str-slice($item, 0, 1) == ":") {}
     @if (str-slice($item, 0, 3) == " : ") {}


### PR DESCRIPTION
## Description

Keep both sides of comparison operators together in compound SCSS control-directive conditions, allowing lines to break at logical `and` and `or` operators instead.

Fixes #5738.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.