### PR TITLE
feat(graphql): format Markdown in block-string descriptions

### DIFF
--- a/changelog_unreleased/graphql/19762.md
+++ b/changelog_unreleased/graphql/19762.md
@@ -1,0 +1,22 @@
+#### Format Markdown code blocks in GraphQL descriptions (#19762 by @raisulchowdhury)
+
+<!-- prettier-ignore -->
+````graphql
+# Input
+"""
+```js
+const value={answer:42}
+```
+"""
+type Query { value: Int }
+
+# Prettier main
+"""
+```js
+const value = { answer: 42 };
+```
+"""
+type Query {
+  value: Int
+}
+````

--- a/src/language-graphql/embed.js
+++ b/src/language-graphql/embed.js
@@ -1,0 +1,28 @@
+import { hardline } from "../document/index.js";
+
+const markdownCodeBlock = /^ {0,3}(?:`{3,}|~{3,})/m;
+
+function embed(path) {
+  const { node, parent } = path;
+
+  if (
+    node.kind !== "StringValue" ||
+    !node.block ||
+    !node.value ||
+    !markdownCodeBlock.test(node.value) ||
+    node.value.includes('"""') ||
+    parent.description !== node
+  ) {
+    return;
+  }
+
+  return async (textToDoc) => [
+    '"""',
+    hardline,
+    await textToDoc(node.value, { parser: "markdown" }),
+    hardline,
+    '"""',
+  ];
+}
+
+export default embed;

--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -10,6 +10,7 @@ import {
 import { printDanglingComments } from "../main/comments/print.js";
 import isNonEmptyArray from "../utilities/is-non-empty-array.js";
 import UnexpectedNodeError from "../utilities/unexpected-node-error.js";
+import embed from "./embed.js";
 import getVisitorKeys from "./get-visitor-keys.js";
 import { locStart } from "./loc.js";
 import { massageAstNode } from "./massage-ast/index.js";
@@ -466,6 +467,7 @@ const printer = {
   insertPragma,
   printComment,
   canAttachComment,
+  embed,
   getVisitorKeys,
 };
 

--- a/tests/format/graphql/embedded-markdown/__snapshots__/format.test.js.snap
+++ b/tests/format/graphql/embedded-markdown/__snapshots__/format.test.js.snap
@@ -1,0 +1,198 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`description.graphql - {"embeddedLanguageFormatting":"off"} format 1`] = `
+====================================options=====================================
+embeddedLanguageFormatting: "off"
+parsers: ["graphql"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+"""
+## Example Request
+
+\`\`\`graphql
+query{a}
+\`\`\`
+
+## Example Response
+
+\`\`\`json
+{"a":42}
+\`\`\`
+"""
+type Query { a: Number! }
+
+type Nested {
+  """
+  ## Field description
+
+  \`\`\`json
+  {"a":42}
+  \`\`\`
+  """
+  a: Number!
+
+  b(
+    """
+    \`\`\`json
+    {"a":42}
+    \`\`\`
+    """
+    value: String
+  ): Number!
+}
+
+"""
+\`\`\`text
+\\"""
+\`\`\`
+"""
+type Escaped { value: String }
+
+=====================================output=====================================
+"""
+## Example Request
+
+\`\`\`graphql
+query{a}
+\`\`\`
+
+## Example Response
+
+\`\`\`json
+{"a":42}
+\`\`\`
+"""
+type Query {
+  a: Number!
+}
+
+type Nested {
+  """
+  ## Field description
+
+  \`\`\`json
+  {"a":42}
+  \`\`\`
+  """
+  a: Number!
+
+  b(
+    """
+    \`\`\`json
+    {"a":42}
+    \`\`\`
+    """
+    value: String
+  ): Number!
+}
+
+"""
+\`\`\`text
+\\"""
+\`\`\`
+"""
+type Escaped {
+  value: String
+}
+
+================================================================================
+`;
+
+exports[`description.graphql format 1`] = `
+====================================options=====================================
+parsers: ["graphql"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+"""
+## Example Request
+
+\`\`\`graphql
+query{a}
+\`\`\`
+
+## Example Response
+
+\`\`\`json
+{"a":42}
+\`\`\`
+"""
+type Query { a: Number! }
+
+type Nested {
+  """
+  ## Field description
+
+  \`\`\`json
+  {"a":42}
+  \`\`\`
+  """
+  a: Number!
+
+  b(
+    """
+    \`\`\`json
+    {"a":42}
+    \`\`\`
+    """
+    value: String
+  ): Number!
+}
+
+"""
+\`\`\`text
+\\"""
+\`\`\`
+"""
+type Escaped { value: String }
+
+=====================================output=====================================
+"""
+## Example Request
+
+\`\`\`graphql
+query {
+  a
+}
+\`\`\`
+
+## Example Response
+
+\`\`\`json
+{ "a": 42 }
+\`\`\`
+"""
+type Query {
+  a: Number!
+}
+
+type Nested {
+  """
+  ## Field description
+
+  \`\`\`json
+  { "a": 42 }
+  \`\`\`
+  """
+  a: Number!
+
+  b(
+    """
+    \`\`\`json
+    { "a": 42 }
+    \`\`\`
+    """
+    value: String
+  ): Number!
+}
+
+"""
+\`\`\`text
+\\"""
+\`\`\`
+"""
+type Escaped {
+  value: String
+}
+
+================================================================================
+`;

--- a/tests/format/graphql/embedded-markdown/description.graphql
+++ b/tests/format/graphql/embedded-markdown/description.graphql
@@ -1,0 +1,41 @@
+"""
+## Example Request
+
+```graphql
+query{a}
+```
+
+## Example Response
+
+```json
+{"a":42}
+```
+"""
+type Query { a: Number! }
+
+type Nested {
+  """
+  ## Field description
+
+  ```json
+  {"a":42}
+  ```
+  """
+  a: Number!
+
+  b(
+    """
+    ```json
+    {"a":42}
+    ```
+    """
+    value: String
+  ): Number!
+}
+
+"""
+```text
+\"""
+```
+"""
+type Escaped { value: String }

--- a/tests/format/graphql/embedded-markdown/format.test.js
+++ b/tests/format/graphql/embedded-markdown/format.test.js
@@ -1,0 +1,4 @@
+runFormatTest(import.meta, ["graphql"]);
+runFormatTest(import.meta, ["graphql"], {
+  embeddedLanguageFormatting: "off",
+});


### PR DESCRIPTION
## Description

Fixes #6745.

Format fenced Markdown code blocks inside GraphQL block-string descriptions.
The GraphQL printer now delegates eligible description blocks to Prettier's
Markdown parser while preserving ordinary GraphQL strings and escaped triple
quotes.

## Validation

- new GraphQL embedded-Markdown snapshots: 2 passing
- targeted lint, formatting, changelog lint, and diff checks

## AI assistance

AI assistance was used to investigate and draft this change. I reviewed the
GraphQL embed and printer contracts, every snapshot change, and independently
ran the focused checks.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the contributing guidelines.
- [ ] I did _not_ use AI to generate this PR.
- [x] I have reviewed the AI-generated content before submitting.
