### PR TITLE
Fix comment moved into brackets in object type members

### DIFF
--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -1039,12 +1039,36 @@ function handleLastBinaryOperatorOperand({
 function handlePropertySignatureComments(context) {
   const { enclosingNode, followingNode, comment, options, placement } = context;
 
-  if (
-    !followingNode ||
-    (enclosingNode?.type !== "TSPropertySignature" &&
-      enclosingNode?.type !== "ObjectTypeProperty")
-  ) {
+  if (!followingNode) {
     return false;
+  }
+
+  let keyNode;
+  let valueNode;
+  switch (enclosingNode?.type) {
+    case "TSPropertySignature":
+      keyNode = enclosingNode.key;
+      valueNode = enclosingNode.typeAnnotation;
+      break;
+    case "TSMappedType":
+      keyNode = enclosingNode.nameType ?? enclosingNode.constraint;
+      valueNode = enclosingNode.typeAnnotation;
+      break;
+    case "ObjectTypeProperty":
+    case "ObjectTypeIndexer":
+      keyNode = enclosingNode.key;
+      valueNode = enclosingNode.value;
+      break;
+    case "ObjectTypeInternalSlot":
+      keyNode = enclosingNode.id;
+      valueNode = enclosingNode.value;
+      break;
+    case "ObjectTypeMappedTypeProperty":
+      keyNode = enclosingNode.sourceType;
+      valueNode = enclosingNode.propType;
+      break;
+    default:
+      return false;
   }
 
   if (
@@ -1055,15 +1079,11 @@ function handlePropertySignatureComments(context) {
     return true;
   }
 
-  if (
-    ((enclosingNode.type === "TSPropertySignature" &&
-      enclosingNode.typeAnnotation) ||
-      (enclosingNode.type === "ObjectTypeProperty" && enclosingNode.value)) &&
-    isBlockComment(comment)
-  ) {
+  if (valueNode && isBlockComment(comment)) {
     const colonTokenIndex = stripComments(options).indexOf(
       ":",
-      locEnd(enclosingNode.key),
+      // @ts-expect-error -- safe
+      locEnd(keyNode),
     );
     if (colonTokenIndex < locStart(comment)) {
       return addLeadingCommentToPossibleUnionType(followingNode, context);

--- a/src/language-js/print/flow.js
+++ b/src/language-js/print/flow.js
@@ -1,7 +1,7 @@
 /** @import {Doc} from "../../document/index.js" */
 
 import * as assert from "#universal/assert";
-import { replaceEndOfLine } from "../../document/index.js";
+import { group, replaceEndOfLine } from "../../document/index.js";
 import printNumber from "../../utilities/print-number.js";
 import printString from "../../utilities/print-string.js";
 import { getRaw } from "../utilities/get-raw.js";
@@ -240,14 +240,16 @@ function printFlow(path, options, print, args) {
       return printFlowMappedTypeProperty(path, options, print);
     case "ObjectTypeIndexer":
       return [
-        node.static ? "static " : "",
-        node.variance ? print("variance") : "",
-        "[",
-        print("id"),
-        node.id ? ": " : "",
-        print("key"),
-        "]: ",
-        print("value"),
+        group([
+          node.static ? "static " : "",
+          node.variance ? print("variance") : "",
+          "[",
+          print("id"),
+          node.id ? ": " : "",
+          print("key"),
+          "]: ",
+          print("value"),
+        ]),
         printClassMemberSemicolon(path, options),
       ];
 
@@ -273,13 +275,15 @@ function printFlow(path, options, print, args) {
     }
     case "ObjectTypeInternalSlot":
       return [
-        node.static ? "static " : "",
-        "[[",
-        print("id"),
-        "]]",
-        printOptionalToken(path),
-        node.method ? "" : ": ",
-        print("value"),
+        group([
+          node.static ? "static " : "",
+          "[[",
+          print("id"),
+          "]]",
+          printOptionalToken(path),
+          node.method ? "" : ": ",
+          print("value"),
+        ]),
         printClassMemberSemicolon(path, options),
       ];
     // Same as `RestElement`

--- a/src/language-js/print/mapped-type.js
+++ b/src/language-js/print/mapped-type.js
@@ -107,26 +107,31 @@ function printTypeScriptMappedType(path, options, print) {
       indent([
         options.bracketSpacing ? line : softline,
         ...danglingCommentsDoc,
-        node.readonly
-          ? [printTypeScriptMappedTypeModifier(node.readonly, "readonly"), " "]
-          : "",
         group([
-          "[",
-          indent([
+          node.readonly
+            ? [
+                printTypeScriptMappedTypeModifier(node.readonly, "readonly"),
+                " ",
+              ]
+            : "",
+          group([
+            "[",
+            indent([
+              softline,
+              print("key"),
+              " in ",
+              print("constraint"),
+              node.nameType ? [" as ", print("nameType")] : "",
+            ]),
             softline,
-            print("key"),
-            " in ",
-            print("constraint"),
-            node.nameType ? [" as ", print("nameType")] : "",
+            "]",
           ]),
-          softline,
-          "]",
+          node.optional
+            ? printTypeScriptMappedTypeModifier(node.optional, "?")
+            : "",
+          node.typeAnnotation ? ": " : "",
+          print("typeAnnotation"),
         ]),
-        node.optional
-          ? printTypeScriptMappedTypeModifier(node.optional, "?")
-          : "",
-        node.typeAnnotation ? ": " : "",
-        print("typeAnnotation"),
         options.semi ? ifBreak(";") : "",
       ]),
       options.bracketSpacing ? line : softline,

--- a/tests/format/flow/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/flow/comments/__snapshots__/format.test.js.snap
@@ -302,6 +302,69 @@ type Props3 = {
 ================================================================================
 `;
 
+exports[`object_type_indexer.js format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+type A = {
+  [key: string]: /** Comment */ B,
+};
+
+type A = {
+  [key: string]: /** Comment */
+    B,
+};
+
+type A = {
+  [key: string] /** Comment */
+    : B,
+};
+
+type A = {
+  [key: string]: /** Comment */ | B,
+};
+
+type A = {
+  [key: string] /** Comment */: B | C,
+};
+
+type A = {
+  [key: string]: // Comment
+    | B
+    | C,
+};
+
+=====================================output=====================================
+type A = {
+  [key: string]: /** Comment */ B,
+};
+
+type A = {
+  [key: string]: /** Comment */ B,
+};
+
+type A = {
+  [key: string /** Comment */]: B,
+};
+
+type A = {
+  [key: string]: /** Comment */ B,
+};
+
+type A = {
+  [key: string /** Comment */]: B | C,
+};
+
+type A = {
+  [key: string]:
+    // Comment
+    B | C,
+};
+
+================================================================================
+`;
+
 exports[`type_annotations.js format 1`] = `
 ====================================options=====================================
 parsers: ["flow"]

--- a/tests/format/flow/comments/object_type_indexer.js
+++ b/tests/format/flow/comments/object_type_indexer.js
@@ -1,0 +1,27 @@
+type A = {
+  [key: string]: /** Comment */ B,
+};
+
+type A = {
+  [key: string]: /** Comment */
+    B,
+};
+
+type A = {
+  [key: string] /** Comment */
+    : B,
+};
+
+type A = {
+  [key: string]: /** Comment */ | B,
+};
+
+type A = {
+  [key: string] /** Comment */: B | C,
+};
+
+type A = {
+  [key: string]: // Comment
+    | B
+    | C,
+};

--- a/tests/format/flow/internal-slot/__snapshots__/format.test.js.snap
+++ b/tests/format/flow/internal-slot/__snapshots__/format.test.js.snap
@@ -1,5 +1,68 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`comments.js format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+type A = {
+  [[slot]]: /** Comment */ B,
+};
+
+type A = {
+  [[slot]]: /** Comment */
+    B,
+};
+
+type A = {
+  [[slot]] /** Comment */
+    : B,
+};
+
+type A = {
+  [[slot]]: /** Comment */ | B,
+};
+
+type A = {
+  [[slot]] /** Comment */: B | C,
+};
+
+type A = {
+  [[slot]]: // Comment
+    | B
+    | C,
+};
+
+=====================================output=====================================
+type A = {
+  [[slot]]: /** Comment */ B,
+};
+
+type A = {
+  [[slot]]: /** Comment */ B,
+};
+
+type A = {
+  [[slot /** Comment */]]: B,
+};
+
+type A = {
+  [[slot]]: /** Comment */ B,
+};
+
+type A = {
+  [[slot /** Comment */]]: B | C,
+};
+
+type A = {
+  [[slot]]:
+    // Comment
+    B | C,
+};
+
+================================================================================
+`;
+
 exports[`internal_slot.js format 1`] = `
 ====================================options=====================================
 parsers: ["flow"]

--- a/tests/format/flow/internal-slot/comments.js
+++ b/tests/format/flow/internal-slot/comments.js
@@ -1,0 +1,27 @@
+type A = {
+  [[slot]]: /** Comment */ B,
+};
+
+type A = {
+  [[slot]]: /** Comment */
+    B,
+};
+
+type A = {
+  [[slot]] /** Comment */
+    : B,
+};
+
+type A = {
+  [[slot]]: /** Comment */ | B,
+};
+
+type A = {
+  [[slot]] /** Comment */: B | C,
+};
+
+type A = {
+  [[slot]]: // Comment
+    | B
+    | C,
+};

--- a/tests/format/flow/mapped-types/__snapshots__/format.test.js.snap
+++ b/tests/format/flow/mapped-types/__snapshots__/format.test.js.snap
@@ -46,6 +46,17 @@ type Type = {
   /* bar */ [T in number]: number;
 };
 
+type Type<T> = { [K in keyof T]: /** Comment */ B };
+
+type Type<T> = {
+  [K in keyof T]: /** Comment */
+    B,
+};
+
+type Type<T> = { [K in keyof T]: /** Comment */ | B };
+
+type Type<T> = { [K in keyof T] /** Comment */: B | C };
+
 =====================================output=====================================
 type Type = {
   // comment
@@ -86,6 +97,16 @@ type Type = {
 type Type = {
   +[/* bar */ T in number]: number, // foo
 };
+
+type Type<T> = { [K in keyof T]: /** Comment */ B };
+
+type Type<T> = {
+  [K in keyof T]: /** Comment */ B,
+};
+
+type Type<T> = { [K in keyof T]: /** Comment */ B };
+
+type Type<T> = { [K in keyof T /** Comment */]: B | C };
 
 ================================================================================
 `;

--- a/tests/format/flow/mapped-types/comments.js
+++ b/tests/format/flow/mapped-types/comments.js
@@ -38,3 +38,14 @@ type Type = {
   + // foo
   /* bar */ [T in number]: number;
 };
+
+type Type<T> = { [K in keyof T]: /** Comment */ B };
+
+type Type<T> = {
+  [K in keyof T]: /** Comment */
+    B,
+};
+
+type Type<T> = { [K in keyof T]: /** Comment */ | B };
+
+type Type<T> = { [K in keyof T] /** Comment */: B | C };

--- a/tests/format/typescript/mapped-type/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/mapped-type/__snapshots__/format.test.js.snap
@@ -1,5 +1,35 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`comments.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+type Type<T> = { [K in keyof T]: /** Comment */ B };
+
+type Type<T> = {
+  [K in keyof T]: /** Comment */
+    B;
+};
+
+type Type<T> = { [K in keyof T]: /** Comment */ | B };
+
+type Type<T> = { [K in keyof T] /** Comment */: B | C };
+
+=====================================output=====================================
+type Type<T> = { [K in keyof T]: /** Comment */ B };
+
+type Type<T> = {
+  [K in keyof T]: /** Comment */ B;
+};
+
+type Type<T> = { [K in keyof T]: /** Comment */ B };
+
+type Type<T> = { [K in keyof T /** Comment */]: B | C };
+
+================================================================================
+`;
+
 exports[`intersection.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/mapped-type/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/mapped-type/__snapshots__/format.test.js.snap
@@ -16,6 +16,16 @@ type Type<T> = { [K in keyof T]: /** Comment */ | B };
 
 type Type<T> = { [K in keyof T] /** Comment */: B | C };
 
+type Type<T> = { [K in keyof T as \`get\${K}\`]: /** Comment */ B };
+
+type Type<T> = { [K in keyof T as \`get\${K}\`]: /** Comment */ | B };
+
+type Type<T> = { [K in keyof T as K extends string ? K : never]: /** Comment */ B };
+
+type Type<T> = {
+  [K in keyof T as K extends string ? K : never] /** Comment */: B | C;
+};
+
 =====================================output=====================================
 type Type<T> = { [K in keyof T]: /** Comment */ B };
 
@@ -26,6 +36,18 @@ type Type<T> = {
 type Type<T> = { [K in keyof T]: /** Comment */ B };
 
 type Type<T> = { [K in keyof T /** Comment */]: B | C };
+
+type Type<T> = { [K in keyof T as \`get\${K}\`]: /** Comment */ B };
+
+type Type<T> = { [K in keyof T as \`get\${K}\`]: /** Comment */ B };
+
+type Type<T> = {
+  [K in keyof T as K extends string ? K : never]: /** Comment */ B;
+};
+
+type Type<T> = {
+  [K in keyof T as K extends string ? K : never /** Comment */]: B | C;
+};
 
 ================================================================================
 `;

--- a/tests/format/typescript/mapped-type/comments.ts
+++ b/tests/format/typescript/mapped-type/comments.ts
@@ -1,0 +1,10 @@
+type Type<T> = { [K in keyof T]: /** Comment */ B };
+
+type Type<T> = {
+  [K in keyof T]: /** Comment */
+    B;
+};
+
+type Type<T> = { [K in keyof T]: /** Comment */ | B };
+
+type Type<T> = { [K in keyof T] /** Comment */: B | C };

--- a/tests/format/typescript/mapped-type/comments.ts
+++ b/tests/format/typescript/mapped-type/comments.ts
@@ -8,3 +8,13 @@ type Type<T> = {
 type Type<T> = { [K in keyof T]: /** Comment */ | B };
 
 type Type<T> = { [K in keyof T] /** Comment */: B | C };
+
+type Type<T> = { [K in keyof T as `get${K}`]: /** Comment */ B };
+
+type Type<T> = { [K in keyof T as `get${K}`]: /** Comment */ | B };
+
+type Type<T> = { [K in keyof T as K extends string ? K : never]: /** Comment */ B };
+
+type Type<T> = {
+  [K in keyof T as K extends string ? K : never] /** Comment */: B | C;
+};


### PR DESCRIPTION
<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
