### PR TITLE
Fix unstable block comments in ternaries and conditional types

### DIFF
--- a/changelog_unreleased/typescript/19765.md
+++ b/changelog_unreleased/typescript/19765.md
@@ -1,0 +1,35 @@
+#### Fix unstable block comments in ternaries and conditional types (#19765 by @subotac)
+
+Block comments before the consequent of a conditional expression or conditional type were formatted differently on the second pass.
+
+<!-- prettier-ignore -->
+```typescript
+// Input
+type T = any extends B
+  /* Comment */
+    ? C
+    : D;
+T = any instanceof B
+  /* Comment */
+    ? C
+    : D;
+
+// Prettier stable
+type T = any extends B
+  ? /* Comment */
+    C
+  : D;
+T =
+  any instanceof B
+    ? /* Comment */
+      C
+    : D;
+
+// Prettier stable (second format)
+type T = any extends B ? /* Comment */ C : D;
+T = any instanceof B ? /* Comment */ C : D;
+
+// Prettier main
+type T = any extends B ? /* Comment */ C : D;
+T = any instanceof B ? /* Comment */ C : D;
+```

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -278,6 +278,27 @@ function handleConditionalExpressionComments({
       isConditionalType(enclosingNode)) &&
     followingNode
   ) {
+    const consequentNode =
+      enclosingNode.type === "ConditionalExpression"
+        ? enclosingNode.consequent
+        : enclosingNode.trueType;
+    if (
+      followingNode === consequentNode &&
+      isBlockComment(comment) &&
+      !hasNewlineInRange(
+        options.originalText,
+        locStart(comment),
+        locEnd(comment),
+      )
+    ) {
+      addDanglingComment(
+        enclosingNode,
+        comment,
+        "commentBeforeTernaryConsequent",
+      );
+      return true;
+    }
+
     if (
       options.experimentalTernaries &&
       enclosingNode.alternate === followingNode &&

--- a/src/language-js/print/ternary-old.js
+++ b/src/language-js/print/ternary-old.js
@@ -183,9 +183,10 @@ function shouldExtraIndentForConditionalExpression(path) {
  * @param {AstPath} path - The path to the ConditionalExpression/TSConditionalType node.
  * @param {Options} options - Prettier options
  * @param {Function} print - Print function to call recursively
+ * @param {Doc} printedConsequent - The printed consequent and its comments
  * @returns {Doc}
  */
-function printTernaryOld(path, options, print) {
+function printTernaryOld(path, options, print, printedConsequent) {
   const { node } = path;
   const isConditionalExpression = node.type === "ConditionalExpression";
   const consequentNodePropertyName = isConditionalExpression
@@ -261,9 +262,7 @@ function printTernaryOld(path, options, print) {
 
     parts.push(
       " ? ",
-      isNil(consequentNode)
-        ? print(consequentNodePropertyName)
-        : wrap(print(consequentNodePropertyName)),
+      isNil(consequentNode) ? printedConsequent : wrap(printedConsequent),
       " : ",
       alternateNode.type === node.type || isNil(alternateNode)
         ? print(alternateNodePropertyName)
@@ -292,16 +291,14 @@ function printTernaryOld(path, options, print) {
      : alternate
     ```
     */
-    const printBranch = (nodePropertyName) =>
-      options.useTabs
-        ? indent(print(nodePropertyName))
-        : align(2, print(nodePropertyName));
+    const printBranch = (nodePropertyName, doc = print(nodePropertyName)) =>
+      options.useTabs ? indent(doc) : align(2, doc);
     // normal mode
     const part = [
       line,
       "? ",
       consequentNode.type === node.type ? ifBreak("", "(") : "",
-      printBranch(consequentNodePropertyName),
+      printBranch(consequentNodePropertyName, printedConsequent),
       consequentNode.type === node.type ? ifBreak("", ")") : "",
       line,
       ": ",

--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -151,16 +151,25 @@ const wrapInParens = (doc) => [
  * @returns {Doc}
  */
 function printTernary(path, options, print, args) {
-  if (!options.experimentalTernaries) {
-    return printTernaryOld(path, options, print);
-  }
-
   const { node } = path;
   const isConditionalExpression = node.type === "ConditionalExpression";
-  const isTSConditional = isConditionalType(node);
   const consequentNodePropertyName = isConditionalExpression
     ? "consequent"
     : "trueType";
+  const consequentComments = printDanglingComments(path, options, {
+    marker: "commentBeforeTernaryConsequent",
+  });
+  const printedConsequent = [
+    consequentComments,
+    consequentComments ? line : "",
+    print(consequentNodePropertyName),
+  ];
+
+  if (!options.experimentalTernaries) {
+    return printTernaryOld(path, options, print, printedConsequent);
+  }
+
+  const isTSConditional = isConditionalType(node);
   const alternateNodePropertyName = isConditionalExpression
     ? "alternate"
     : "falseType";
@@ -287,7 +296,9 @@ function printTernary(path, options, print, args) {
       alternateComments.push(printDanglingComments(path, options));
     }, "test");
   }
-  if (hasComment(node, CommentCheckFlags.Dangling)) {
+  if (
+    hasComment(node, CommentCheckFlags.Dangling, (comment) => !comment.printed)
+  ) {
     alternateComments.push(printDanglingComments(path, options));
   }
 
@@ -314,7 +325,6 @@ function printTernary(path, options, print, args) {
     id: testId,
   });
 
-  const printedConsequent = print(consequentNodePropertyName);
   const consequent = indent([
     isConsequentTernary ||
     (isInJsx && (isJsxElement(consequentNode) || isParentTernary || isInChain))

--- a/tests/format/typescript/conditional-types/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/conditional-types/__snapshots__/format.test.js.snap
@@ -124,6 +124,15 @@ T = any instanceof B
      B | C
     : D;
 
+type T = any extends B
+  /* Comment */
+    ? C
+    : D;
+T = any instanceof B
+  /* Comment */
+    ? C
+    : D;
+
 =====================================output=====================================
 type A =
   B extends T ?
@@ -247,6 +256,9 @@ T = any instanceof B ?
   : D;
 type T = any extends B ? /* Comment */ B | C : D;
 T = any instanceof B ? /* Comment */ B | C : D;
+
+type T = any extends B ? /* Comment */ C : D;
+T = any instanceof B ? /* Comment */ C : D;
 
 ================================================================================
 `;
@@ -374,6 +386,15 @@ T = any instanceof B
      B | C
     : D;
 
+type T = any extends B
+  /* Comment */
+    ? C
+    : D;
+T = any instanceof B
+  /* Comment */
+    ? C
+    : D;
+
 =====================================output=====================================
 type A = B extends T
   ? // comment
@@ -488,6 +509,9 @@ T =
     : D;
 type T = any extends B ? /* Comment */ B | C : D;
 T = any instanceof B ? /* Comment */ B | C : D;
+
+type T = any extends B ? /* Comment */ C : D;
+T = any instanceof B ? /* Comment */ C : D;
 
 ================================================================================
 `;

--- a/tests/format/typescript/conditional-types/comments.ts
+++ b/tests/format/typescript/conditional-types/comments.ts
@@ -115,3 +115,12 @@ T = any instanceof B
   ?/* Comment */
      B | C
     : D;
+
+type T = any extends B
+  /* Comment */
+    ? C
+    : D;
+T = any instanceof B
+  /* Comment */
+    ? C
+    : D;


### PR DESCRIPTION
  ## Description
   Fixes #18646
  Treat single-line block comments before ternary consequents as marked dangling comments and print them consistently in both ternary printers. This keeps conditional expressions and TypeScript conditional
  types idempotent.

  ## Checklist

  - [x] I’ve added tests to confirm my change works.
  - [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
  - [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
  - [x] I’ve read the contributing guidelines.
  - [x] I did not use AI to generate this PR.
  - [ ] I have reviewed the AI-generated content before submitting.