### PR TITLE
docs: fix helix editor configuration link

### DIFF
--- a/docs/editors.md
+++ b/docs/editors.md
@@ -29,7 +29,7 @@ For more details see [the Vim setup guide](vim.md).
 
 A formatter can be specified in your [Helix language configuration](https://docs.helix-editor.com/languages.html#language-configuration), which will take precedence over any language servers.
 
-For more details see the [Helix external binary formatter configuration for Prettier](https://github.com/helix-editor/helix/wiki/External-formatter-configuration#prettier).
+For more details see the [Helix Formatter Configurations](https://github.com/helix-editor/helix/wiki/Formatter-Configurations) page.
 
 ## Sublime Text
 

--- a/docs/editors.md
+++ b/docs/editors.md
@@ -29,7 +29,7 @@ For more details see [the Vim setup guide](vim.md).
 
 A formatter can be specified in your [Helix language configuration](https://docs.helix-editor.com/languages.html#language-configuration), which will take precedence over any language servers.
 
-For more details see the [Helix Formatter Configurations](https://github.com/helix-editor/helix/wiki/Formatter-Configurations) page.
+For more details see the [Helix Formatter Configurations](https://github.com/helix-editor/helix/wiki/Formatter-Configurations#prettier) page.
 
 ## Sublime Text
 

--- a/website/versioned_docs/version-stable/editors.md
+++ b/website/versioned_docs/version-stable/editors.md
@@ -31,7 +31,6 @@ A formatter can be specified in your [Helix language configuration](https://docs
 
 For more details see the [Helix Formatter Configurations](https://github.com/helix-editor/helix/wiki/Formatter-Configurations#prettier) page.
 
-
 ## Sublime Text
 
 Sublime Text support is available through Package Control and the [JsPrettier](https://packagecontrol.io/packages/JsPrettier) plug-in.

--- a/website/versioned_docs/version-stable/editors.md
+++ b/website/versioned_docs/version-stable/editors.md
@@ -29,7 +29,8 @@ For more details see [the Vim setup guide](vim.md).
 
 A formatter can be specified in your [Helix language configuration](https://docs.helix-editor.com/languages.html#language-configuration), which will take precedence over any language servers.
 
-For more details see the [Helix external binary formatter configuration for Prettier](https://github.com/helix-editor/helix/wiki/External-formatter-configuration#prettier).
+For more details see the [Helix Formatter Configurations](https://github.com/helix-editor/helix/wiki/Formatter-Configurations#prettier) page.
+
 
 ## Sublime Text
 


### PR DESCRIPTION

## Description

Fixing a dead link I found in the "Editor Integration" section of the doc. The link to Helix editor's format configuration page is no longer valid. I have updated to use the correct link.

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.
