### PR TITLE
Fix MDX links broken by line breaks inside component text

### DIFF
--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -308,6 +308,42 @@ function printJsxElementInternal(path, options, print) {
 // turn themselves into the rather ugly `{' '}` when breaking.
 //
 // This function returns Doc array that satisfies rule of `fill()`.
+function splitMdxJsxText(text) {
+  if (text === "") {
+    return [""];
+  }
+
+  const tokens = [
+    ...text.matchAll(
+      /!?\[[^\]]*\](?:\([^)]*\)|\[[^\]]*\])?|[ \n\r\t]+|[^ \n\r\t]+/g,
+    ),
+  ].map((match) => match[0]);
+
+  const words = [];
+  if (/^[ \n\r\t]/.test(text)) {
+    const leading = tokens.shift();
+    words.push("", leading);
+    if (tokens.length === 0) {
+      words.push("");
+      return words;
+    }
+  }
+
+  if (tokens.length > 0 && /[ \n\r\t]$/.test(text)) {
+    const trailing = tokens.pop();
+    for (const token of tokens) {
+      words.push(token);
+    }
+    words.push(trailing, "");
+  } else {
+    for (const token of tokens) {
+      words.push(token);
+    }
+  }
+
+  return words;
+}
+
 function printJsxChildren(
   path,
   options,
@@ -337,7 +373,10 @@ function printJsxChildren(
 
       // Contains a non-whitespace character
       if (isMeaningfulJsxText(node)) {
-        const words = jsxWhitespace.split(text, /* captureWhitespace */ true);
+        const words =
+          options.parentParser === "mdx"
+            ? splitMdxJsxText(text)
+            : jsxWhitespace.split(text, /* captureWhitespace */ true);
 
         // Starts with whitespace
         if (words[0] === "") {

--- a/tests/format/mdx/mdx/__snapshots__/format.test.js.snap
+++ b/tests/format/mdx/mdx/__snapshots__/format.test.js.snap
@@ -368,6 +368,49 @@ opinionated-code-formatter-that-support-many-languages-and-integrate-with-most-e
 ================================================================================
 `;
 
+exports[`issue-19113.mdx - {"semi":false} format 1`] = `
+====================================options=====================================
+parsers: ["mdx"]
+semi: false
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+<TestComp>
+   Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam [nonumy  eirmod tempor](https://prettier.io) invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+</TestComp>
+
+=====================================output=====================================
+<TestComp>
+  Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
+  [nonumy  eirmod tempor](https://prettier.io) invidunt ut labore et dolore
+  magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo
+  dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est
+  Lorem ipsum dolor sit amet.
+</TestComp>
+
+================================================================================
+`;
+
+exports[`issue-19113.mdx format 1`] = `
+====================================options=====================================
+parsers: ["mdx"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+<TestComp>
+   Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam [nonumy  eirmod tempor](https://prettier.io) invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+</TestComp>
+
+=====================================output=====================================
+<TestComp>
+  Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
+  [nonumy  eirmod tempor](https://prettier.io) invidunt ut labore et dolore
+  magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo
+  dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est
+  Lorem ipsum dolor sit amet.
+</TestComp>
+
+================================================================================
+`;
+
 exports[`jsx.mdx - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["mdx"]

--- a/tests/format/mdx/mdx/issue-19113.mdx
+++ b/tests/format/mdx/mdx/issue-19113.mdx
@@ -1,0 +1,3 @@
+<TestComp>
+   Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam [nonumy  eirmod tempor](https://prettier.io) invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+</TestComp>


### PR DESCRIPTION
## Summary

MDX component text was being split for `fill()` word wrapping without recognizing Markdown links/images. When a long link label contained multiple spaces, Prettier inserted a line break inside the label, producing invalid Markdown:

```md
[nonumy
  eirmod tempor](https://prettier.io)
```

This change tokenizes JSX text inside MDX into Markdown links, images, whitespace runs, and other words so that the whole link token stays on one line.

Fixes #19113