### PR TITLE
Keep comment on the same line in property signature

### DIFF
--- a/changelog_unreleased/typescript/19688.md
+++ b/changelog_unreleased/typescript/19688.md
@@ -1,0 +1,19 @@
+#### Keep comment on the same line in property signature (#19688 by @kovsu)
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+interface A { property: /** Comment */
+B }
+
+// Prettier stable
+interface A {
+  property: /** Comment */
+  B;
+}
+
+// Prettier main
+interface A {
+  property: /** Comment */ B;
+}
+```

--- a/src/language-js/print/flow.js
+++ b/src/language-js/print/flow.js
@@ -1,7 +1,7 @@
 /** @import {Doc} from "../../document/index.js" */
 
 import * as assert from "#universal/assert";
-import { replaceEndOfLine } from "../../document/index.js";
+import { group, replaceEndOfLine } from "../../document/index.js";
 import printNumber from "../../utilities/print-number.js";
 import printString from "../../utilities/print-string.js";
 import { getRaw } from "../utilities/get-raw.js";
@@ -261,13 +261,15 @@ function printFlow(path, options, print, args) {
       }
 
       return [
-        modifier,
-        node.kind !== "init" ? node.kind + " " : "",
-        node.variance ? print("variance") : "",
-        printKey(path, options, print),
-        printOptionalToken(path),
-        isMethod(node) ? "" : ": ",
-        print("value"),
+        group([
+          modifier,
+          node.kind !== "init" ? node.kind + " " : "",
+          node.variance ? print("variance") : "",
+          printKey(path, options, print),
+          printOptionalToken(path),
+          isMethod(node) ? "" : ": ",
+          print("value"),
+        ]),
         printClassMemberSemicolon(path, options),
       ];
     }

--- a/src/language-js/print/index-signature.js
+++ b/src/language-js/print/index-signature.js
@@ -21,13 +21,15 @@ function printIndexSignature(path, options, print) {
   const isClassMember = path.key === "body" && path.parent.type === "ClassBody";
 
   return [
-    // `static` only allowed in class member
-    isClassMember && node.static ? "static " : "",
-    node.readonly ? "readonly " : "",
-    "[",
-    node.parameters ? parametersGroup : "",
-    "]",
-    printTypeAnnotationProperty(path, print),
+    group([
+      // `static` only allowed in class member
+      isClassMember && node.static ? "static " : "",
+      node.readonly ? "readonly " : "",
+      "[",
+      node.parameters ? parametersGroup : "",
+      "]",
+      printTypeAnnotationProperty(path, print),
+    ]),
     printClassMemberSemicolon(path, options),
   ];
 }

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -1,3 +1,4 @@
+import { group } from "../../document/index.js";
 import UnexpectedNodeError from "../../utilities/unexpected-node-error.js";
 import isTsKeywordType from "../utilities/is-ts-keyword-type.js";
 import { printArray } from "./array.js";
@@ -111,10 +112,12 @@ function printTypescript(path, options, print, args) {
       return printArrayType(print);
     case "TSPropertySignature":
       return [
-        node.readonly ? "readonly " : "",
-        printKey(path, options, print),
-        printOptionalToken(path),
-        printTypeAnnotationProperty(path, print),
+        group([
+          node.readonly ? "readonly " : "",
+          printKey(path, options, print),
+          printOptionalToken(path),
+          printTypeAnnotationProperty(path, print),
+        ]),
         printClassMemberSemicolon(path, options),
       ];
 

--- a/tests/format/typescript/index-signature/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/index-signature/__snapshots__/format.test.js.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`comment.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+interface A {
+  [key: string]: /** Comment */
+  B;
+}
+
+interface A {
+  [key: string]: /** Comment */ B;
+}
+
+=====================================output=====================================
+interface A {
+  [key: string]: /** Comment */ B;
+}
+
+interface A {
+  [key: string]: /** Comment */ B;
+}
+
+================================================================================
+`;
+
 exports[`index-signature.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/index-signature/comment.ts
+++ b/tests/format/typescript/index-signature/comment.ts
@@ -1,0 +1,8 @@
+interface A {
+  [key: string]: /** Comment */
+  B;
+}
+
+interface A {
+  [key: string]: /** Comment */ B;
+}

--- a/tests/format/typescript/property-signature/consistent-with-flow/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/property-signature/consistent-with-flow/__snapshots__/format.test.js.snap
@@ -42,8 +42,7 @@ interface A {
 }
 
 interface A {
-  property: /** Comment */
-  B;
+  property: /** Comment */ B;
 }
 
 interface A {


### PR DESCRIPTION
<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

Print `TSPropertySignature`, `TSIndexSignature`, and Flow `ObjectTypeProperty` are the same shape as `printMethodSignature` and `printFunctionType`.

`printMethodSignature` and `printFunctionType` print their members like this below

```ts
  return [group(parts), printClassMemberSemicolon(path, options)];
```

<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
