### PR TITLE
feat(playground): paste config JSON

### DIFF
--- a/website/playground/Playground.jsx
+++ b/website/playground/Playground.jsx
@@ -108,7 +108,14 @@ function setup(props) {
       if (!config || Array.isArray(config) || typeof config !== "object") {
         throw new TypeError("Expected a configuration object.");
       }
-      Object.assign(state, { options: { ...state.options, ...config } });
+      const supportedOptions = new Set(
+        props.availableOptions.map((option) => option.name),
+      );
+      const options = Object.fromEntries(
+        Object.entries(config).filter(([name]) => supportedOptions.has(name)),
+      );
+      Object.assign(state, { options: { ...state.options, ...options } });
+      formatInput();
     } catch {
       window.alert("Unable to paste a valid Prettier configuration.");
     }

--- a/website/playground/Playground.jsx
+++ b/website/playground/Playground.jsx
@@ -102,6 +102,18 @@ function setup(props) {
     state.content = "";
   };
 
+  const pasteConfig = async () => {
+    try {
+      const config = JSON.parse(await navigator.clipboard.readText());
+      if (!config || Array.isArray(config) || typeof config !== "object") {
+        throw new TypeError("Expected a configuration object.");
+      }
+      Object.assign(state, { options: { ...state.options, ...config } });
+    } catch {
+      window.alert("Unable to paste a valid Prettier configuration.");
+    }
+  };
+
   const resetOptions = () => {
     Object.assign(state, { options: { ...defaultOptions } });
   };
@@ -490,6 +502,7 @@ function setup(props) {
                   >
                     Copy config JSON
                   </ClipboardButton>
+                  <Button onClick={pasteConfig}>Paste config JSON</Button>
                   <Button
                     onClick={insertDummyId}
                     onMousedown={(event) => event.preventDefault()} // prevent button from focusing


### PR DESCRIPTION
## Description

Fixes #6142.

Add a `Paste config JSON` action to the Playground. It reads the clipboard,
accepts only a JSON configuration object, merges it into the current options,
and shows a clear alert for invalid JSON, non-object values, or clipboard
errors.

## Validation

- exact source-handler harness: 6 valid and invalid clipboard scenarios
- targeted ESLint and Prettier checks
- production website build
- generated bundle contains the paste handler and button

## AI assistance

AI assistance was used to investigate and draft this change. I reviewed the
clipboard, validation, and state-merge contracts and independently ran the
source harness and production build.

## Checklist

- [x] I’ve added tests or a focused reproduction to confirm my change works.
- [x] I’ve read the contributing guidelines.
- [ ] I did _not_ use AI to generate this PR.
- [x] I have reviewed the AI-generated content before submitting.
