### PR TITLE
Add ng-model-options to recognized AngularJS attributes

### DIFF
--- a/changelog_unreleased/angular/19777.md
+++ b/changelog_unreleased/angular/19777.md
@@ -1,0 +1,19 @@
+#### Add ng-model-options to recognized AngularJS attributes (#19777 by @xemlock)
+
+<!-- prettier-ignore -->
+```html
+<!-- Input -->
+<input ng-model="$ctrl.name" ng-model-options="{ debounce : 1000 , 'updateOn' : 'blur' }" />
+
+<!-- Prettier stable -->
+<input
+  ng-model="$ctrl.name"
+  ng-model-options="{ debounce : 1000 , 'updateOn' : 'blur' }"
+/>
+
+<!-- Prettier main -->
+<input
+  ng-model="$ctrl.name"
+  ng-model-options="{ debounce: 1000, updateOn: 'blur' }"
+/>
+```

--- a/src/language-html/embed/angular-attributes.js
+++ b/src/language-html/embed/angular-attributes.js
@@ -54,7 +54,7 @@ const printers = [
         (name.startsWith("[") && name.endsWith("]")) ||
         /^bind(?:on)?-/.test(name) ||
         // Unofficial rudimentary support for some of the most used directives of AngularJS 1.x
-        /^ng-(?:if|show|hide|class|style)$/.test(name)
+        /^ng-(?:if|show|hide|class|style|model-options)$/.test(name)
       );
     },
     print: createAngularPrinter("__ng_binding"),

--- a/tests/format/angular/angular/__snapshots__/format.test.js.snap
+++ b/tests/format/angular/angular/__snapshots__/format.test.js.snap
@@ -8,8 +8,6 @@ parsers: ["angular"]
 =====================================input======================================
 <div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
 
-<input ng-model="$ctrl.name" ng-model-options="{ debounce : 1000 , 'updateOn' : 'blur' }" />
-
 <div
 	class="common--error-message"
 	test-hook="upper-error-message"
@@ -21,11 +19,6 @@ parsers: ["angular"]
 
 =====================================output=====================================
 <div ng-if="$ctrl.shouldShowWarning && !$ctrl.loading">Warning!</div>
-
-<input
-  ng-model="$ctrl.name"
-  ng-model-options="{debounce: 1000, updateOn: 'blur'}"
-/>
 
 <div
   class="common--error-message"
@@ -55,8 +48,6 @@ parsers: ["angular"]
 =====================================input======================================
 <div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
 
-<input ng-model="$ctrl.name" ng-model-options="{ debounce : 1000 , 'updateOn' : 'blur' }" />
-
 <div
 	class="common--error-message"
 	test-hook="upper-error-message"
@@ -68,11 +59,6 @@ parsers: ["angular"]
 
 =====================================output=====================================
 <div ng-if="$ctrl.shouldShowWarning && !$ctrl.loading">Warning!</div>
-
-<input
-  ng-model="$ctrl.name"
-  ng-model-options="{ debounce: 1000, updateOn: 'blur' }"
-/>
 
 <div
   class="common--error-message"
@@ -102,8 +88,6 @@ printWidth: 1
 =====================================input======================================
 <div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
 
-<input ng-model="$ctrl.name" ng-model-options="{ debounce : 1000 , 'updateOn' : 'blur' }" />
-
 <div
 	class="common--error-message"
 	test-hook="upper-error-message"
@@ -122,15 +106,6 @@ printWidth: 1
 >
   Warning!
 </div>
-
-<input
-  ng-model="$ctrl.name"
-  ng-model-options="{
-    debounce: 1000,
-    updateOn:
-      'blur',
-  }"
-/>
 
 <div
   class="common--error-message"
@@ -184,8 +159,6 @@ trailingComma: "es5"
 =====================================input======================================
 <div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
 
-<input ng-model="$ctrl.name" ng-model-options="{ debounce : 1000 , 'updateOn' : 'blur' }" />
-
 <div
 	class="common--error-message"
 	test-hook="upper-error-message"
@@ -197,11 +170,6 @@ trailingComma: "es5"
 
 =====================================output=====================================
 <div ng-if="$ctrl.shouldShowWarning && !$ctrl.loading">Warning!</div>
