### PR TITLE
Fix HTML attribute name normalization

### DIFF
--- a/changelog_unreleased/html/19709.md
+++ b/changelog_unreleased/html/19709.md
@@ -1,0 +1,16 @@
+#### Fix attribute name normalization (#19709 by @fisker)
+
+<!-- prettier-ignore -->
+```html
+<!-- Input -->
+<span CLASS="foo"></span>
+<div CLASS="foo"></div>
+
+<!-- Prettier stable -->
+<span CLASS="foo"></span>
+<div class="foo"></div>
+
+<!-- Prettier main -->
+<span class="foo"></span>
+<div class="foo"></div>
+```

--- a/jest.config.js
+++ b/jest.config.js
@@ -74,6 +74,7 @@ if (nodejsMajorVersion <= 14) {
     "tests/integration/__tests__/experimental-cli.js",
     // Fails on Node.js v14
     "tests/dts/unit/run.js",
+    "tests/format/html/attributes/lowercase/format.test.js",
   );
 }
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -61,7 +61,10 @@ if (TEST_RUNTIME === "browser") {
 
 if (nodejsMajorVersion <= 18) {
   // Uses import attributes and `Array#toSorted()`
-  testPathIgnorePatterns.push("tests/integration/__tests__/help-options.js");
+  testPathIgnorePatterns.push(
+    "tests/integration/__tests__/help-options.js",
+    "tests/format/html/attributes/lowercase/format.test.js",
+  );
 }
 
 if (nodejsMajorVersion <= 14) {
@@ -74,7 +77,6 @@ if (nodejsMajorVersion <= 14) {
     "tests/integration/__tests__/experimental-cli.js",
     // Fails on Node.js v14
     "tests/dts/unit/run.js",
-    "tests/format/html/attributes/lowercase/format.test.js",
   );
 }
 

--- a/src/language-html/parse/postprocess.js
+++ b/src/language-html/parse/postprocess.js
@@ -243,7 +243,7 @@ function normalizeName(node, parseOptions) {
             (lowerCasedAttrName) =>
               HTML_TAGS.has(node.name) &&
               (GLOBAL_ATTRIBUTES.has(lowerCasedAttrName) ||
-                ELEMENT_ATTRIBUTES.get(node.name).has(lowerCasedAttrName)),
+                ELEMENT_ATTRIBUTES.get(node.name)?.has(lowerCasedAttrName)),
           );
         }
       }

