### PR TITLE
Preserve polyglot shell directives after shebangs

### DIFF
--- a/changelog_unreleased/javascript/19753.md
+++ b/changelog_unreleased/javascript/19753.md
@@ -1,0 +1,21 @@
+#### Preserve polyglot shell directives after `#!/bin/sh` shebangs (#19753 by @raisulchowdhury)
+
+Prettier now keeps the shell handoff in `#!/bin/sh` polyglot JavaScript files executable.
+
+<!-- prettier-ignore -->
+```js
+// Input
+#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+const ten = 10;
+
+// Prettier stable
+#!/bin/sh
+":"; //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+const ten = 10;
+
+// Prettier main
+#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+const ten = 10;
+```

--- a/src/language-js/print/estree.js
+++ b/src/language-js/print/estree.js
@@ -7,6 +7,7 @@ import {
 } from "../../document/index.js";
 import { printDanglingComments } from "../../main/comments/print.js";
 import UnexpectedNodeError from "../../utilities/unexpected-node-error.js";
+import { isPolyglotShellDirective } from "../semicolon/semicolon.js";
 import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
 import { isMeaningfulEmptyStatement } from "../utilities/is-meaningful-empty-statement.js";
 import { isMethod } from "../utilities/is-method.js";
@@ -222,7 +223,10 @@ function printEstree(path, options, print, args) {
     case "Super":
       return "super";
     case "Directive":
-      return [print("value"), printSemicolon(options)];
+      return [
+        print("value"),
+        isPolyglotShellDirective(path, options) ? "" : printSemicolon(options),
+      ];
     case "UnaryExpression": {
       const parts = [node.operator];
 

--- a/src/language-js/print/expression-statement.js
+++ b/src/language-js/print/expression-statement.js
@@ -3,6 +3,7 @@ import {
   printLeadingComments,
 } from "../../main/comments/print.js";
 import {
+  isPolyglotShellDirective,
   isSingleHtmlEventHandlerExpressionStatement,
   isSingleJsxExpressionStatementInMarkdown,
   isSingleVueEventBindingExpressionStatement,
@@ -30,6 +31,10 @@ function shouldPrintSemicolon(path, options) {
   }
 
   if (!options.semi) {
+    return false;
+  }
+
+  if (isPolyglotShellDirective(path, options)) {
     return false;
   }
 

--- a/src/language-js/semicolon/semicolon.js
+++ b/src/language-js/semicolon/semicolon.js
@@ -127,7 +127,22 @@ function isSingleVueEventBindingExpressionStatement(path, options) {
   );
 }
 
+function isPolyglotShellDirective(path, options) {
+  const { node, parent } = path;
+  const isFirstDirective =
+    node.type === "Directive"
+      ? parent.directives?.[0] === node && node.value.value === ":"
+      : parent.body?.[0] === node && node.directive === ":";
+
+  return (
+    parent.type === "Program" &&
+    isFirstDirective &&
+    /^#!\/bin\/sh[ \t]*\r?\n[ \t]*":"[ \t]*\/\/;/u.test(options.originalText)
+  );
+}
+
 export {
+  isPolyglotShellDirective,
   isSingleHtmlEventHandlerExpressionStatement,
   isSingleJsxExpressionStatementInMarkdown,
   isSingleVueEventBindingExpressionStatement,

--- a/tests/format/js/shebang/__snapshots__/format.test.js.snap
+++ b/tests/format/js/shebang/__snapshots__/format.test.js.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`non-polyglot-shell.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+#!/usr/bin/env node
+":" //; ordinary JavaScript comment
+const ten = 10;
+
+=====================================output=====================================
+#!/usr/bin/env node
+":"; //; ordinary JavaScript comment
+const ten = 10;
+
+================================================================================
+`;
+
+exports[`polyglot-shell.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+const ten = 10;
+
+=====================================output=====================================
+#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+const ten = 10;
+
+================================================================================
+`;
+
 exports[`shebang.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]

--- a/tests/format/js/shebang/non-polyglot-shell.js
+++ b/tests/format/js/shebang/non-polyglot-shell.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+":" //; ordinary JavaScript comment
+const ten = 10;

--- a/tests/format/js/shebang/polyglot-shell.js
+++ b/tests/format/js/shebang/polyglot-shell.js
@@ -1,0 +1,3 @@
+#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+const ten = 10;


### PR DESCRIPTION
## Description

Fixes #7562.

Prettier no longer inserts a semicolon between the colon directive and the shell handoff in `#!/bin/sh` polyglot JavaScript files. The exception is limited to the reported `":" //;` form on the line immediately after the shell shebang. Ordinary JavaScript directives, including the same comment form after a Node shebang, retain their configured semicolons.

## Validation

- verified the positive reproducer with Babel, Flow, TypeScript, Babel-TS, Acorn, Espree, Meriyah, Oxc, and Yuku parsers
- `FULL_TEST=1 node_modules/.bin/jest tests/format/js/shebang` (180 tests)
- full JavaScript format suite (49,436 tests) during worker validation
- targeted ESLint, Prettier formatting, and `git diff --check`

## AI assistance

An AI coding agent reproduced the issue, prepared the initial implementation, and ran the broad JavaScript suite. A separate primary-agent review read the printer and semicolon contracts, narrowed the exception to avoid affecting non-shell shebangs or cross-line whitespace, added a negative regression fixture, and independently reran the parser matrix and focused deep tests.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) Not applicable.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/javascript/19753.md` following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
