### PR TITLE
docs: clarify Stylelint guidance on the install page

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -185,7 +185,9 @@ And being able to run Prettier from the command line is still a good fallback, a
 
 ## ESLint (and other linters)
 
-If you use ESLint, install [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier#installation) to make ESLint and Prettier play nice with each other. It turns off all ESLint rules that are unnecessary or might conflict with Prettier. There’s a similar config for Stylelint: [stylelint-config-prettier](https://github.com/prettier/stylelint-config-prettier)
+If you use ESLint, install [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier#installation) to make ESLint and Prettier play nice with each other. It turns off all ESLint rules that are unnecessary or might conflict with Prettier.
+
+As of Stylelint v15, stylistic rules are deprecated, so [stylelint-config-prettier](https://github.com/prettier/stylelint-config-prettier) is usually unnecessary. Only consider it if you are on an older Stylelint version or still enable those deprecated rules.
 
 (See [Prettier vs. Linters](comparison.md) to learn more about formatting vs linting, [Integrating with Linters](integrating-with-linters.md) for more in-depth information on configuring your linters, and [Related projects](related-projects.md) for even more integration possibilities, if needed.)
 

--- a/website/versioned_docs/version-stable/install.md
+++ b/website/versioned_docs/version-stable/install.md
@@ -185,7 +185,9 @@ And being able to run Prettier from the command line is still a good fallback, a
 
 ## ESLint (and other linters)
 
-If you use ESLint, install [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier#installation) to make ESLint and Prettier play nice with each other. It turns off all ESLint rules that are unnecessary or might conflict with Prettier. There’s a similar config for Stylelint: [stylelint-config-prettier](https://github.com/prettier/stylelint-config-prettier)
+If you use ESLint, install [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier#installation) to make ESLint and Prettier play nice with each other. It turns off all ESLint rules that are unnecessary or might conflict with Prettier.
+
+As of Stylelint v15, stylistic rules are deprecated, so [stylelint-config-prettier](https://github.com/prettier/stylelint-config-prettier) is usually unnecessary. Only consider it if you are on an older Stylelint version or still enable those deprecated rules.
 
 (See [Prettier vs. Linters](comparison.md) to learn more about formatting vs linting, [Integrating with Linters](integrating-with-linters.md) for more in-depth information on configuring your linters, and [Related projects](related-projects.md) for even more integration possibilities, if needed.)
 


### PR DESCRIPTION
## Summary
- The install docs still suggested `stylelint-config-prettier` for everyone.
- Stylelint v15 deprecated stylistic rules, so that config is usually unnecessary now.
- Updated both `docs/install.md` and the stable website copy to match.

Fixes #16905

## Test plan
- [ ] Confirm the install page no longer recommends Stylelint config by default
- [ ] Confirm older Stylelint / deprecated stylistic-rule users are still pointed at `stylelint-config-prettier`