### PR TITLE
Add pnpm setup note for lint-staged pre-commit hook

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -20,6 +20,28 @@ npx mrm@2 lint-staged
 
 This will install [husky](https://github.com/typicode/husky) and [lint-staged](https://github.com/okonet/lint-staged), then add a configuration to the project’s `package.json` that will automatically format supported files in a pre-commit hook.
 
+:::caution
+
+`npx mrm@2 lint-staged` does not detect pnpm. If your project uses pnpm, set up husky and lint-staged manually:
+
+```bash
+pnpm add --save-dev husky lint-staged
+pnpm exec husky init
+node --eval "fs.writeFileSync('.husky/pre-commit','pnpm exec lint-staged\n')"
+```
+
+Then add the following to your `package.json`:
+
+```json
+{
+  "lint-staged": {
+    "**/*": "prettier --write --ignore-unknown"
+  }
+}
+```
+
+:::
+
 Read more at the [lint-staged](https://github.com/okonet/lint-staged#configuration) repo.
 
 ## Option 2. [pretty-quick](https://github.com/prettier/pretty-quick)

--- a/website/versioned_docs/version-stable/precommit.md
+++ b/website/versioned_docs/version-stable/precommit.md
@@ -20,6 +20,28 @@ npx mrm@2 lint-staged
 
 This will install [husky](https://github.com/typicode/husky) and [lint-staged](https://github.com/okonet/lint-staged), then add a configuration to the project’s `package.json` that will automatically format supported files in a pre-commit hook.
 
+:::caution
+
+`npx mrm@2 lint-staged` does not detect pnpm. If your project uses pnpm, set up husky and lint-staged manually:
+
+```bash
+pnpm add --save-dev husky lint-staged
+pnpm exec husky init
+node --eval "fs.writeFileSync('.husky/pre-commit','pnpm exec lint-staged\n')"
+```
+
+Then add the following to your `package.json`:
+
+```json
+{
+  "lint-staged": {
+    "**/*": "prettier --write --ignore-unknown"
+  }
+}
+```
+
+:::
+
 Read more at the [lint-staged](https://github.com/okonet/lint-staged#configuration) repo.
 
 ## Option 2. [pretty-quick](https://github.com/prettier/pretty-quick)


### PR DESCRIPTION
Fixes #14405.

`npx mrm@2 lint-staged` does not detect pnpm, so running it in a pnpm project throws. This PR adds a `:::caution` block to the pre-commit hook docs (both `docs/precommit.md` and the versioned copy) that explains how to set up husky and lint-staged manually for pnpm.

The pnpm commands match the existing manual setup in `docs/install.md#git-hooks`.