### PR TITLE
Fix Liquid block parsing after Markdown tables (#19724)

### DIFF
--- a/changelog_unreleased/markdown/19724.md
+++ b/changelog_unreleased/markdown/19724.md
@@ -1,0 +1,29 @@
+#### Preserve Liquid blocks after Markdown tables (#19724 by @al-ameen)
+
+Standalone Liquid tags are now parsed as block syntax, preventing multiline tags from being absorbed into a preceding table or blockquote. Whitespace inside multiline Liquid tags is also now preserved.
+
+<!-- prettier-ignore -->
+```markdown
+<!-- Input -->
+| Argument | Type |
+| -------- | ---- |
+{% set default_params = {
+    "model": ["str"],
+} %}
+
+<!-- Prettier stable -->
+| Argument                  | Type |
+| ------------------------- | ---- |
+| {% set default_params = { |
+
+    "model": ["str"],
+
+} %}
+
+<!-- Prettier main -->
+| Argument | Type |
+| -------- | ---- |
+{% set default_params = {
+    "model": ["str"],
+} %}
+```

--- a/src/language-markdown/parse/micromark/micromark-extension-liquid.js
+++ b/src/language-markdown/parse/micromark/micromark-extension-liquid.js
@@ -1,4 +1,7 @@
-import { markdownLineEnding } from "micromark-util-character";
+import {
+  markdownLineEnding,
+  markdownSpace,
+} from "micromark-util-character";
 import { codes, types } from "micromark-util-symbol";
 
 /**
@@ -7,9 +10,15 @@ import { codes, types } from "micromark-util-symbol";
  * @typedef {import('mdast-util-from-markdown').CompileContext} CompileContext
  * @typedef {import('mdast-util-from-markdown').Handle} Handle
  * @typedef {import('micromark-util-types').State} State
+ * @typedef {import('micromark-util-types').TokenizeContext} TokenizeContext
  */
 
 const nodeType = "liquidNode";
+
+const nonLazyContinuation = {
+  tokenize: tokenizeNonLazyContinuation,
+  partial: true,
+};
 
 /**
  * @returns {FromMarkdownExtension}
@@ -45,16 +54,33 @@ function liquidFromMarkdown() {
  * @returns {import('micromark-util-types').Extension}
  */
 function liquidSyntax() {
+  const liquid = {
+    name: "liquid",
+    tokenize,
+  };
+
   return {
-    text: {
+    flow: {
       [codes.leftCurlyBrace]: {
-        name: "liquid",
-        tokenize,
+        name: "liquidFlow",
+        tokenize: tokenizeFlow,
       },
+    },
+    text: {
+      [codes.leftCurlyBrace]: liquid,
     },
   };
 
+  /** @this {TokenizeContext} */
+  function tokenizeFlow(effects, ok, nok) {
+    return tokenizeLiquid(effects, ok, nok, true, this.interrupt);
+  }
+
   function tokenize(effects, ok, nok) {
+    return tokenizeLiquid(effects, ok, nok, false, false);
+  }
+
+  function tokenizeLiquid(effects, ok, nok, isFlow, interrupt) {
     /** @type {typeof codes.rightCurlyBrace | typeof codes.percentSign} */
     let closingCode;
 
@@ -74,7 +100,7 @@ function liquidSyntax() {
                 ? codes.percentSign
                 : codes.rightCurlyBrace;
             effects.consume(code);
-            return inside;
+            return isFlow && interrupt ? ok : inside;
           default:
             return nok(code);
         }
@@ -92,6 +118,13 @@ function liquidSyntax() {
         default:
           if (markdownLineEnding(code)) {
             effects.exit(types.data);
+            if (isFlow) {
+              return effects.attempt(
+                nonLazyContinuation,
+                afterLineEnding,
+                nok,
+              )(code);
+            }
             effects.enter(types.lineEnding);
             effects.consume(code);
             effects.exit(types.lineEnding);
@@ -104,16 +137,78 @@ function liquidSyntax() {
     }
 
     /** @type {State} */
+    function afterLineEnding(code) {
+      if (markdownLineEnding(code)) {
+        return effects.attempt(nonLazyContinuation, afterLineEnding, nok)(code);
+      }
+
+      effects.enter(types.data);
+      return inside(code);
+    }
+
+    /** @type {State} */
     function mayClose(code) {
       if (code === codes.rightCurlyBrace) {
         effects.consume(code);
         effects.exit(types.data);
         effects.exit(nodeType);
-        return ok;
+        return isFlow ? afterClose : ok;
       }
 
       return inside;
     }
+
+    /** @type {State} */
+    function afterClose(code) {
+      if (markdownSpace(code)) {
+        effects.enter(types.whitespace);
+        effects.consume(code);
+        return afterWhitespace;
+      }
+
+      return after(code);
+    }
+
+    /** @type {State} */
+    function afterWhitespace(code) {
+      if (markdownSpace(code)) {
+        effects.consume(code);
+        return afterWhitespace;
+      }
+
+      effects.exit(types.whitespace);
+      return after(code);
+    }
+
+    /** @type {State} */
+    function after(code) {
+      return code === codes.eof || markdownLineEnding(code)
+        ? ok(code)
+        : nok(code);
+    }
+  }
+}
+
+/** @this {TokenizeContext} */
+function tokenizeNonLazyContinuation(effects, ok, nok) {
+  const { now, parser } = this;
+  return start;
+
+  /** @type {State} */
+  function start(code) {
+    if (code === codes.eof) {
+      return ok(code);
+    }
+
+    effects.enter(types.lineEnding);
+    effects.consume(code);
+    effects.exit(types.lineEnding);
+    return lineStart;
+  }
+
+  /** @type {State} */
+  function lineStart(code) {
+    return parser.lazy[now().line] ? nok(code) : ok(code);
   }
 }
 

--- a/src/language-markdown/print/children.js
+++ b/src/language-markdown/print/children.js
@@ -42,7 +42,11 @@ function printChildren(path, options, print, events = {}) {
 }
 
 function shouldPrePrintHardline({ node, parent }) {
-  const isInlineNode = INLINE_NODE_TYPES.has(node.type);
+  const isInlineNode =
+    INLINE_NODE_TYPES.has(node.type) &&
+    !(
+      node.type === "liquidNode" && !INLINE_NODE_WRAPPER_TYPES.has(parent.type)
+    );
 
   const isInlineHTML =
     node.type === "html" && INLINE_NODE_WRAPPER_TYPES.has(parent.type);
@@ -119,6 +123,9 @@ function shouldPrePrintDoubleHardline(path, options) {
     parent.type === "listItem" &&
     previous.type === "paragraph" &&
     previous.position.end.line + 1 === node.position.start.line;
+  const isBlockLiquidWithoutBlankLine =
+    (node.type === "liquidNode" || previous.type === "liquidNode") &&
+    previous.position.end.line + 1 === node.position.start.line;
 
   return !(
     isSiblingNode ||
@@ -126,7 +133,8 @@ function shouldPrePrintDoubleHardline(path, options) {
     isPrevNodePrettierIgnore ||
     isBlockHtmlWithoutBlankLineBetweenPrevHtml ||
     isBlockHtmlWithoutBlankLineBetweenPrevParagraph ||
-    isHtmlDirectAfterListItem
+    isHtmlDirectAfterListItem ||
+    isBlockLiquidWithoutBlankLine
   );
 }
 

--- a/tests/format/markdown/liquid/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/liquid/__snapshots__/format.test.js.snap
@@ -24,7 +24,8 @@ proseWrap: "always"
 
 {%
  if user
-%} Hello, {{ user }}! {% endif %}
+%} Hello, {{ user }}!
+{% endif %}
 
 ================================================================================
 `;
@@ -84,7 +85,8 @@ where does it end }}
 
 # Userscripts <span>[{% img github.svg alt:"View on GitHub" title:"View on GitHub" %}](https://github.com/Charcoal-SE/Userscripts) [Build <span>status loading…</span>](//travis-ci.org/Charcoal-SE/userscripts){: .build}</span>
 
-{% css userscripts %} {% js userscripts %}
+{% css userscripts %}
+{% js userscripts %}
 
 {{ foo
 multiline
@@ -167,7 +169,7 @@ bar  baz %}
 
 {{ foo
 
-bar baz
+bar   baz
 
 qux }}
 
@@ -177,7 +179,7 @@ qux }}
 
 {% foo %
 
-bar baz %}
+bar  baz %}
 
 ================================================================================
 `;
@@ -220,7 +222,7 @@ bar  baz %}
 
 {{ foo
 
-bar baz
+bar   baz
 
 qux }}
 
@@ -230,7 +232,7 @@ qux }}
 
 {% foo %
 
-bar baz %}
+bar  baz %}
 
 ================================================================================
 `;
@@ -402,6 +404,109 @@ This input uses Hugo shortcode. Prettier doesn't support this explicitly but it 
 
 {{ blocks/cover
 %}}
+
+================================================================================
+`;
+
+exports[`issue-19724.md - {"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+proseWrap: "always"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+{% macro param_table(params=None) -%}
+| Argument | Type |
+| -------- | ---- |
+{% set default_params = {
+    "model": ["str"],
+} %}
+{% endmacro %}
+
+---
+
+> abc
+{% abc %}
+
+---
+
+Inline {{ liquid }} stays inline.
+
+---
+
+{% liquid %} followed by text
+
+=====================================output=====================================
+{% macro param_table(params=None) -%}
+| Argument | Type |
+| -------- | ---- |
+{% set default_params = {
+    "model": ["str"],
+} %}
+{% endmacro %}
+
+---
+
+> abc
+{% abc %}
+
+---
+
+Inline {{ liquid }} stays inline.
+
+---
+
+{% liquid %} followed by text
+
+================================================================================
+`;
+
+exports[`issue-19724.md format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+{% macro param_table(params=None) -%}
+| Argument | Type |
+| -------- | ---- |
+{% set default_params = {
+    "model": ["str"],
+} %}
+{% endmacro %}
+
+---
+
+> abc
+{% abc %}
+
+---
+
+Inline {{ liquid }} stays inline.
+
+---
+
+{% liquid %} followed by text
+
+=====================================output=====================================
+{% macro param_table(params=None) -%}
+| Argument | Type |
+| -------- | ---- |
+{% set default_params = {
+    "model": ["str"],
+} %}
+{% endmacro %}
+
+---
+
+> abc
+{% abc %}
+
+---
+
+Inline {{ liquid }} stays inline.
+
+---
+
+{% liquid %} followed by text
 
 ================================================================================
 `;

--- a/tests/format/markdown/liquid/issue-19724.md
+++ b/tests/format/markdown/liquid/issue-19724.md
@@ -1,0 +1,20 @@
+{% macro param_table(params=None) -%}
+| Argument | Type |
+| -------- | ---- |
+{% set default_params = {
+    "model": ["str"],
+} %}
+{% endmacro %}
+
+---
+
+> abc
+{% abc %}
+
+---
+
+Inline {{ liquid }} stays inline.
+
+---
+
+{% liquid %} followed by text


### PR DESCRIPTION
Closes #19724

<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

Liquid tags (`{% ... %}`) after Markdown tables or blockquotes were incorrectly absorbed into the preceding block as table cells or blockquote content.

This fix adds flow-context parsing for Liquid tags via a `tokenizeFlow` entry point and treats `liquidNode` as block-level when not inside an inline wrapper (e.g. `paragraph`, `tableCell`), preserving the author's formatting intent.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
