### PR TITLE
Fix embedded HTML template expression idempotency

### DIFF
--- a/changelog_unreleased/javascript/19722.md
+++ b/changelog_unreleased/javascript/19722.md
@@ -1,0 +1,73 @@
+#### Make embedded HTML template formatting idempotent (#19722 by @deepakganesh78)
+
+Multiline JavaScript expressions in embedded HTML templates no longer keep stale indentation from the input when the HTML printer moves the interpolation.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+const list = html`
+  <ol>
+    ${items.map(
+      (entry) => html`
+        <li>
+          ${entry.children
+            ? html`
+                <ol>
+                  ${entry.children.map(
+                    (child) => html`<li>${child.title}</li>`,
+                  )}
+                </ol>
+              `
+            : entry.title}
+        </li>
+      `,
+    )}
+  </ol>
+`;
+
+// Prettier stable
+const list = html`
+  <ol>
+    ${items.map(
+      (entry) => html`
+        <li>
+          ${
+            entry.children
+              ? html`
+                  <ol>
+                    ${entry.children.map(
+                    (child) => html`<li>${child.title}</li>`,
+                  )}
+                  </ol>
+                `
+              : entry.title
+          }
+        </li>
+      `,
+    )}
+  </ol>
+`;
+
+// Prettier main
+const list = html`
+  <ol>
+    ${items.map(
+      (entry) => html`
+        <li>
+          ${
+            entry.children
+              ? html`
+                  <ol>
+                    ${entry.children.map(
+                      (child) => html`<li>${child.title}</li>`,
+                    )}
+                  </ol>
+                `
+              : entry.title
+          }
+        </li>
+      `,
+    )}
+  </ol>
+`;
+```

--- a/src/language-js/embed/html.js
+++ b/src/language-js/embed/html.js
@@ -30,7 +30,9 @@ async function printEmbedHtmlLike(parser, textToDoc, print, path, options) {
     )
     .join("");
 
-  const expressionDocs = printTemplateExpressions(path, options, print);
+  const expressionDocs = printTemplateExpressions(path, options, print, {
+    shouldPreserveIndentation: false,
+  });
 
   const placeholderRegex = new RegExp(
     composePlaceholder(String.raw`(\d+)`),

--- a/src/language-js/print/template-literal.js
+++ b/src/language-js/print/template-literal.js
@@ -203,7 +203,12 @@ function getTemplateLiteralExpressionIndent(path, options) {
 - `TemplateLiteral`
 - `TSTemplateLiteralType` (TypeScript)
 */
-function printTemplateExpression(path, options, print) {
+function printTemplateExpression(
+  path,
+  options,
+  print,
+  { shouldPreserveIndentation },
+) {
   const { node, index } = path;
   let expressionDoc = print();
 
@@ -260,25 +265,35 @@ function printTemplateExpression(path, options, print) {
   // quasi literal), therefore we want to indent the JavaScript
   // expression inside at the beginning of ${ instead of the beginning
   // of the `.
-  let { indentSize, previousQuasiText } = getTemplateLiteralExpressionIndent(
-    path,
-    options,
-  );
-  // In `jest.each`, we know expression will at least indent 2 level
-  if (options.__inJestEach) {
-    indentSize = Math.max(indentSize, options.tabWidth);
+  if (shouldPreserveIndentation) {
+    let { indentSize, previousQuasiText } = getTemplateLiteralExpressionIndent(
+      path,
+      options,
+    );
+    // In `jest.each`, we know expression will at least indent 2 level
+    if (options.__inJestEach) {
+      indentSize = Math.max(indentSize, options.tabWidth);
+    }
+    expressionDoc =
+      indentSize === 0 && previousQuasiText.endsWith("\n")
+        ? align(Number.NEGATIVE_INFINITY, expressionDoc)
+        : addAlignmentToDoc(expressionDoc, indentSize, options.tabWidth);
   }
-  expressionDoc =
-    indentSize === 0 && previousQuasiText.endsWith("\n")
-      ? align(Number.NEGATIVE_INFINITY, expressionDoc)
-      : addAlignmentToDoc(expressionDoc, indentSize, options.tabWidth);
 
   return group(["${", expressionDoc, lineSuffixBoundary, "}"]);
 }
 
