### PR TITLE
Preserve comments after empty switch discriminants

### DIFF
--- a/changelog_unreleased/javascript/19752.md
+++ b/changelog_unreleased/javascript/19752.md
@@ -1,0 +1,18 @@
+#### Preserve comments after empty switch discriminants (#19752 by @raisulchowdhury)
+
+Comments between an empty `switch` statement's discriminant and opening brace
+are now kept in that position instead of being moved inside the discriminant.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+switch (value) /* comment */ {}
+
+// Prettier stable
+switch (value /* comment */) {
+}
+
+// Prettier main
+switch (value) /* comment */ {
+}
+```

--- a/src/language-js/comments/attach/handle-switch-statement-comments.js
+++ b/src/language-js/comments/attach/handle-switch-statement-comments.js
@@ -30,6 +30,15 @@ function handleSwitchStatementComments({
     locEnd(comment),
   );
 
+  if (nextCharacter === "{") {
+    addDanglingComment(
+      enclosingNode,
+      comment,
+      "commentAfterSwitchDiscriminant",
+    );
+    return true;
+  }
+
   if (nextCharacter === "}") {
     addDanglingComment(enclosingNode, comment);
     return true;

--- a/src/language-js/print/switch-statement.js
+++ b/src/language-js/print/switch-statement.js
@@ -6,11 +6,43 @@ import {
   softline,
 } from "../../document/index.js";
 import { printDanglingComments } from "../../main/comments/print.js";
-import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
+import hasNewline from "../../utilities/has-newline.js";
+import { locStart } from "../location/index.js";
+import { isLineComment } from "../utilities/comment-types.js";
+import {
+  CommentCheckFlags,
+  getComments,
+  hasComment,
+} from "../utilities/comments.js";
 import { isNextLineEmpty } from "../utilities/is-next-line-empty.js";
 import { printStatementSequence } from "./statement-sequence.js";
 
 function printSwitchStatement(path, options, print) {
+  const { node } = path;
+  const commentsAfterDiscriminant = getComments(
+    node,
+    CommentCheckFlags.Dangling,
+    (comment) => comment.marker === "commentAfterSwitchDiscriminant",
+  );
+  const firstCommentAfterDiscriminant = commentsAfterDiscriminant[0];
+  const commentAfterDiscriminantIsOnOwnLine =
+    firstCommentAfterDiscriminant &&
+    hasNewline(options.originalText, locStart(firstCommentAfterDiscriminant), {
+      backwards: true,
+    });
+  const commentAfterDiscriminant = firstCommentAfterDiscriminant
+    ? [
+        commentAfterDiscriminantIsOnOwnLine ? hardline : " ",
+        printDanglingComments(path, options, {
+          marker: "commentAfterSwitchDiscriminant",
+        }),
+        isLineComment(commentsAfterDiscriminant.at(-1)) ||
+        commentAfterDiscriminantIsOnOwnLine
+          ? hardline
+          : " ",
+      ]
+    : " ";
+
   return [
     group([
       "switch (",
@@ -18,8 +50,9 @@ function printSwitchStatement(path, options, print) {
       softline,
       ")",
     ]),
-    " {",
-    path.node.cases.length > 0
+    commentAfterDiscriminant,
+    "{",
+    node.cases.length > 0
       ? indent([
           hardline,
           join(

--- a/tests/format/js/comments/while-like/__snapshots__/format.test.js.snap
+++ b/tests/format/js/comments/while-like/__snapshots__/format.test.js.snap
@@ -120,6 +120,8 @@ switch(true){}// 3
 
 switch(true)/*4*/{}
 
+switch(a) /*c*/{}
+
 switch(
   true // 5
   && true // 52
@@ -145,21 +147,22 @@ switch (
 ) {
 }
 
-switch (
-  true // 2
-) {
+switch (true) // 2
+{
 }
 
-switch (
-  true
-  // 22
-) {
+switch (true)
+// 22
+{
 }
 
 switch (true) {
 } // 3
 
-switch (true /*4*/) {
+switch (true) /*4*/ {
+}
+
+switch (a) /*c*/ {
 }
 
 switch (

--- a/tests/format/js/comments/while-like/switch.js
+++ b/tests/format/js/comments/while-like/switch.js
@@ -14,6 +14,8 @@ switch(true){}// 3
 
 switch(true)/*4*/{}
 
+switch(a) /*c*/{}
+
 switch(
   true // 5
   && true // 52


### PR DESCRIPTION
## Description

Fixes #19582.

Preserve comments between an empty `switch` statement's discriminant and its
opening brace. These comments previously attached to the discriminant and
printed inside `switch (...)`; they now print in the header position,
consistent with `if` and `while`.

AI assistance was used to investigate and draft this change. I reviewed the
comment-attachment and printing logic, inspected every snapshot change, and
independently ran the focused, deep, and broader comment test suites.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the contributing guidelines.
- [ ] I did _not_ use AI to generate this PR.
- [x] I have reviewed the AI-generated content before submitting.
