### PR TITLE
fix(markdown): preserve escaped character references in link URLs

### DIFF
--- a/changelog_unreleased/markdown/19754.md
+++ b/changelog_unreleased/markdown/19754.md
@@ -1,0 +1,13 @@
+#### Preserve escaped character references in Markdown link destinations (#19754 by @Vam-si-krish)
+
+<!-- prettier-ignore -->
+```markdown
+<!-- Input -->
+[test](/hello?foo&quot\;bar)
+
+<!-- Prettier stable -->
+[test](/hello?foo&quot;bar)
+
+<!-- Prettier main -->
+[test](/hello?foo&quot\;bar)
+```

--- a/src/language-markdown/print/mdast.js
+++ b/src/language-markdown/print/mdast.js
@@ -226,7 +226,11 @@ function printMdast(path, options, print) {
             "](",
             options.parser !== "mdx" && node.url === ""
               ? "<>"
-              : printUrl(node.url, ")"),
+              : printUrl(
+                  node.url,
+                  ")",
+                  getRawLinkDestination(node, options.originalText),
+                ),
             printTitle(node.title, options),
             ")",
           ];
@@ -243,7 +247,11 @@ function printMdast(path, options, print) {
         "](",
         options.parser !== "mdx" && node.url === ""
           ? "<>"
-          : printUrl(node.url, ")"),
+          : printUrl(
+              node.url,
+              ")",
+              getRawLinkDestination(node, options.originalText),
+            ),
         printTitle(node.title, options),
         ")",
       ];
@@ -518,12 +526,92 @@ const encodeUrl = (url, characters) => {
   return url;
 };
 
+function getRawLinkDestination(node, originalText) {
+  const source = originalText.slice(
+    node.position.start.offset,
+    node.position.end.offset,
+  );
+  let index = source.startsWith("![") ? 1 : 0;
+
+  if (source[index] !== "[") {
+    return;
+  }
+
+  let bracketDepth = 1;
+  for (index++; index < source.length && bracketDepth > 0; index++) {
+    switch (source[index]) {
+      case "\\":
+        index++;
+        break;
+      case "[":
+        bracketDepth++;
+        break;
+      case "]":
+        bracketDepth--;
+    }
+  }
+
+  if (bracketDepth !== 0 || source[index] !== "(") {
+    return;
+  }
+
+  index++;
+  while (/[\t\n\r ]/.test(source[index])) {
+    index++;
+  }
+
+  if (source[index] === "<") {
+    const start = ++index;
+    while (index < source.length && source[index] !== ">") {
+      index += source[index] === "\\" ? 2 : 1;
+    }
+    return source.slice(start, index);
+  }
+
+  const start = index;
+  let parenthesisDepth = 0;
+  while (index < source.length) {
+    const character = source[index];
+    if (character === "\\") {
+      index += 2;
+      continue;
+    }
+    if (character === "(") {
+      parenthesisDepth++;
+    } else if (character === ")") {
+      if (parenthesisDepth === 0) {
+        break;
+      }
+      parenthesisDepth--;
+    } else if (/[\t\n\r ]/.test(character) && parenthesisDepth === 0) {
+      break;
+    }
+    index++;
+  }
+  return source.slice(start, index);
+}
+
+function restoreEscapedCharacterReferences(url, originalUrl) {
+  for (const { 0: escapedCharacterReference } of originalUrl?.matchAll(
+    /&(?:#(?:\d+|x[\da-f]+)|[a-z][\da-z]+)\\;/gi,
+  ) ?? []) {
+    const characterReference = escapedCharacterReference.replace(
+      String.raw`\;`,
+      ";",
+    );
+    url = url.replace(characterReference, escapedCharacterReference);
+  }
+  return url;
+}
+
 /**
  * @param {string} url
  * @param {string[] | string} [dangerousCharOrChars]
+ * @param {string} [originalUrl]
  * @returns {string}
  */
-function printUrl(url, dangerousCharOrChars = []) {
+function printUrl(url, dangerousCharOrChars = [], originalUrl) {
+  url = restoreEscapedCharacterReferences(url, originalUrl);
   const dangerousChars = [
     " ",
     ...(Array.isArray(dangerousCharOrChars)

--- a/tests/format/markdown/link/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/link/__snapshots__/format.test.js.snap
@@ -129,6 +129,32 @@ proseWrap: "always"
 ================================================================================
 `;
 
+exports[`issue-19588.md - {"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+proseWrap: "always"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+[test](/hello?foo&quot\\;bar)
+
+[test](/hello?foo&quot;bar)
+
+[test](/hello?foo&#34\\;bar)
+
+![test](/hello?foo&#x22\\;bar)
+
+=====================================output=====================================
+[test](/hello?foo&quot\\;bar)
+
+[test](/hello?foo"bar)
+
+[test](/hello?foo&#34\\;bar)
+
+![test](/hello?foo&#x22\\;bar)
+
+================================================================================
+`;
+
 exports[`long.md - {"proseWrap":"always"} format 1`] = `
 ====================================options=====================================
 parsers: ["markdown"]

--- a/tests/format/markdown/link/issue-19588.md
+++ b/tests/format/markdown/link/issue-19588.md
@@ -1,0 +1,7 @@
+[test](/hello?foo&quot\;bar)
+
+[test](/hello?foo&quot;bar)
+
+[test](/hello?foo&#34\;bar)
+
+![test](/hello?foo&#x22\;bar)


### PR DESCRIPTION
## Description

Fixes #19588.

Markdown character references whose semicolon is escaped, such as `&quot\;`,
were decoded one layer further on each formatting pass. This change reads the
original inline link destination and restores the escaped semicolon before URL
printing, keeping repeated formatting idempotent.

The regression fixture covers named, decimal, and hexadecimal character
references in links and images.

Tested with:

- `corepack yarn jest tests/format/markdown/link`
- `corepack yarn eslint src/language-markdown/print/mdast.js`
- `corepack yarn lint:format-test`

This PR was prepared with AI assistance. I reviewed the generated changes and
validated them with the checks above.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
