### PR TITLE
fix(markdown): preserve escaped semicolons in character references in URLs

### DIFF
--- a/changelog_unreleased/markdown/19700.md
+++ b/changelog_unreleased/markdown/19700.md
@@ -1,0 +1,15 @@
+#### Fix idempotency for escaped semicolons in Markdown link/image URLs (#19700 by @g1mn)
+
+Previously, an escaped semicolon (`\;`) that prevented a character reference (e.g. `&quot;`) from being decoded was dropped when printing the URL, so a second formatting pass would decode the now-unescaped reference. The escape is now preserved so formatting is stable.
+
+<!-- prettier-ignore -->
+```markdown
+<!-- Input -->
+[test](/hello?foo&quot\;bar)
+
+<!-- Prettier stable -->
+[test](/hello?foo&quot;bar)
+
+<!-- Prettier main -->
+[test](/hello?foo&quot\;bar)
+```

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "collapse-white-space": "1.0.6",
     "css-units-list": "2.1.0",
     "dashify": "2.0.0",
+    "decode-named-character-reference": "1.3.0",
     "deno-path-from-file-url": "0.0.7",
     "diff": "9.0.0",
     "editorconfig-without-wasm": "0.0.7",

--- a/src/language-markdown/print/mdast.js
+++ b/src/language-markdown/print/mdast.js
@@ -1,4 +1,5 @@
 import collapseWhiteSpace from "collapse-white-space";
+import { decodeNamedCharacterReference } from "decode-named-character-reference";
 import escapeStringRegexp from "escape-string-regexp";
 import {
   align,
@@ -518,6 +519,26 @@ const encodeUrl = (url, characters) => {
   return url;
 };
 
+// Matches a character reference as it would be recognized by a CommonMark
+// parser: `&name;` (bounded by `characterReferenceNamedSizeMax`) or a numeric
+// reference like `&#123;`/`&#x1f;` (bounded by the decimal/hexadecimal size
+// maxes).
+const CHARACTER_REFERENCE_REGEX =
+  /&(#(?:\d{1,7}|x[\da-f]{1,6})|[a-z][\da-z]{0,30});/gi;
+
+// A url's node.url is already decoded by the markdown parser, so escape
+// sequences (e.g. `\;`) that prevented a character reference from being
+// decoded are lost. If such a reference is printed back verbatim, formatting
+// again will decode it, breaking idempotency. Re-escape the `;` to keep the
+// reference inert, matching the original, unresolved source.
+function escapeUrlCharacterReferences(url) {
+  return url.replaceAll(CHARACTER_REFERENCE_REGEX, (reference, name) =>
+    name.startsWith("#") || decodeNamedCharacterReference(name) !== false
+      ? reference.slice(0, -1) + String.raw`\;`
+      : reference,
+  );
+}
+
 /**
  * @param {string} url
  * @param {string[] | string} [dangerousCharOrChars]
@@ -530,6 +551,8 @@ function printUrl(url, dangerousCharOrChars = []) {
       ? dangerousCharOrChars
       : [dangerousCharOrChars]),
   ];
+
+  url = escapeUrlCharacterReferences(url);
 
   return new RegExp(
     dangerousChars.map((x) => escapeStringRegexp(x)).join("|"),

--- a/tests/format/markdown/link/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/link/__snapshots__/format.test.js.snap
@@ -129,6 +129,36 @@ proseWrap: "always"
 ================================================================================
 `;
 
+exports[`escaped-character-reference.md - {"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+proseWrap: "always"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+[test](/hello?foo&quot\\;bar)
+
+[test](/hello?foo&quot;bar)
+
+[test](/hello?foo&#34\\;bar)
+
+[test](/hello?foo&#x22\\;bar)
+
+[test](/hello?foo&notarealentity\\;bar)
+
+=====================================output=====================================
+[test](/hello?foo&quot\\;bar)
+
+[test](/hello?foo"bar)
+
+[test](/hello?foo&#34\\;bar)
+
+[test](/hello?foo&#x22\\;bar)
+
+[test](/hello?foo&notarealentity;bar)
+
+================================================================================
+`;
+
 exports[`long.md - {"proseWrap":"always"} format 1`] = `
 ====================================options=====================================
 parsers: ["markdown"]

--- a/tests/format/markdown/link/escaped-character-reference.md
+++ b/tests/format/markdown/link/escaped-character-reference.md
@@ -1,0 +1,9 @@
+[test](/hello?foo&quot\;bar)
+
+[test](/hello?foo&quot;bar)
+
+[test](/hello?foo&#34\;bar)
+
+[test](/hello?foo&#x22\;bar)
+
+[test](/hello?foo&notarealentity\;bar)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4109,7 +4109,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decode-named-character-reference@npm:^1.0.0":
+"decode-named-character-reference@npm:1.3.0, decode-named-character-reference@npm:^1.0.0":
   version: 1.3.0
   resolution: "decode-named-character-reference@npm:1.3.0"
   dependencies:
@@ -8286,6 +8286,7 @@ __metadata:
     cspell: "npm:10.0.1"
     css-units-list: "npm:2.1.0"
     dashify: "npm:2.0.0"
+    decode-named-character-reference: "npm:1.3.0"
     deno-path-from-file-url: "npm:0.0.7"
     diff: "npm:9.0.0"
     editorconfig-without-wasm: "npm:0.0.7"


### PR DESCRIPTION
## Description
Fixes #19588 — a Markdown idempotency bug.

When a link/image URL contains an escaped semicolon that prevents a character reference from decoding (e.g. `[test](/hello?foo&quot\;bar)`), the backslash escape was dropped on the first format pass, producing `&quot;`. A second pass then decoded `&quot;` into `"`, so formatting was not idempotent.

This preserves the escape for the semicolon of a valid named/numeric character reference, so the output is stable across passes.

## Test
Added `tests/format/markdown/link/escaped-character-reference.md` covering named (`&quot\;`), decimal (`&#34\;`), hex (`&#x22\;`), invalid-entity fallback, and an unescaped control case. Full `yarn test` and the idempotency (`FULL_TEST=1`) pass; `yarn lint`/`lint:changelog` clean; changelog entry added.

Closes #19588

---
<sub>Independently cross-reviewed with a second AI model before submission.</sub>
