### PR TITLE
docs: fix MDX parser attribution to remark-mdx

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -320,7 +320,7 @@ Valid options:
 - `"json-stringify"` (parse like `JSON.parse()` except it's less strict, whitespace resembles `JSON.stringify()`) _First available in v1.13.0_
 - `"graphql"` (via [graphql/language](https://github.com/graphql/graphql-js/tree/main/src/language)) _First available in v1.5.0_
 - `"markdown"` (via [micromark](https://github.com/micromark/micromark)) _First available in v1.8.0_
-- `"mdx"` (via [remark-parse](https://github.com/wooorm/remark/tree/main/packages/remark-parse) and [@mdx-js/mdx](https://github.com/mdx-js/mdx/tree/master/packages/mdx)) _First available in v1.15.0_
+- `"mdx"` (via [remark-parse](https://github.com/wooorm/remark/tree/main/packages/remark-parse) and [remark-mdx](https://github.com/mdx-js/mdx/tree/main/packages/remark-mdx)) _First available in v1.15.0_
 - `"html"` (via [angular-html-parser](https://github.com/ikatyang/angular-html-parser/tree/master/packages/angular-html-parser)) _First available in 1.15.0_
 - `"vue"` (same parser as `"html"`, but also formats vue-specific syntax) _First available in 1.10.0_
 - `"angular"` (same parser as `"html"`, but also formats angular-specific syntax via [angular-estree-parser](https://github.com/ikatyang/angular-estree-parser)) _First available in 1.15.0_

--- a/website/versioned_docs/version-stable/options.md
+++ b/website/versioned_docs/version-stable/options.md
@@ -320,7 +320,7 @@ Valid options:
 - `"json-stringify"` (parse like `JSON.parse()` except it's less strict, whitespace resembles `JSON.stringify()`) _First available in v1.13.0_
 - `"graphql"` (via [graphql/language](https://github.com/graphql/graphql-js/tree/main/src/language)) _First available in v1.5.0_
 - `"markdown"` (via [micromark](https://github.com/micromark/micromark)) _First available in v1.8.0_
-- `"mdx"` (via [remark-parse](https://github.com/wooorm/remark/tree/main/packages/remark-parse) and [@mdx-js/mdx](https://github.com/mdx-js/mdx/tree/master/packages/mdx)) _First available in v1.15.0_
+- `"mdx"` (via [remark-parse](https://github.com/wooorm/remark/tree/main/packages/remark-parse) and [remark-mdx](https://github.com/mdx-js/mdx/tree/main/packages/remark-mdx)) _First available in v1.15.0_
 - `"html"` (via [angular-html-parser](https://github.com/ikatyang/angular-html-parser/tree/master/packages/angular-html-parser)) _First available in 1.15.0_
 - `"vue"` (same parser as `"html"`, but also formats vue-specific syntax) _First available in 1.10.0_
 - `"angular"` (same parser as `"html"`, but also formats angular-specific syntax via [angular-estree-parser](https://github.com/ikatyang/angular-estree-parser)) _First available in 1.15.0_


### PR DESCRIPTION
## Description

`docs/options.md` incorrectly attributed the MDX parser to `@mdx-js/mdx`. The actual derived MDX parsing code comes from `packages/remark-mdx`.

## Problem

The `mdx` parser entry linked to `@mdx-js/mdx` (the compiler package) instead of the remark plugin whose code Prettier uses.

## Root cause

- `src/language-markdown/parse/mdx.js` is “modified from …/packages/remark-mdx/index.js”.
- `src/language-markdown/embed.js` references `…/packages/remark-mdx/extract-imports-and-exports.js` for MDX import/export validation.

## Fix

Update `docs/options.md` line 323 to link to `remark-mdx` at `mdx-js/mdx/tree/main/packages/remark-mdx`, leaving the existing `remark-parse` link unchanged.

## Verification

- `python3 ../scripts/preflight_ship.py --repo prettier/prettier --local prettier --branch main --file docs/options.md --must-contain '@mdx-js/mdx](https://github.com/mdx-js/mdx/tree/master/packages/mdx)' --must-not-contain 'packages/remark-mdx' --search 'mdx parser attribution' --search 'remark-mdx in:title,body'` returned exit 0.
- Confirmed upstream `docs/options.md` still has the old attribution.
- Confirmed `src/language-markdown/parse/mdx.js` and `src/language-markdown/embed.js` cite `packages/remark-mdx`.

## Checklist

- [ ] I’ve added tests to confirm my change works. (Not applicable; docs-only link fix.)
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory). (Not applicable.)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`. (Not applicable; this is a documentation link correction.)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
