### PR TITLE
docs: document addAlignmentToDoc in commands.md

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -234,6 +234,22 @@ For example:
     - `<indent><align 2><indent><align 2>` -> `<tab><tab><tab><2 space>`
     - `<indent><align 4><indent><align 2>` -> `<tab><tab><tab><2 space>`
 
+### `addAlignmentToDoc`
+
+```ts
+declare function addAlignmentToDoc(
+  doc: Doc,
+  size: number,
+  tabWidth: number,
+): Doc;
+```
+
+Align `doc` as if it starts at column `size` from the left edge of the document, using `tabWidth` to choose how many indent levels versus remaining spaces to apply.
+
+Unlike [`align`](#align) and [`indent`](#indent), which adjust relative to the current indentation, `addAlignmentToDoc` resets indentation to the root and then applies the equivalent of `floor(size / tabWidth)` indents plus `size % tabWidth` spaces.
+
+This is useful when a nested document should line up with content elsewhere on the page, for example aligning an interpolated expression in a template literal with the `${` that opens it.
+
 ### `markAsRoot`
 
 ```ts

--- a/src/document/public.d.ts
+++ b/src/document/public.d.ts
@@ -107,6 +107,7 @@ export namespace builders {
     id?: symbol | undefined;
   }
 
+  /** @see [addAlignmentToDoc](https://github.com/prettier/prettier/blob/main/commands.md#addalignmenttodoc) */
   function addAlignmentToDoc(doc: Doc, size: number, tabWidth: number): Doc;
 
   /** @see [align](https://github.com/prettier/prettier/blob/main/commands.md#align) */


### PR DESCRIPTION
## Description

Documents the missing `addAlignmentToDoc` doc builder in `commands.md` so the `#addalignmenttodoc` anchor resolves, and adds a matching `@see` link on the TypeScript declaration.

Fixes #10962.

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.