### PR TITLE
Keep leading `+` glued in An+B notation

### DIFF
--- a/changelog_unreleased/css/19738.md
+++ b/changelog_unreleased/css/19738.md
@@ -1,0 +1,18 @@
+#### Keep leading `+` glued in An+B notation (#19738 by @lazerg)
+
+The An+B grammar doesn't allow whitespace between a leading `+` and the `n`, so the extra space produced invalid output.
+
+<!-- prettier-ignore -->
+```css
+/* Input */
+a:nth-child(+3n+2) {
+}
+
+/* Prettier stable */
+a:nth-child(+ 3n + 2) {
+}
+
+/* Prettier main */
+a:nth-child(+3n + 2) {
+}
+```

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -350,13 +350,25 @@ function genericPrint(path, options, print) {
         node.value === ">>>"
       ) {
         const parentNode = path.parent;
-        const leading =
+        const isFirstNode =
           parentNode.type === "selector-selector" &&
-          parentNode.nodes[0] === node
-            ? ""
-            : line;
+          parentNode.nodes[0] === node;
+        const leading = isFirstNode ? "" : line;
 
-        return [leading, node.value, path.isLast ? "" : " "];
+        // The leading `+` in An+B notation (e.g. `:nth-child(+2n)`) must stay
+        // glued to the following token, a space there is invalid per spec.
+        const grandparentNode = path.grandparent;
+        const isNthLeadingSign =
+          isFirstNode &&
+          node.value === "+" &&
+          grandparentNode?.type === "selector-pseudo" &&
+          grandparentNode.value.toLowerCase().startsWith(":nth-");
+
+        return [
+          leading,
+          node.value,
+          path.isLast || isNthLeadingSign ? "" : " ",
+        ];
       }
 
       const leading = node.value.trimStart().startsWith("(") ? line : "";

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -362,7 +362,12 @@ function genericPrint(path, options, print) {
           isFirstNode &&
           node.value === "+" &&
           grandparentNode?.type === "selector-pseudo" &&
-          grandparentNode.value.toLowerCase().startsWith(":nth-");
+          [
+            ":nth-child",
+            ":nth-last-child",
+            ":nth-of-type",
+            ":nth-last-of-type",
+          ].includes(grandparentNode.value.toLowerCase());
 
         return [
           leading,

--- a/tests/format/css/combinator/__snapshots__/format.test.js.snap
+++ b/tests/format/css/combinator/__snapshots__/format.test.js.snap
@@ -5,37 +5,47 @@ exports[`an-plus-b.css format 1`] = `
 parsers: ["css"]
                                                       printWidth: 80 (default) |
 =====================================input======================================
-a:nth-child(+2n) {}
-a:nth-child(+n) {}
-a:nth-child(+3n+2) {}
-a:nth-last-child(+3n+1) {}
-a:nth-of-type(+2n) {}
-a:nth-last-of-type(+n+3) {}
-a:nth-child(2n+1) {}
-a:nth-child(-n+2) {}
-a:has(+ img) {}
-a:has(+img) {}
+:nth-child(+2n),
+:nth-child(+n),
+:nth-child(+3n+2),
+:nth-last-child(+3n+1),
+:nth-of-type(+2n),
+:nth-last-of-type(+n+3),
+:nth-child(2n+1),
+:nth-child(-n+2),
+:not(:nth-child(+2n)),
+:not(:nth-child(+n)),
+:not(:nth-child(+3n+2)),
+:not(:nth-last-child(+3n+1)),
+:not(:nth-of-type(+2n)),
+:not(:nth-last-of-type(+n+3)),
+:not(:nth-child(2n+1)),
+:not(:nth-child(-n+2)) {}
+
+:has(+ img),
+:has(+img) {}
 
 =====================================output=====================================
-a:nth-child(+2n) {
+:nth-child(+2n),
+:nth-child(+n),
+:nth-child(+3n + 2),
+:nth-last-child(+3n + 1),
+:nth-of-type(+2n),
+:nth-last-of-type(+n + 3),
+:nth-child(2n + 1),
+:nth-child(-n + 2),
+:not(:nth-child(+2n)),
+:not(:nth-child(+n)),
+:not(:nth-child(+3n + 2)),
+:not(:nth-last-child(+3n + 1)),
+:not(:nth-of-type(+2n)),
+:not(:nth-last-of-type(+n + 3)),
+:not(:nth-child(2n + 1)),
+:not(:nth-child(-n + 2)) {
 }
-a:nth-child(+n) {
-}
-a:nth-child(+3n + 2) {
-}
-a:nth-last-child(+3n + 1) {
-}
-a:nth-of-type(+2n) {
-}
-a:nth-last-of-type(+n + 3) {
-}
-a:nth-child(2n + 1) {
-}
-a:nth-child(-n + 2) {
-}
-a:has(+ img) {
-}
-a:has(+ img) {
+
+:has(+ img),
+:has(+ img) {
 }
 
 ================================================================================

--- a/tests/format/css/combinator/__snapshots__/format.test.js.snap
+++ b/tests/format/css/combinator/__snapshots__/format.test.js.snap
@@ -1,5 +1,46 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`an-plus-b.css format 1`] = `
+====================================options=====================================
+parsers: ["css"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+a:nth-child(+2n) {}
+a:nth-child(+n) {}
+a:nth-child(+3n+2) {}
+a:nth-last-child(+3n+1) {}
+a:nth-of-type(+2n) {}
+a:nth-last-of-type(+n+3) {}
+a:nth-child(2n+1) {}
+a:nth-child(-n+2) {}
+a:has(+ img) {}
+a:has(+img) {}
+
+=====================================output=====================================
+a:nth-child(+2n) {
+}
+a:nth-child(+n) {
+}
+a:nth-child(+3n + 2) {
+}
+a:nth-last-child(+3n + 1) {
+}
+a:nth-of-type(+2n) {
+}
+a:nth-last-of-type(+n + 3) {
+}
+a:nth-child(2n + 1) {
+}
+a:nth-child(-n + 2) {
+}
+a:has(+ img) {
+}
+a:has(+ img) {
+}
+
+================================================================================
+`;
+
 exports[`combinator.css format 1`] = `
 ====================================options=====================================
 parsers: ["css"]

--- a/tests/format/css/combinator/an-plus-b.css
+++ b/tests/format/css/combinator/an-plus-b.css
@@ -1,10 +1,19 @@
-a:nth-child(+2n) {}
-a:nth-child(+n) {}
-a:nth-child(+3n+2) {}
-a:nth-last-child(+3n+1) {}
-a:nth-of-type(+2n) {}
-a:nth-last-of-type(+n+3) {}
-a:nth-child(2n+1) {}
-a:nth-child(-n+2) {}
-a:has(+ img) {}
-a:has(+img) {}
+:nth-child(+2n),
+:nth-child(+n),
+:nth-child(+3n+2),
+:nth-last-child(+3n+1),
+:nth-of-type(+2n),
+:nth-last-of-type(+n+3),
+:nth-child(2n+1),
+:nth-child(-n+2),
+:not(:nth-child(+2n)),
+:not(:nth-child(+n)),
+:not(:nth-child(+3n+2)),
+:not(:nth-last-child(+3n+1)),
+:not(:nth-of-type(+2n)),
+:not(:nth-last-of-type(+n+3)),
+:not(:nth-child(2n+1)),
+:not(:nth-child(-n+2)) {}
+
+:has(+ img),
+:has(+img) {}

--- a/tests/format/css/combinator/an-plus-b.css
+++ b/tests/format/css/combinator/an-plus-b.css
@@ -1,0 +1,10 @@
+a:nth-child(+2n) {}
+a:nth-child(+n) {}
+a:nth-child(+3n+2) {}
+a:nth-last-child(+3n+1) {}
+a:nth-of-type(+2n) {}
+a:nth-last-of-type(+n+3) {}
+a:nth-child(2n+1) {}
+a:nth-child(-n+2) {}
+a:has(+ img) {}
+a:has(+img) {}


### PR DESCRIPTION
## Description

In An+B notation a leading `+` was printed with a trailing space, so `:nth-child(+2n)` became `:nth-child(+ 2n)` and `:nth-child(+3n+2)` became `:nth-child(+ 3n + 2)`. The grammar doesn't allow whitespace between a leading `+` and the `n`, so that output is invalid.

The `+` is parsed as a leading selector combinator, and the combinator printer always appends a trailing space. This drops that space when the combinator is the leading sign inside an `:nth-*` pseudo, and leaves relative combinators like `:has(+ img)` alone.

Fixes #19736

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.
