### PR TITLE
docs: update pretty-quick repository link

### DIFF
--- a/docs/related-projects.md
+++ b/docs/related-projects.md
@@ -24,7 +24,7 @@ title: Related Projects
 
 - [parallel-prettier](https://github.com/microsoft/parallel-prettier) is an alternative CLI that formats files in parallel to speed up large projects
 - [prettier_d](https://github.com/josephfrazier/prettier_d.js) runs Prettier as a server to avoid Node.js startup delay
-- [pretty-quick](https://github.com/azz/pretty-quick) formats changed files with Prettier
+- [pretty-quick](https://github.com/prettier/pretty-quick) formats changed files with Prettier
 - [rollup-plugin-prettier](https://github.com/mjeanroy/rollup-plugin-prettier) allows you to use Prettier with Rollup
 - [jest-runner-prettier](https://github.com/keplersj/jest-runner-prettier) is Prettier as a Jest runner
 - [prettier-chrome](https://github.com/u3u/prettier-chrome) is an extension that runs Prettier in the browser

--- a/website/versioned_docs/version-stable/related-projects.md
+++ b/website/versioned_docs/version-stable/related-projects.md
@@ -24,7 +24,7 @@ title: Related Projects
 
 - [parallel-prettier](https://github.com/microsoft/parallel-prettier) is an alternative CLI that formats files in parallel to speed up large projects
 - [prettier_d](https://github.com/josephfrazier/prettier_d.js) runs Prettier as a server to avoid Node.js startup delay
-- [pretty-quick](https://github.com/azz/pretty-quick) formats changed files with Prettier
+- [pretty-quick](https://github.com/prettier/pretty-quick) formats changed files with Prettier
 - [rollup-plugin-prettier](https://github.com/mjeanroy/rollup-plugin-prettier) allows you to use Prettier with Rollup
 - [jest-runner-prettier](https://github.com/keplersj/jest-runner-prettier) is Prettier as a Jest runner
 - [prettier-chrome](https://github.com/u3u/prettier-chrome) is an extension that runs Prettier in the browser


### PR DESCRIPTION
The `pretty-quick` entry in `docs/related-projects.md` linked to `azz/pretty-quick`, which redirects but is inconsistent with `docs/precommit.md` (and the repo org transfer). Update it to `prettier/pretty-quick` for consistency.