### PR TITLE
Fix duplicate parentheses in JSX ternaries

### DIFF
--- a/changelog_unreleased/javascript/19731.md
+++ b/changelog_unreleased/javascript/19731.md
@@ -1,0 +1,28 @@
+#### Avoid duplicate parentheses in JSX ternaries (#19731 by @utkarshalpha)
+
+When a JSX-containing ternary breaks across lines, Prettier no longer adds a
+second pair of parentheses around a nullish-coalescing alternate.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+const value = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
+
+// Prettier stable
+const value = condition ? (
+  <Example /> // comment
+) : (
+  ("alpha" ?? "bravo")
+);
+
+// Prettier main
+const value = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
+```

--- a/src/language-js/print/index.js
+++ b/src/language-js/print/index.js
@@ -1,4 +1,10 @@
-import { group, indent, inheritLabel, softline } from "../../document/index.js";
+import {
+  group,
+  ifBreak,
+  indent,
+  inheritLabel,
+  softline,
+} from "../../document/index.js";
 import { printComments } from "../../main/comments/print.js";
 import isNonEmptyArray from "../../utilities/is-non-empty-array.js";
 import needsParentheses from "../parentheses/needs-parentheses.js";
@@ -90,9 +96,17 @@ function print(path, options, print, args) {
   }
 
   return inheritLabel(doc, (doc) => [
-    needsParens ? "(" : "",
+    needsParens
+      ? args?.parenthesesWhenNotBroken
+        ? ifBreak("", "(")
+        : "("
+      : "",
     decoratorsDoc ? group([decoratorsDoc, doc]) : doc,
-    needsParens ? ")" : "",
+    needsParens
+      ? args?.parenthesesWhenNotBroken
+        ? ifBreak("", ")")
+        : ")"
+      : "",
   ]);
 }
 

--- a/src/language-js/print/ternary-old.js
+++ b/src/language-js/print/ternary-old.js
@@ -243,9 +243,12 @@ function printTernaryOld(path, options, print) {
     // Even though they don't need parens, we wrap (almost) everything in
     // parens when using ?: within JSX, because the parens are analogous to
     // curly braces in an if statement.
-    const wrap = (doc) => [
+    const wrap = (nodePropertyName) => [
       ifBreak("("),
-      indent([softline, doc]),
+      indent([
+        softline,
+        print(nodePropertyName, { parenthesesWhenNotBroken: true }),
+      ]),
       softline,
       ifBreak(")"),
     ];
@@ -263,11 +266,11 @@ function printTernaryOld(path, options, print) {
       " ? ",
       isNil(consequentNode)
         ? print(consequentNodePropertyName)
-        : wrap(print(consequentNodePropertyName)),
+        : wrap(consequentNodePropertyName),
       " : ",
       alternateNode.type === node.type || isNil(alternateNode)
         ? print(alternateNodePropertyName)
-        : wrap(print(alternateNodePropertyName)),
+        : wrap(alternateNodePropertyName),
     );
   } else {
     /*

--- a/tests/format/js/nullish-coalescing/__snapshots__/format.test.js.snap
+++ b/tests/format/js/nullish-coalescing/__snapshots__/format.test.js.snap
@@ -87,7 +87,7 @@ _ = (
            * with zero data rows, the DataTable
            * displays the empty component.
            */
-          (empty ?? null)
+          empty ?? null
         ) : (
           /**
            * After the initial load, if the data for the list
@@ -145,6 +145,14 @@ foo ?? bar ? a : b;
 a ? foo ?? bar : b;
 a ? b : foo ?? bar;
 
+condition ? <Example /> : "alpha" ?? "bravo";
+
+const value = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
+
 =====================================output=====================================
 obj.foo ?? "default";
 
@@ -172,6 +180,14 @@ foo && (baz ?? baz);
 (foo ?? bar) ? a : b;
 a ? (foo ?? bar) : b;
 a ? b : (foo ?? bar);
+
+condition ? <Example /> : ("alpha" ?? "bravo");
+
+const value = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);
 
 ================================================================================
 `;

--- a/tests/format/js/nullish-coalescing/nullish-coalesing-operator.js
+++ b/tests/format/js/nullish-coalescing/nullish-coalesing-operator.js
@@ -24,3 +24,11 @@ foo && (baz ?? baz);
 foo ?? bar ? a : b;
 a ? foo ?? bar : b;
 a ? b : foo ?? bar;
+
+condition ? <Example /> : "alpha" ?? "bravo";
+
+const value = condition ? (
+  <Example /> // comment
+) : (
+  "alpha" ?? "bravo"
+);


### PR DESCRIPTION
## Description

Fixes #19533.

When the legacy ternary printer breaks a JSX-containing conditional, its layout wrapper now replaces any syntax parentheses already required by the branch expression instead of nesting another pair around them. Required syntax parentheses are still emitted when the ternary remains on one line.

The regression coverage includes both multiline and compact nullish-coalescing alternates.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.