### PR TITLE
docs: clarify proseWrap applies to Markdown, MDX, and YAML

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -427,6 +427,8 @@ or
 
 _First available in v1.8.2_
 
+This option applies to prose in Markdown, MDX, and YAML.
+
 By default, Prettier will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket. To have Prettier wrap prose to the print width, change this option to "always". If you want Prettier to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use `"never"`.
 
 Valid options:

--- a/website/versioned_docs/version-stable/options.md
+++ b/website/versioned_docs/version-stable/options.md
@@ -427,6 +427,8 @@ or
 
 _First available in v1.8.2_
 
+This option applies to prose in Markdown, MDX, and YAML.
+
 By default, Prettier will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket. To have Prettier wrap prose to the print width, change this option to "always". If you want Prettier to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use `"never"`.
 
 Valid options:


### PR DESCRIPTION
## Description

- The `proseWrap` option documentation only mentioned Markdown, but it also affects YAML formatting (block scalars and plain/quoted scalars) as well as MDX.
- Added a single sentence to the `## Prose Wrap` section in `docs/options.md` clarifying the full scope.
- Updated the corresponding `website/versioned_docs/version-stable/options.md` mirror.

Fixes #16127.

## Checklist

- [ ] I've added tests to confirm my change works.
- [ ] (If changing the API or CLI) I've documented the changes I've made (in the `docs/` directory).
- [ ] (If the change is user-facing) I've added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I've read the contributing guidelines.

## Background

This was previously attempted in #19003 but that PR was closed unmerged. The approach here is the same minimal docs clarification. Verified against the source: `proseWrap` is used in `src/language-yaml/utilities.js`, `src/language-yaml/print/mapping-item.js`, and `src/language-yaml/options.js`.

This is a documentation-only change; no code, tests, or dependencies are affected.