### PR TITLE
Add test for `return` in `static block`

### DIFF
--- a/tests/format/js/commonjs/__snapshots__/format.test.js.snap
+++ b/tests/format/js/commonjs/__snapshots__/format.test.js.snap
@@ -117,7 +117,7 @@ new.target
 ^~~~~~~~~~"
 `;
 
-exports[`snippet: return.cjs format 1`] = `
+exports[`snippet: return-top-level.cjs format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
                                                       printWidth: 80 (default) |
@@ -129,7 +129,7 @@ return;
 ================================================================================
 `;
 
-exports[`snippet: return.mjs format 1`] = `
+exports[`snippet: return-top-level.mjs format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
                                                       printWidth: 80 (default) |
@@ -141,33 +141,33 @@ return;
 ================================================================================
 `;
 
-exports[`snippet: return.mjs format[espree] 1`] = `
+exports[`snippet: return-top-level.mjs format[espree] 1`] = `
 "'return' outside of function (1:1)
 > 1 | return
     | ^
 Cause: 'return' outside of function"
 `;
 
-exports[`snippet: return.mjs format[meriyah] 1`] = `
+exports[`snippet: return-top-level.mjs format[meriyah] 1`] = `
 "Illegal return statement (1:1)
 > 1 | return
     | ^^^^^^
 Cause: [1:0-1:6]: Illegal return statement"
 `;
 
-exports[`snippet: return.mjs format[yuku] 1`] = `
+exports[`snippet: return-top-level.mjs format[yuku] 1`] = `
 "'return' statement is only valid inside a function (1:1)
 > 1 | return
     | ^^^^^^"
 `;
 
-exports[`snippet: return.mjs format[yuku-ts] 1`] = `
+exports[`snippet: return-top-level.mjs format[yuku-ts] 1`] = `
 "'return' statement is only valid inside a function (1:1)
 > 1 | return
     | ^^^^^^"
 `;
 
-exports[`snippet: return.unknown format 1`] = `
+exports[`snippet: return-top-level.unknown format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
                                                       printWidth: 80 (default) |

--- a/tests/format/js/commonjs/__snapshots__/format.test.js.snap
+++ b/tests/format/js/commonjs/__snapshots__/format.test.js.snap
@@ -117,7 +117,253 @@ new.target
 ^~~~~~~~~~"
 `;
 
-exports[`snippet: return-top-level.cjs format 1`] = `
+exports[`snippet: return/in-static-block.cjs format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+class X { static { return; } }
+=====================================output=====================================
+class X {
+  static {
+    return;
+  }
+}
+
+================================================================================
+`;
+
+exports[`snippet: return/in-static-block.cjs format[__babel_estree] 1`] = `
+"'return' outside of function. (1:20)
+> 1 | class X { static { return; } }
+    |                    ^
+Cause: 'return' outside of function. (1:19)"
+`;
+
+exports[`snippet: return/in-static-block.cjs format[acorn] 1`] = `
+"'return' outside of function (1:20)
+> 1 | class X { static { return; } }
+    |                    ^
+Cause: 'return' outside of function (1:19)"
+`;
+
+exports[`snippet: return/in-static-block.cjs format[babel] 1`] = `
+"'return' outside of function. (1:20)
+> 1 | class X { static { return; } }
+    |                    ^
+Cause: 'return' outside of function. (1:19)"
+`;
+
+exports[`snippet: return/in-static-block.cjs format[babel-ts] 1`] = `
+"'return' outside of function. (1:20)
+> 1 | class X { static { return; } }
+    |                    ^
+Cause: 'return' outside of function. (1:19)"
+`;
+
+exports[`snippet: return/in-static-block.cjs format[espree] 1`] = `
+"'return' outside of function (1:20)
+> 1 | class X { static { return; } }
+    |                    ^
+Cause: 'return' outside of function"
+`;
+
+exports[`snippet: return/in-static-block.cjs format[meriyah] 1`] = `
+"Illegal return statement (1:20)
+> 1 | class X { static { return; } }
+    |                    ^^^^^^
+Cause: [1:19-1:25]: Illegal return statement"
+`;
+
+exports[`snippet: return/in-static-block.cjs format[oxc] 1`] = `
+"A 'return' statement cannot be used inside a class static block. (1:20)
+> 1 | class X { static { return; } }
+    |                    ^^^^^^"
+`;
+
+exports[`snippet: return/in-static-block.cjs format[oxc-ts] 1`] = `
+"A 'return' statement cannot be used inside a class static block. (1:20)
+> 1 | class X { static { return; } }
+    |                    ^^^^^^"
+`;
+
+exports[`snippet: return/in-static-block.cjs format[yuku] 1`] = `
+"'return' statement is only valid inside a function (1:20)
+> 1 | class X { static { return; } }
+    |                    ^^^^^^"
+`;
+
+exports[`snippet: return/in-static-block.cjs format[yuku-ts] 1`] = `
+"'return' statement is only valid inside a function (1:20)
+> 1 | class X { static { return; } }
+    |                    ^^^^^^"
+`;
+
+exports[`snippet: return/in-static-block.mjs format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+class X { static { return; } }
+=====================================output=====================================
+class X {
+  static {
+    return;
+  }
+}
+
+================================================================================
+`;
+
+exports[`snippet: return/in-static-block.mjs format[__babel_estree] 1`] = `
+"'return' outside of function. (1:20)
+> 1 | class X { static { return; } }
+    |                    ^
+Cause: 'return' outside of function. (1:19)"
+`;
+
+exports[`snippet: return/in-static-block.mjs format[acorn] 1`] = `
+"'return' outside of function (1:20)
+> 1 | class X { static { return; } }
+    |                    ^
+Cause: 'return' outside of function (1:19)"
+`;
+
+exports[`snippet: return/in-static-block.mjs format[babel] 1`] = `
+"'return' outside of function. (1:20)
+> 1 | class X { static { return; } }
+    |                    ^
+Cause: 'return' outside of function. (1:19)"
+`;
+
+exports[`snippet: return/in-static-block.mjs format[babel-ts] 1`] = `
+"'return' outside of function. (1:20)
+> 1 | class X { static { return; } }
+    |                    ^
+Cause: 'return' outside of function. (1:19)"
+`;
+
+exports[`snippet: return/in-static-block.mjs format[espree] 1`] = `
+"'return' outside of function (1:20)
+> 1 | class X { static { return; } }
+    |                    ^
+Cause: 'return' outside of function"
+`;
+
+exports[`snippet: return/in-static-block.mjs format[meriyah] 1`] = `
+"Illegal return statement (1:20)
+> 1 | class X { static { return; } }
+    |                    ^^^^^^
+Cause: [1:19-1:25]: Illegal return statement"
+`;
+
+exports[`snippet: return/in-static-block.mjs format[oxc] 1`] = `
+"A 'return' statement cannot be used inside a class static block. (1:20)
+> 1 | class X { static { return; } }
+    |                    ^^^^^^"
+`;
+
+exports[`snippet: return/in-static-block.mjs format[oxc-ts] 1`] = `
+"A 'return' statement cannot be used inside a class static block. (1:20)
+> 1 | class X { static { return; } }
+    |                    ^^^^^^"
+`;
+
+exports[`snippet: return/in-static-block.mjs format[yuku] 1`] = `
+"'return' statement is only valid inside a function (1:20)
+> 1 | class X { static { return; } }
+    |                    ^^^^^^"
+`;
+
+exports[`snippet: return/in-static-block.mjs format[yuku-ts] 1`] = `
+"'return' statement is only valid inside a function (1:20)
+> 1 | class X { static { return; } }
+    |                    ^^^^^^"
+`;
+
+exports[`snippet: return/in-static-block.unknown format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+class X { static { return; } }
+=====================================output=====================================
+class X {
+  static {
+    return;
+  }
+}
+
+================================================================================
+`;
+
+exports[`snippet: return/in-static-block.unknown format[__babel_estree] 1`] = `
+"'return' outside of function. (1:20)
+> 1 | class X { static { return; } }
+    |                    ^
+Cause: 'return' outside of function. (1:19)"
+`;
+
+exports[`snippet: return/in-static-block.unknown format[acorn] 1`] = `
+"'return' outside of function (1:20)
+> 1 | class X { static { return; } }
+    |                    ^
+Cause: 'return' outside of function (1:19)"
+`;
+
+exports[`snippet: return/in-static-block.unknown format[babel] 1`] = `
+"'return' outside of function. (1:20)
+> 1 | class X { static { return; } }
+    |                    ^
+Cause: 'return' outside of function. (1:19)"
+`;
+
+exports[`snippet: return/in-static-block.unknown format[babel-ts] 1`] = `
+"'return' outside of function. (1:20)
+> 1 | class X { static { return; } }
+    |                    ^
+Cause: 'return' outside of function. (1:19)"
+`;
+
+exports[`snippet: return/in-static-block.unknown format[espree] 1`] = `
+"'return' outside of function (1:20)
+> 1 | class X { static { return; } }
+    |                    ^
+Cause: 'return' outside of function"
+`;
+
+exports[`snippet: return/in-static-block.unknown format[meriyah] 1`] = `
+"Illegal return statement (1:20)
+> 1 | class X { static { return; } }
+    |                    ^^^^^^
+Cause: [1:19-1:25]: Illegal return statement"
+`;
+
+exports[`snippet: return/in-static-block.unknown format[oxc] 1`] = `
+"A 'return' statement cannot be used inside a class static block. (1:20)
+> 1 | class X { static { return; } }
+    |                    ^^^^^^"
+`;
+
+exports[`snippet: return/in-static-block.unknown format[oxc-ts] 1`] = `
+"A 'return' statement cannot be used inside a class static block. (1:20)
+> 1 | class X { static { return; } }
+    |                    ^^^^^^"
+`;
+
+exports[`snippet: return/in-static-block.unknown format[yuku] 1`] = `
+"'return' statement is only valid inside a function (1:20)
+> 1 | class X { static { return; } }
+    |                    ^^^^^^"
+`;
+
+exports[`snippet: return/in-static-block.unknown format[yuku-ts] 1`] = `
+"'return' statement is only valid inside a function (1:20)
+> 1 | class X { static { return; } }
+    |                    ^^^^^^"
+`;
+
+exports[`snippet: return/top-level.cjs format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
                                                       printWidth: 80 (default) |
@@ -129,7 +375,7 @@ return;
 ================================================================================
 `;
 
-exports[`snippet: return-top-level.mjs format 1`] = `
+exports[`snippet: return/top-level.mjs format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
                                                       printWidth: 80 (default) |
@@ -141,33 +387,33 @@ return;
 ================================================================================
 `;
 
-exports[`snippet: return-top-level.mjs format[espree] 1`] = `
+exports[`snippet: return/top-level.mjs format[espree] 1`] = `
 "'return' outside of function (1:1)
 > 1 | return
     | ^
 Cause: 'return' outside of function"
 `;
 
-exports[`snippet: return-top-level.mjs format[meriyah] 1`] = `
+exports[`snippet: return/top-level.mjs format[meriyah] 1`] = `
 "Illegal return statement (1:1)
 > 1 | return
     | ^^^^^^
 Cause: [1:0-1:6]: Illegal return statement"
 `;
 
-exports[`snippet: return-top-level.mjs format[yuku] 1`] = `
+exports[`snippet: return/top-level.mjs format[yuku] 1`] = `
 "'return' statement is only valid inside a function (1:1)
 > 1 | return
     | ^^^^^^"
 `;
 
-exports[`snippet: return-top-level.mjs format[yuku-ts] 1`] = `
+exports[`snippet: return/top-level.mjs format[yuku-ts] 1`] = `
 "'return' statement is only valid inside a function (1:1)
 > 1 | return
     | ^^^^^^"
 `;
 
-exports[`snippet: return-top-level.unknown format 1`] = `
+exports[`snippet: return/top-level.unknown format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
                                                       printWidth: 80 (default) |

--- a/tests/format/js/commonjs/format.test.js
+++ b/tests/format/js/commonjs/format.test.js
@@ -1,7 +1,12 @@
 const tests = [
   {
     code: "return",
-    baseFilename: "return-top-level",
+    baseFilename: "return/top-level",
+  },
+  // https://github.com/acornjs/acorn/issues/1376#issuecomment-2960924476
+  {
+    code: "class X { static { return; } }",
+    baseFilename: "return/in-static-block",
   },
   {
     code: "new.target",
@@ -23,9 +28,42 @@ runFormatTest(
   ["babel", "flow", "typescript"],
   {
     errors: {
-      acorn: ["new-target.mjs"],
-      espree: ["return-top-level.mjs", "new-target.mjs"],
-      meriyah: ["using.cjs", "return-top-level.mjs", "new-target.mjs"],
+      babel: [
+        "return/in-static-block.cjs",
+        "return/in-static-block.mjs",
+        "return/in-static-block.unknown",
+      ],
+      "babel-ts": [
+        "return/in-static-block.cjs",
+        "return/in-static-block.mjs",
+        "return/in-static-block.unknown",
+      ],
+      __babel_estree: [
+        "return/in-static-block.cjs",
+        "return/in-static-block.mjs",
+        "return/in-static-block.unknown",
+      ],
+      acorn: [
+        "new-target.mjs",
+        "return/in-static-block.cjs",
+        "return/in-static-block.mjs",
+        "return/in-static-block.unknown",
+      ],
+      espree: [
+        "return/top-level.mjs",
+        "new-target.mjs",
+        "return/in-static-block.cjs",
+        "return/in-static-block.mjs",
+        "return/in-static-block.unknown",
+      ],
+      meriyah: [
+        "using.cjs",
+        "return/top-level.mjs",
+        "new-target.mjs",
+        "return/in-static-block.cjs",
+        "return/in-static-block.mjs",
+        "return/in-static-block.unknown",
+      ],
       flow: [
         "new-target.cjs",
         "new-target.mjs",
@@ -35,10 +73,30 @@ runFormatTest(
         "using.unknown",
       ],
       hermes: ["new-target.cjs", "new-target.mjs", "new-target.unknown"],
-      oxc: ["new-target.mjs"],
-      "oxc-ts": ["new-target.mjs"],
-      yuku: ["return-top-level.mjs"],
-      "yuku-ts": ["return-top-level.mjs"],
+      oxc: [
+        "new-target.mjs",
+        "return/in-static-block.cjs",
+        "return/in-static-block.mjs",
+        "return/in-static-block.unknown",
+      ],
+      "oxc-ts": [
+        "new-target.mjs",
+        "return/in-static-block.cjs",
+        "return/in-static-block.mjs",
+        "return/in-static-block.unknown",
+      ],
+      yuku: [
+        "return/top-level.mjs",
+        "return/in-static-block.cjs",
+        "return/in-static-block.mjs",
+        "return/in-static-block.unknown",
+      ],
+      "yuku-ts": [
+        "return/top-level.mjs",
+        "return/in-static-block.cjs",
+        "return/in-static-block.mjs",
+        "return/in-static-block.unknown",
+      ],
     },
   },
 );

--- a/tests/format/js/commonjs/format.test.js
+++ b/tests/format/js/commonjs/format.test.js
@@ -1,7 +1,7 @@
 const tests = [
   {
     code: "return",
-    baseFilename: "return",
+    baseFilename: "return-top-level",
   },
   {
     code: "new.target",
@@ -24,8 +24,8 @@ runFormatTest(
   {
     errors: {
       acorn: ["new-target.mjs"],
-      espree: ["return.mjs", "new-target.mjs"],
-      meriyah: ["using.cjs", "return.mjs", "new-target.mjs"],
+      espree: ["return-top-level.mjs", "new-target.mjs"],
+      meriyah: ["using.cjs", "return-top-level.mjs", "new-target.mjs"],
       flow: [
         "new-target.cjs",
         "new-target.mjs",
@@ -37,8 +37,8 @@ runFormatTest(
       hermes: ["new-target.cjs", "new-target.mjs", "new-target.unknown"],
       oxc: ["new-target.mjs"],
       "oxc-ts": ["new-target.mjs"],
-      yuku: ["return.mjs"],
-      "yuku-ts": ["return.mjs"],
+      yuku: ["return-top-level.mjs"],
+      "yuku-ts": ["return-top-level.mjs"],
     },
   },
 );


### PR DESCRIPTION
<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.