-
-<input
-  ng-model="$ctrl.name"
-  ng-model-options="{ debounce: 1000, updateOn: 'blur' }"
-/>
 
 <div
   class="common--error-message"
@@ -231,8 +199,6 @@ trailingComma: "none"
 =====================================input======================================
 <div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
 
-<input ng-model="$ctrl.name" ng-model-options="{ debounce : 1000 , 'updateOn' : 'blur' }" />
-
 <div
 	class="common--error-message"
 	test-hook="upper-error-message"
@@ -244,11 +210,6 @@ trailingComma: "none"
 
 =====================================output=====================================
 <div ng-if="$ctrl.shouldShowWarning && !$ctrl.loading">Warning!</div>
-
-<input
-  ng-model="$ctrl.name"
-  ng-model-options="{ debounce: 1000, updateOn: 'blur' }"
-/>
 
 <div
   class="common--error-message"
@@ -3973,6 +3934,82 @@ trailingComma: "none"
 <p>{{ { a: a === {} } }}</p>
 <p>{{ { a: !{} } }}</p>
 <p>{{ { a: a ? b : {} } }}</p>
+
+================================================================================
+`;
+
+exports[`ng-model-options.html - {"bracketSpacing":false} format 1`] = `
+====================================options=====================================
+bracketSpacing: false
+parsers: ["angular"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+<input ng-model-options="   {    debounce : 1000 , 'updateOn' : 'blur' }" />
+
+=====================================output=====================================
+<input ng-model-options="{debounce: 1000, updateOn: 'blur'}" />
+
+================================================================================
+`;
+
+exports[`ng-model-options.html - {"htmlWhitespaceSensitivity":"ignore"} format 1`] = `
+====================================options=====================================
+htmlWhitespaceSensitivity: "ignore"
+parsers: ["angular"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+<input ng-model-options="   {    debounce : 1000 , 'updateOn' : 'blur' }" />
+
+=====================================output=====================================
+<input ng-model-options="{ debounce: 1000, updateOn: 'blur' }" />
+
+================================================================================
+`;
+
+exports[`ng-model-options.html - {"printWidth":1} format 1`] = `
+====================================options=====================================
+parsers: ["angular"]
+printWidth: 1
+ | printWidth: 1
+=====================================input======================================
+<input ng-model-options="   {    debounce : 1000 , 'updateOn' : 'blur' }" />
+
+=====================================output=====================================
+<input
+  ng-model-options="{
+    debounce: 1000,
+    updateOn:
+      'blur',
+  }"
+/>
+
+================================================================================
+`;
+
+exports[`ng-model-options.html - {"trailingComma":"es5"} format 1`] = `
+====================================options=====================================
+parsers: ["angular"]
+trailingComma: "es5"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+<input ng-model-options="   {    debounce : 1000 , 'updateOn' : 'blur' }" />
+
+=====================================output=====================================
+<input ng-model-options="{ debounce: 1000, updateOn: 'blur' }" />
+
+================================================================================
+`;
+
+exports[`ng-model-options.html - {"trailingComma":"none"} format 1`] = `
+====================================options=====================================
+parsers: ["angular"]
+trailingComma: "none"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+<input ng-model-options="   {    debounce : 1000 , 'updateOn' : 'blur' }" />
+
+=====================================output=====================================
+<input ng-model-options="{ debounce: 1000, updateOn: 'blur' }" />
 
 ================================================================================
 `;

--- a/tests/format/angular/angular/__snapshots__/format.test.js.snap
+++ b/tests/format/angular/angular/__snapshots__/format.test.js.snap
@@ -8,6 +8,8 @@ parsers: ["angular"]
 =====================================input======================================
 <div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
 
+<input ng-model="$ctrl.name" ng-model-options="{ debounce : 1000 , 'updateOn' : 'blur' }" />
+
 <div
 	class="common--error-message"
 	test-hook="upper-error-message"
@@ -19,6 +21,11 @@ parsers: ["angular"]
 
 =====================================output=====================================
 <div ng-if="$ctrl.shouldShowWarning && !$ctrl.loading">Warning!</div>
+
+<input
+  ng-model="$ctrl.name"
+  ng-model-options="{debounce: 1000, updateOn: 'blur'}"
+/>
 
 <div
   class="common--error-message"
@@ -48,6 +55,8 @@ parsers: ["angular"]
 =====================================input======================================
 <div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
 
+<input ng-model="$ctrl.name" ng-model-options="{ debounce : 1000 , 'updateOn' : 'blur' }" />
+
 <div
 	class="common--error-message"
 	test-hook="upper-error-message"
@@ -59,6 +68,11 @@ parsers: ["angular"]
 
 =====================================output=====================================
 <div ng-if="$ctrl.shouldShowWarning && !$ctrl.loading">Warning!</div>
+
+<input
+  ng-model="$ctrl.name"
+  ng-model-options="{ debounce: 1000, updateOn: 'blur' }"
+/>
 
 <div
   class="common--error-message"
@@ -88,6 +102,8 @@ printWidth: 1
 =====================================input======================================
 <div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
 
+<input ng-model="$ctrl.name" ng-model-options="{ debounce : 1000 , 'updateOn' : 'blur' }" />
+
 <div
 	class="common--error-message"
 	test-hook="upper-error-message"
@@ -106,6 +122,15 @@ printWidth: 1
 >
   Warning!
 </div>
+
+<input
+  ng-model="$ctrl.name"
+  ng-model-options="{
+    debounce: 1000,
+    updateOn:
+      'blur',
+  }"
+/>
 
 <div
   class="common--error-message"
@@ -159,6 +184,8 @@ trailingComma: "es5"
 =====================================input======================================
 <div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
 
+<input ng-model="$ctrl.name" ng-model-options="{ debounce : 1000 , 'updateOn' : 'blur' }" />
+
 <div
 	class="common--error-message"
 	test-hook="upper-error-message"
@@ -170,6 +197,11 @@ trailingComma: "es5"
 
 =====================================output=====================================
 <div ng-if="$ctrl.shouldShowWarning && !$ctrl.loading">Warning!</div>
+
+<input
+  ng-model="$ctrl.name"
+  ng-model-options="{ debounce: 1000, updateOn: 'blur' }"
+/>
 
 <div
   class="common--error-message"
@@ -199,6 +231,8 @@ trailingComma: "none"
 =====================================input======================================
 <div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
 
+<input ng-model="$ctrl.name" ng-model-options="{ debounce : 1000 , 'updateOn' : 'blur' }" />
+
 <div
 	class="common--error-message"
 	test-hook="upper-error-message"
@@ -210,6 +244,11 @@ trailingComma: "none"
 
 =====================================output=====================================
 <div ng-if="$ctrl.shouldShowWarning && !$ctrl.loading">Warning!</div>
+
+<input
+  ng-model="$ctrl.name"
+  ng-model-options="{ debounce: 1000, updateOn: 'blur' }"
+/>
 
 <div
   class="common--error-message"

--- a/tests/format/angular/angular/angularjs.html
+++ b/tests/format/angular/angular/angularjs.html
@@ -1,5 +1,7 @@
 <div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
 
+<input ng-model="$ctrl.name" ng-model-options="{ debounce : 1000 , 'updateOn' : 'blur' }" />
+
 <div
 	class="common--error-message"
 	test-hook="upper-error-message"

--- a/tests/format/angular/angular/angularjs.html
+++ b/tests/format/angular/angular/angularjs.html
@@ -1,7 +1,5 @@
 <div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
 
-<input ng-model="$ctrl.name" ng-model-options="{ debounce : 1000 , 'updateOn' : 'blur' }" />
-
 <div
 	class="common--error-message"
 	test-hook="upper-error-message"

--- a/tests/format/angular/angular/ng-model-options.html
+++ b/tests/format/angular/angular/ng-model-options.html
@@ -1,0 +1,1 @@
+<input ng-model-options="   {    debounce : 1000 , 'updateOn' : 'blur' }" />


### PR DESCRIPTION
AngularJS may be officially retired, but plenty of legacy codebases (and the people who maintain them) are still very much alive.

This PR extends the (sort of) unofficial AngularJS 1.x directive support in the HTML/Angular parser so that [ng-model-options](https://docs.angularjs.org/api/ng/directive/ngModelOptions) joins the list of recognized and formatted attributes.

<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.
