### PR TITLE
Fix esm blocks being truncated at blank lines in mdx

### DIFF
--- a/src/language-markdown/acorn/dummy-parser.js
+++ b/src/language-markdown/acorn/dummy-parser.js
@@ -1,3 +1,8 @@
+// TODO[@fisker]: Move this part to acorn parser and access from `options`
+import { Parser as AcornParser } from "acorn";
+import acornJsx from "acorn-jsx";
+
+let acorn;
 function parse(text, options = {}) {
   const program = {
     /** @type {"Program"} */
@@ -8,6 +13,21 @@ function parse(text, options = {}) {
     end: text.length,
     isProgram: true,
   };
+
+  acorn ??= AcornParser.extend(acornJsx());
+
+  try {
+    acorn.parse(text, options);
+  } catch (/** @type {any} */ error) {
+    const message = String(error.message).replace(/ \(\d+:\d+\)$/, "");
+    if (
+      (error.raisedAt >= text.length &&
+        !/^Export '.*' is not defined$/u.test(message)) ||
+      message === "Unterminated comment"
+    ) {
+      throw error;
+    }
+  }
 
   return program;
 }

--- a/tests/format/mdx/import-export/__snapshots__/format.test.js.snap
+++ b/tests/format/mdx/import-export/__snapshots__/format.test.js.snap
@@ -48,6 +48,101 @@ export { foo };
 ================================================================================
 `;
 
+exports[`issue-13934.mdx format 1`] = `
+====================================options=====================================
+parsers: ["mdx"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+export const attempt2 = (input) => {
+    return input.split('\\n').map((line) => line.split(' ')).map((([them, me]) => {
+       console.log(them, me);
+    })).reduce((sum, [them, me]) => {
+let round = 0;
+
+if(me === "X") {round += 1;}
+
+if(me === "Y"){ round += 2;}
+
+    }, 0)
+
+}
+
+=====================================output=====================================
+export const attempt2 = (input) => {
+  return input
+    .split("\\n")
+    .map((line) => line.split(" "))
+    .map(([them, me]) => {
+      console.log(them, me);
+    })
+    .reduce((sum, [them, me]) => {
+      let round = 0;
+
+      if (me === "X") {
+        round += 1;
+      }
+
+      if (me === "Y") {
+        round += 2;
+      }
+    }, 0);
+};
+
+================================================================================
+`;
+
+exports[`issue-16241.mdx format 1`] = `
+====================================options=====================================
+parsers: ["mdx"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+export function Example1() {
+  /** NOT formatted because has empty line */
+  const x =     '42';
+
+  return x;
+}
+
+=====================================output=====================================
+export function Example1() {
+  /** NOT formatted because has empty line */
+  const x = "42";
+
+  return x;
+}
+
+================================================================================
+`;
+
+exports[`issue-17906.mdx format 1`] = `
+====================================options=====================================
+parsers: ["mdx"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+export const description = \`
+  # this is a test
+
+  some text in the body
+\`;
+
+# the actual body
+
+some more text <span className="test">test</span>
+
+=====================================output=====================================
+export const description = \`
+  # this is a test
+
+  some text in the body
+\`;
+
+# the actual body
+
+some more text <span className="test">test</span>
+
+================================================================================
+`;
+
 exports[`like-import-declaration.mdx format 1`] = `
 ====================================options=====================================
 parsers: ["mdx"]
@@ -137,6 +232,28 @@ parsers: ["mdx"]
 import is a word
 =====================================output=====================================
 import is a word
+
+================================================================================
+`;
+
+exports[`unterminated-comment.mdx format 1`] = `
+====================================options=====================================
+parsers: ["mdx"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+export const a = 1; /* comment starts
+
+comment ends */ export const b = "x   y";
+
+# heading
+
+=====================================output=====================================
+export const a = 1;
+/* comment starts
+
+comment ends */ export const b = "x   y";
+
+# heading
 
 ================================================================================
 `;

--- a/tests/format/mdx/import-export/__snapshots__/format.test.js.snap
+++ b/tests/format/mdx/import-export/__snapshots__/format.test.js.snap
@@ -97,7 +97,6 @@ parsers: ["mdx"]
                                                       printWidth: 80 (default) |
 =====================================input======================================
 export function Example1() {
-  /** NOT formatted because has empty line */
   const x =     '42';
 
   return x;
@@ -105,7 +104,6 @@ export function Example1() {
 
 =====================================output=====================================
 export function Example1() {
-  /** NOT formatted because has empty line */
   const x = "42";
 
   return x;

--- a/tests/format/mdx/import-export/issue-13934.mdx
+++ b/tests/format/mdx/import-export/issue-13934.mdx
@@ -1,0 +1,13 @@
+export const attempt2 = (input) => {
+    return input.split('\n').map((line) => line.split(' ')).map((([them, me]) => {
+       console.log(them, me);
+    })).reduce((sum, [them, me]) => {
+let round = 0;
+
+if(me === "X") {round += 1;}
+
+if(me === "Y"){ round += 2;}
+
+    }, 0)
+
+}

--- a/tests/format/mdx/import-export/issue-16241.mdx
+++ b/tests/format/mdx/import-export/issue-16241.mdx
@@ -1,0 +1,6 @@
+export function Example1() {
+  /** NOT formatted because has empty line */
+  const x =     '42';
+
+  return x;
+}

--- a/tests/format/mdx/import-export/issue-16241.mdx
+++ b/tests/format/mdx/import-export/issue-16241.mdx
@@ -1,5 +1,4 @@
 export function Example1() {
-  /** NOT formatted because has empty line */
   const x =     '42';
 
   return x;

--- a/tests/format/mdx/import-export/issue-17906.mdx
+++ b/tests/format/mdx/import-export/issue-17906.mdx
@@ -1,0 +1,9 @@
+export const description = `
+  # this is a test
+
+  some text in the body
+`;
+
+# the actual body
+
+some more text <span className="test">test</span>

--- a/tests/format/mdx/import-export/unterminated-comment.mdx
+++ b/tests/format/mdx/import-export/unterminated-comment.mdx
@@ -1,0 +1,5 @@
+export const a = 1; /* comment starts
+
+comment ends */ export const b = "x   y";
+
+# heading


### PR DESCRIPTION
<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

<!-- Please provide a brief summary of your changes -->

Fixes #13934 
Fixes #16241 
Fixes #17906

In https://github.com/micromark/micromark-extension-mdxjs-esm#authoring, it mentions this.

>We continue parsing until we find a blank line. At that point, we parse with acorn: it if parses, we found our block. Otherwise, if parsing failed at the last character, we assume it’s a blank line in code: we continue on until the next blank line and try again. Otherwise, the acorn error is thrown.

But actually the dummy parser always parses successfully, so the extension always takes the "we found our block" path is always terminated at its first blank line, even when the blank line is inside unfinished code.


## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