-function printTemplateExpressions(path, options, print) {
+function printTemplateExpressions(
+  path,
+  options,
+  print,
+  { shouldPreserveIndentation = true } = {},
+) {
   return path.map(
-    () => printTemplateExpression(path, options, print),
+    () =>
+      printTemplateExpression(path, options, print, {
+        shouldPreserveIndentation,
+      }),
     path.node.type === "TSTemplateLiteralType" ? "types" : "expressions",
   );
 }

--- a/tests/format/js/multiparser-html/__snapshots__/format.test.js.snap
+++ b/tests/format/js/multiparser-html/__snapshots__/format.test.js.snap
@@ -51,6 +51,35 @@ style='\${foo}'
         style=\${foo}>   </div>
 \`
 
+const list = html\`
+  <ol>
+    \${items.map(
+      (entry) => html\`
+        <li>
+          \${entry.children
+            ? html\`
+                <ol>
+                  \${entry.children.map(
+                    (child) => html\`<li>\${child.title}</li>\`,
+                  )}
+                </ol>
+              \`
+            : entry.title}
+        </li>
+      \`,
+    )}
+  </ol>
+\`;
+
+const pre = html\`
+  <div>
+    <pre>\${JSON.stringify({
+      a: 1,
+      b: 2,
+    })}</pre>
+  </div>
+\`;
+
 =====================================output=====================================
 const nestedFun = /* HTML */ \`
   \${outerExpr(1)}
@@ -107,6 +136,40 @@ a = /* HTML */ \`
   <div style="\${foo}" style="\${foo}" style=\${foo}></div>
 \`;
 
+const list = html\`
+  <ol>
+    \${items.map(
+      (entry) => html\`
+        <li>
+          \${
+            entry.children
+              ? html\`
+                  <ol>
+                    \${entry.children.map(
+                      (child) => html\`
+                        <li>\${child.title}</li>
+                      \`,
+                    )}
+                  </ol>
+                \`
+              : entry.title
+          }
+        </li>
+      \`,
+    )}
+  </ol>
+\`;
+
+const pre = html\`
+  <div>
+    <pre>
+\${JSON.stringify({
+        a: 1,
+        b: 2,
+      })}</pre>
+  </div>
+\`;
+
 ================================================================================
 `;
 
@@ -160,6 +223,35 @@ style='\${foo}'
         style=\${foo}>   </div>
 \`
 
+const list = html\`
+  <ol>
+    \${items.map(
+      (entry) => html\`
+        <li>
+          \${entry.children
+            ? html\`
+                <ol>
+                  \${entry.children.map(
+                    (child) => html\`<li>\${child.title}</li>\`,
+                  )}
+                </ol>
+              \`
+            : entry.title}
+        </li>
+      \`,
+    )}
+  </ol>
+\`;
+
+const pre = html\`
+  <div>
+    <pre>\${JSON.stringify({
+      a: 1,
+      b: 2,
+    })}</pre>
+  </div>
+\`;
+
 =====================================output=====================================
 const nestedFun = /* HTML */ \`\${outerExpr(1)}
   <script>
@@ -201,6 +293,38 @@ a = /* HTML */ \`<div
   unquoted=\${foo}
 ></div> \`;
 a = /* HTML */ \`<div style="\${foo}" style="\${foo}" style=\${foo}></div> \`;
+
+const list = html\`
+  <ol>
+    \${items.map(
+      (entry) => html\`
+        <li>
+          \${
+            entry.children
+              ? html\`
+                  <ol>
+                    \${entry.children.map(
+                      (child) => html\`<li>\${child.title}</li>\`,
+                    )}
+                  </ol>
+                \`
+              : entry.title
+          }
+        </li>
+      \`,
+    )}
+  </ol>
+\`;
+
+const pre = html\`
+  <div>
+    <pre>
+\${JSON.stringify({
+        a: 1,
+        b: 2,
+      })}</pre>
+  </div>
+\`;
 
 ================================================================================
 `;

--- a/tests/format/js/multiparser-html/html-template-literals.js
+++ b/tests/format/js/multiparser-html/html-template-literals.js
@@ -42,3 +42,32 @@ a = /* HTML */ `<div
 style='${foo}'
         style=${foo}>   </div>
 `
+
+const list = html`
+  <ol>
+    ${items.map(
+      (entry) => html`
+        <li>
+          ${entry.children
+            ? html`
+                <ol>
+                  ${entry.children.map(
+                    (child) => html`<li>${child.title}</li>`,
+                  )}
+                </ol>
+              `
+            : entry.title}
+        </li>
+      `,
+    )}
+  </ol>
+`;
+
+const pre = html`
+  <div>
+    <pre>${JSON.stringify({
+      a: 1,
+      b: 2,
+    })}</pre>
+  </div>
+`;


### PR DESCRIPTION
## Description

Fixes #19518.

Embedded HTML template expressions were aligned to their indentation in the original source even though the HTML printer can move the interpolation. Multiline JavaScript inside a moved interpolation therefore used stale absolute indentation and needed another Prettier pass to stabilize.

This change lets embedded HTML control expression indentation while preserving the existing source-alignment behavior for regular, CSS, GraphQL, and Markdown template literals. Regression coverage includes the reported nested `.map()`/ternary case and JavaScript embedded in a `<pre>` element.

Validation:

- `FULL_TEST=1 yarn jest tests/format/js/multiparser-html --runInBand`
- `yarn eslint src/language-js/embed/html.js src/language-js/print/template-literal.js tests/format/js/multiparser-html/html-template-literals.js`
- `yarn prettier src/language-js/embed/html.js src/language-js/print/template-literal.js tests/format/js/multiparser-html/html-template-literals.js tests/format/js/multiparser-html/__snapshots__/format.test.js.snap --check`
- `yarn lint:format-test`
- `yarn lint:typecheck`
- `git diff --check`

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.