### PR TITLE
docs: prevent empty commits in pre-commit example

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -242,6 +242,12 @@ echo "$FILES" | xargs ./node_modules/.bin/prettier --ignore-unknown --write
 # Add back the modified/prettified files to staging
 echo "$FILES" | xargs git add
 
+# Abort if formatting removed all staged changes.
+if git diff --cached --quiet; then
+  echo "Prettier formatting removed all staged changes. Commit aborted."
+  exit 1
+fi
+
 exit 0
 ```
 

--- a/website/versioned_docs/version-stable/precommit.md
+++ b/website/versioned_docs/version-stable/precommit.md
@@ -242,6 +242,12 @@ echo "$FILES" | xargs ./node_modules/.bin/prettier --ignore-unknown --write
 # Add back the modified/prettified files to staging
 echo "$FILES" | xargs git add
 
+# Abort if formatting removed all staged changes.
+if git diff --cached --quiet; then
+  echo "Prettier formatting removed all staged changes. Commit aborted."
+  exit 1
+fi
+
 exit 0
 ```
 


### PR DESCRIPTION
## Description

Fixes #6254.

Update the website's example pre-commit shell script so formatting cannot
create an empty commit. The example now checks whether formatting changed any
files before committing and reports the no-op case clearly.

## Validation

- functional hook reproduction
- shell syntax validation
- mirrored documentation, formatting, and diff checks

## AI assistance

AI assistance was used to investigate and draft this change. I reviewed the
example's shell behavior and complete diff, then independently ran the
functional reproduction and repository checks.

## Checklist

- [x] I’ve added tests or a focused reproduction to confirm my change works.
- [x] I’ve read the contributing guidelines.
- [ ] I did _not_ use AI to generate this PR.
- [x] I have reviewed the AI-generated content before submitting.
