### PR TITLE
docs: document /* HTML */ comment alternative for embedded HTML formatting

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -548,6 +548,8 @@ Control whether Prettier formats quoted code embedded in the file.
 
 When Prettier identifies cases where it looks like you've placed some code it knows how to format within a string in another file, like in a tagged template in JavaScript with a tag named `html` or in code blocks in Markdown, it will by default try to format that code.
 
+In JavaScript, a leading `/* HTML */` block comment can be used instead of the `html` tag to mark a template literal as embedded HTML. The comment must be uppercase (`HTML`).
+
 Sometimes this behavior is undesirable, particularly in cases where you might not have intended the string to be interpreted as code. This option allows you to switch between the default behavior (`auto`) and disabling this feature entirely (`off`).
 
 Valid options:

--- a/website/versioned_docs/version-stable/options.md
+++ b/website/versioned_docs/version-stable/options.md
@@ -548,6 +548,8 @@ Control whether Prettier formats quoted code embedded in the file.
 
 When Prettier identifies cases where it looks like you've placed some code it knows how to format within a string in another file, like in a tagged template in JavaScript with a tag named `html` or in code blocks in Markdown, it will by default try to format that code.
 
+In JavaScript, a leading `/* HTML */` block comment can be used instead of the `html` tag to mark a template literal as embedded HTML. The comment must be uppercase (`HTML`).
+
 Sometimes this behavior is undesirable, particularly in cases where you might not have intended the string to be interpreted as code. This option allows you to switch between the default behavior (`auto`) and disabling this feature entirely (`off`).
 
 Valid options:


### PR DESCRIPTION
Closes #13911

This PR documents the `/* HTML */` block-comment alternative for marking embedded HTML in JavaScript template literals. The docs previously only mentioned the `html` tag.

Changes:
- `docs/options.md`
- `website/versioned_docs/version-stable/options.md`

Both now note that a leading uppercase `/* HTML */` comment can be used in place of the `html` tagged template tag.