--- a/src/language-html/parse/postprocess.js
+++ b/src/language-html/parse/postprocess.js
@@ -241,7 +241,7 @@ function normalizeName(node, parseOptions) {
           attr.name = lowerCaseIf(
             attr.name,
             (lowerCasedAttrName) =>
-              ELEMENT_ATTRIBUTES.has(node.name) &&
+              HTML_TAGS.has(node.name) &&
               (GLOBAL_ATTRIBUTES.has(lowerCasedAttrName) ||
                 ELEMENT_ATTRIBUTES.get(node.name).has(lowerCasedAttrName)),
           );

--- a/tests/format/html/attributes/lowercase/__snapshots__/format.test.js.snap
+++ b/tests/format/html/attributes/lowercase/__snapshots__/format.test.js.snap
@@ -5,13 +5,28 @@ exports[`snippet: #0 format 1`] = `
 parsers: ["html"]
                                                       printWidth: 80 (default) |
 =====================================input======================================
-<div CLASS="should print as lowercase">Tag with attributes</div>
-<span CLASS="should print as lowercase">Tag without attributes</span>
-<unknown CLASS="should print as uppercase">Non-html element</unknown>
+<div
+  CLASS="should print as lowercase"
+  UNKNOWN="should print as uppercase"
+>Tag with attributes</div>
+<span
+  CLASS="should print as lowercase"
+  UNKNOWN="should print as uppercase"
+>Tag without attributes</span>
+<unknown
+  CLASS="should print as uppercase"
+  UNKNOWN="should print as uppercase"
+>Non-html element</unknown>
 =====================================output=====================================
-<div class="should print as lowercase">Tag with attributes</div>
-<span class="should print as lowercase">Tag without attributes</span>
-<unknown CLASS="should print as uppercase">Non-html element</unknown>
+<div class="should print as lowercase" UNKNOWN="should print as uppercase">
+  Tag with attributes
+</div>
+<span class="should print as lowercase" UNKNOWN="should print as uppercase"
+  >Tag without attributes</span
+>
+<unknown CLASS="should print as uppercase" UNKNOWN="should print as uppercase"
+  >Non-html element</unknown
+>
 
 ================================================================================
 `;

--- a/tests/format/html/attributes/lowercase/__snapshots__/format.test.js.snap
+++ b/tests/format/html/attributes/lowercase/__snapshots__/format.test.js.snap
@@ -5,13 +5,13 @@ exports[`snippet: #0 format 1`] = `
 parsers: ["html"]
                                                       printWidth: 80 (default) |
 =====================================input======================================
-
-        <div CLASS="should print as lowercase">Tag with attributes</div>
-        <span CLASS="should print as lowercase">Tag without attributes</span>
-      
+<div CLASS="should print as lowercase">Tag with attributes</div>
+<span CLASS="should print as lowercase">Tag without attributes</span>
+<unknown CLASS="should print as uppercase">Non-html element</unknown>
 =====================================output=====================================
 <div class="should print as lowercase">Tag with attributes</div>
 <span class="should print as lowercase">Tag without attributes</span>
+<unknown CLASS="should print as uppercase">Non-html element</unknown>
 
 ================================================================================
 `;

--- a/tests/format/html/attributes/lowercase/__snapshots__/format.test.js.snap
+++ b/tests/format/html/attributes/lowercase/__snapshots__/format.test.js.snap
@@ -7,30 +7,30 @@ parsers: ["html"]
 =====================================input======================================
 <div
   CLASS="should print as lowercase"
-  UNKNOWN="should print as uppercase"
+  UNKNOWN="should print as UPPERCASE"
 >
   Tag with attributes
 </div>
 <span
   CLASS="should print as lowercase"
-  UNKNOWN="should print as uppercase"
+  UNKNOWN="should print as UPPERCASE"
 >
   Tag without attributes
 </span>
 <unknown
-  CLASS="should print as uppercase"
-  UNKNOWN="should print as uppercase"
+  CLASS="should print as UPPERCASE"
+  UNKNOWN="should print as UPPERCASE"
 >
   Non-html element
 </unknown>
 =====================================output=====================================
-<div class="should print as lowercase" UNKNOWN="should print as uppercase">
+<div class="should print as lowercase" UNKNOWN="should print as UPPERCASE">
   Tag with attributes
 </div>
-<span class="should print as lowercase" UNKNOWN="should print as uppercase">
+<span class="should print as lowercase" UNKNOWN="should print as UPPERCASE">
   Tag without attributes
 </span>
-<unknown CLASS="should print as uppercase" UNKNOWN="should print as uppercase">
+<unknown CLASS="should print as UPPERCASE" UNKNOWN="should print as UPPERCASE">
   Non-html element
 </unknown>
 

--- a/tests/format/html/attributes/lowercase/__snapshots__/format.test.js.snap
+++ b/tests/format/html/attributes/lowercase/__snapshots__/format.test.js.snap
@@ -11,7 +11,7 @@ parsers: ["html"]
       
 =====================================output=====================================
 <div class="should print as lowercase">Tag with attributes</div>
-<span CLASS="should print as lowercase">Tag without attributes</span>
+<span class="should print as lowercase">Tag without attributes</span>
 
 ================================================================================
 `;

--- a/tests/format/html/attributes/lowercase/__snapshots__/format.test.js.snap
+++ b/tests/format/html/attributes/lowercase/__snapshots__/format.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`snippet: #0 format 1`] = `
+====================================options=====================================
+parsers: ["html"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+
+        <div CLASS="should print as lowercase">Tag with attributes</div>
+        <span CLASS="should print as lowercase">Tag without attributes</span>
+      
+=====================================output=====================================
+<div class="should print as lowercase">Tag with attributes</div>
+<span CLASS="should print as lowercase">Tag without attributes</span>
+
+================================================================================
+`;

--- a/tests/format/html/attributes/lowercase/__snapshots__/format.test.js.snap
+++ b/tests/format/html/attributes/lowercase/__snapshots__/format.test.js.snap
@@ -8,25 +8,31 @@ parsers: ["html"]
 <div
   CLASS="should print as lowercase"
   UNKNOWN="should print as uppercase"
->Tag with attributes</div>
+>
+  Tag with attributes
+</div>
 <span
   CLASS="should print as lowercase"
   UNKNOWN="should print as uppercase"
->Tag without attributes</span>
+>
+  Tag without attributes
+</span>
 <unknown
   CLASS="should print as uppercase"
   UNKNOWN="should print as uppercase"
->Non-html element</unknown>
+>
+  Non-html element
+</unknown>
 =====================================output=====================================
 <div class="should print as lowercase" UNKNOWN="should print as uppercase">
   Tag with attributes
 </div>
-<span class="should print as lowercase" UNKNOWN="should print as uppercase"
-  >Tag without attributes</span
->
-<unknown CLASS="should print as uppercase" UNKNOWN="should print as uppercase"
-  >Non-html element</unknown
->
+<span class="should print as lowercase" UNKNOWN="should print as uppercase">
+  Tag without attributes
+</span>
+<unknown CLASS="should print as uppercase" UNKNOWN="should print as uppercase">
+  Non-html element
+</unknown>
 
 ================================================================================
 `;

--- a/tests/format/html/attributes/lowercase/format.test.js
+++ b/tests/format/html/attributes/lowercase/format.test.js
@@ -1,5 +1,6 @@
 import { elementAttributes } from "@prettier/html-attributes";
 import { htmlTags } from "@prettier/html-tags";
+import { outdent } from "outdent";
 
 const tagWithAttribute = elementAttributes.div
   ? "div"
@@ -12,9 +13,10 @@ runFormatTest(
   {
     importMeta: import.meta,
     snippets: [
-      /* Indent */ `
+      outdent`
         <${tagWithAttribute} CLASS="should print as lowercase">Tag with attributes</${tagWithAttribute}>
         <${tagWithoutAttribute} CLASS="should print as lowercase">Tag without attributes</${tagWithoutAttribute}>
+        <unknown CLASS="should print as uppercase">Non-html element</unknown>
       `,
     ],
   },

--- a/tests/format/html/attributes/lowercase/format.test.js
+++ b/tests/format/html/attributes/lowercase/format.test.js
@@ -16,19 +16,19 @@ runFormatTest(
       outdent`
         <${tagWithAttribute}
           CLASS="should print as lowercase"
-          UNKNOWN="should print as uppercase"
+          UNKNOWN="should print as UPPERCASE"
         >
           Tag with attributes
         </${tagWithAttribute}>
         <${tagWithoutAttribute}
           CLASS="should print as lowercase"
-          UNKNOWN="should print as uppercase"
+          UNKNOWN="should print as UPPERCASE"
         >
           Tag without attributes
         </${tagWithoutAttribute}>
         <unknown
-          CLASS="should print as uppercase"
-          UNKNOWN="should print as uppercase"
+          CLASS="should print as UPPERCASE"
+          UNKNOWN="should print as UPPERCASE"
         >
           Non-html element
         </unknown>

--- a/tests/format/html/attributes/lowercase/format.test.js
+++ b/tests/format/html/attributes/lowercase/format.test.js
@@ -1,0 +1,22 @@
+import { elementAttributes } from "@prettier/html-attributes";
+import { htmlTags } from "@prettier/html-tags";
+
+const tagWithAttribute = elementAttributes.div
+  ? "div"
+  : htmlTags.find((tag) => elementAttributes[tag]);
+const tagWithoutAttribute = !elementAttributes.span
+  ? "span"
+  : htmlTags.find((tag) => !elementAttributes[tag]);
+
+runFormatTest(
+  {
+    importMeta: import.meta,
+    snippets: [
+      /* Indent */ `
+        <${tagWithAttribute} CLASS="should print as lowercase">Tag with attributes</${tagWithAttribute}>
+        <${tagWithoutAttribute} CLASS="should print as lowercase">Tag without attributes</${tagWithoutAttribute}>
+      `,
+    ],
+  },
+  ["html"],
+);

--- a/tests/format/html/attributes/lowercase/format.test.js
+++ b/tests/format/html/attributes/lowercase/format.test.js
@@ -17,15 +17,21 @@ runFormatTest(
         <${tagWithAttribute}
           CLASS="should print as lowercase"
           UNKNOWN="should print as uppercase"
-        >Tag with attributes</${tagWithAttribute}>
+        >
+          Tag with attributes
+        </${tagWithAttribute}>
         <${tagWithoutAttribute}
           CLASS="should print as lowercase"
           UNKNOWN="should print as uppercase"
-        >Tag without attributes</${tagWithoutAttribute}>
+        >
+          Tag without attributes
+        </${tagWithoutAttribute}>
         <unknown
           CLASS="should print as uppercase"
           UNKNOWN="should print as uppercase"
-        >Non-html element</unknown>
+        >
+          Non-html element
+        </unknown>
       `,
     ],
   },

--- a/tests/format/html/attributes/lowercase/format.test.js
+++ b/tests/format/html/attributes/lowercase/format.test.js
@@ -14,9 +14,18 @@ runFormatTest(
     importMeta: import.meta,
     snippets: [
       outdent`
-        <${tagWithAttribute} CLASS="should print as lowercase">Tag with attributes</${tagWithAttribute}>
-        <${tagWithoutAttribute} CLASS="should print as lowercase">Tag without attributes</${tagWithoutAttribute}>
-        <unknown CLASS="should print as uppercase">Non-html element</unknown>
+        <${tagWithAttribute}
+          CLASS="should print as lowercase"
+          UNKNOWN="should print as uppercase"
+        >Tag with attributes</${tagWithAttribute}>
+        <${tagWithoutAttribute}
+          CLASS="should print as lowercase"
+          UNKNOWN="should print as uppercase"
+        >Tag without attributes</${tagWithoutAttribute}>
+        <unknown
+          CLASS="should print as uppercase"
+          UNKNOWN="should print as uppercase"
+        >Non-html element</unknown>
       `,
     ],
   },


### PR DESCRIPTION
<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

<!-- Please provide a brief summary of your changes -->

Previously, it checked against `html-element-attributes` which is incorrect.
Found this during https://github.com/prettier/prettier/pull/19707#discussion_r3645885235

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.
