### PR TITLE
fix: preserve shell shebang trampoline directives

### DIFF
--- a/changelog_unreleased/javascript/19791.md
+++ b/changelog_unreleased/javascript/19791.md
@@ -1,0 +1,21 @@
+#### Preserve shell shebang trampoline directives (#19791 by @santhiprakash)
+
+Prettier no longer inserts a semicolon between the `":"` directive and the `//;` shell comment in `#!/bin/sh` polyglot JavaScript files. It also preserves required leading semicolons on the following statement when they are needed for ASI protection.
+
+<!-- prettier-ignore -->
+```js
+// Input
+#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+const ten = 10;
+
+// Prettier stable
+#!/bin/sh
+":"; //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+const ten = 10;
+
+// Prettier main
+#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+const ten = 10;
+```

--- a/src/language-js/print/estree.js
+++ b/src/language-js/print/estree.js
@@ -7,6 +7,7 @@ import {
 } from "../../document/index.js";
 import { printDanglingComments } from "../../main/comments/print.js";
 import UnexpectedNodeError from "../../utilities/unexpected-node-error.js";
+import { isShellShebangDirective } from "../semicolon/semicolon.js";
 import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
 import { isMeaningfulEmptyStatement } from "../utilities/is-meaningful-empty-statement.js";
 import { isMethod } from "../utilities/is-method.js";
@@ -222,7 +223,10 @@ function printEstree(path, options, print, args) {
     case "Super":
       return "super";
     case "Directive":
-      return [print("value"), printSemicolon(options)];
+      return [
+        print("value"),
+        isShellShebangDirective(path, options) ? "" : printSemicolon(options),
+      ];
     case "UnaryExpression": {
       const parts = [node.operator];
 

--- a/src/language-js/print/expression-statement.js
+++ b/src/language-js/print/expression-statement.js
@@ -3,6 +3,7 @@ import {
   printLeadingComments,
 } from "../../main/comments/print.js";
 import {
+  isShellShebangDirective,
   isSingleHtmlEventHandlerExpressionStatement,
   isSingleJsxExpressionStatementInMarkdown,
   isSingleVueEventBindingExpressionStatement,
@@ -37,7 +38,9 @@ function shouldPrintSemicolon(path, options) {
     // Do not append semicolon after the only JSX element in a program
     isSingleJsxExpressionStatementInMarkdown(path, options) ||
     // Do not append semicolon after the only HTML event binding expression in a program
-    isSingleHtmlEventHandlerExpressionStatement(path, options)
+    isSingleHtmlEventHandlerExpressionStatement(path, options) ||
+    // Do not append semicolon after the shell shebang trampoline directive
+    isShellShebangDirective(path, options)
   ) {
     return false;
   }
@@ -61,12 +64,25 @@ function printExpressionStatement(path, options, print) {
         filter: (comment) => comment === typeCastComment,
       });
 
-      return printComments(path, [";", typeCastCommentDoc, ...parts], options, {
-        filter: (comment) => comment !== typeCastComment,
-      });
+      return printComments(
+        path,
+        [
+          ";",
+          typeCastCommentDoc,
+          ...parts,
+          shouldPrintSemicolon(path, options) ? ";" : "",
+        ],
+        options,
+        {
+          filter: (comment) => comment !== typeCastComment,
+        },
+      );
     }
 
     parts.unshift(";");
+    if (shouldPrintSemicolon(path, options)) {
+      parts.push(";");
+    }
   } else if (shouldPrintSemicolon(path, options)) {
     parts.push(";");
   }

--- a/src/language-js/semicolon/semicolon.js
+++ b/src/language-js/semicolon/semicolon.js
@@ -1,3 +1,4 @@
+import { locEnd } from "../location/index.js";
 import needsParentheses from "../parentheses/needs-parentheses.js";
 import { shouldPrintParamsWithoutParens } from "../print/function.js";
 import {
@@ -6,8 +7,84 @@ import {
 } from "../utilities/left-side.js";
 import { isJsxElement } from "../utilities/node-types.js";
 
+const SHELL_SHEBANG_RE = /^#!.*\b(?:sh|bash|dash|ash|zsh|fish|ksh)\b/;
+
+function getFirstLine(originalText) {
+  const lineEnd = originalText.indexOf("\n");
+  return lineEnd === -1 ? originalText : originalText.slice(0, lineEnd);
+}
+
+function isShellShebang(options) {
+  return (
+    options.originalText.startsWith("#!") &&
+    SHELL_SHEBANG_RE.test(getFirstLine(options.originalText))
+  );
+}
+
+function isColonDirectiveLikeNode(node) {
+  return (
+    (node.type === "Directive" && node.value?.value === ":") ||
+    (node.type === "ExpressionStatement" &&
+      (node.directive === ":" || node.expression?.value === ":"))
+  );
+}
+
+function isFirstProgramNode(node, parent) {
+  return (
+    parent.type === "Program" &&
+    (parent.directives?.[0] === node || parent.body?.[0] === node)
+  );
+}
+
+function hasShellTrampolineComment(node, options) {
+  const contentNode = node.value ?? node.expression;
+  if (!contentNode) {
+    return false;
+  }
+
+  const contentEnd = locEnd(contentNode);
+  const lineEnd = options.originalText.indexOf("\n", contentEnd);
+  const lineRest =
+    lineEnd === -1
+      ? options.originalText.slice(contentEnd)
+      : options.originalText.slice(contentEnd, lineEnd);
+
+  return /^\s*\/\/\s*;/.test(lineRest);
+}
+
+function isShellShebangDirective(path, options) {
+  const { node, parent } = path;
+
+  return (
+    isShellShebang(options) &&
+    isFirstProgramNode(node, parent) &&
+    isColonDirectiveLikeNode(node) &&
+    hasShellTrampolineComment(node, options)
+  );
+}
+
+function isAfterShellShebangDirective(path, options) {
+  const { node, parent } = path;
+
+  if (
+    node.type !== "ExpressionStatement" ||
+    parent?.type !== "Program" ||
+    path.key !== "body"
+  ) {
+    return false;
+  }
+
+  const previousNode =
+    path.index === 0 ? parent.directives?.at(-1) : parent.body[path.index - 1];
+
+  return (
+    previousNode &&
+    isShellShebangDirective({ node: previousNode, parent }, options)
+  );
+}
+
 function shouldExpressionStatementPrintLeadingSemicolon(path, options) {
-  if (options.semi) {
+  if (options.semi && !isAfterShellShebangDirective(path, options)) {
     return false;
   }
 
@@ -128,6 +205,8 @@ function isSingleVueEventBindingExpressionStatement(path, options) {
 }
 
 export {
+  isAfterShellShebangDirective,
+  isShellShebangDirective,
   isSingleHtmlEventHandlerExpressionStatement,
   isSingleJsxExpressionStatementInMarkdown,
   isSingleVueEventBindingExpressionStatement,

--- a/src/language-js/semicolon/semicolon.js
+++ b/src/language-js/semicolon/semicolon.js
@@ -205,7 +205,6 @@ function isSingleVueEventBindingExpressionStatement(path, options) {
 }
 
 export {
-  isAfterShellShebangDirective,
   isShellShebangDirective,
   isSingleHtmlEventHandlerExpressionStatement,
   isSingleJsxExpressionStatementInMarkdown,

--- a/tests/format/js/shebang/__snapshots__/format.test.js.snap
+++ b/tests/format/js/shebang/__snapshots__/format.test.js.snap
@@ -1,5 +1,56 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`non-polyglot-shell.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+#!/usr/bin/env node
+":" //; ordinary JavaScript comment
+const ten = 10;
+
+=====================================output=====================================
+#!/usr/bin/env node
+":"; //; ordinary JavaScript comment
+const ten = 10;
+
+================================================================================
+`;
+
+exports[`polyglot-shell.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+const ten = 10;
+
+=====================================output=====================================
+#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+const ten = 10;
+
+================================================================================
+`;
+
+exports[`polyglot-shell-asi.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+;[].forEach();
+
+=====================================output=====================================
+#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+;[].forEach();
+
+================================================================================
+`;
+
 exports[`shebang.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]

--- a/tests/format/js/shebang/non-polyglot-shell.js
+++ b/tests/format/js/shebang/non-polyglot-shell.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+":" //; ordinary JavaScript comment
+const ten = 10;

--- a/tests/format/js/shebang/polyglot-shell-asi.js
+++ b/tests/format/js/shebang/polyglot-shell-asi.js
@@ -1,0 +1,3 @@
+#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+;[].forEach();

--- a/tests/format/js/shebang/polyglot-shell.js
+++ b/tests/format/js/shebang/polyglot-shell.js
@@ -1,0 +1,3 @@
+#!/bin/sh
+":" //; exec /usr/bin/env ts-node --transpile-only "$0" "$@"
+const ten = 10;


### PR DESCRIPTION
## Description

Prettier was inserting a `;` after the `":"` directive in shell shebang polyglot files, moving the `;` out of the `//; exec ...` shell comment and breaking the shell trampoline.

This change skips the trailing semicolon for the first `":"` directive in a shell shebang (`#!/bin/sh`, `bash`, `dash`, etc.) when it is followed by a `//;` style shell comment. It also forces a leading semicolon on the next statement when that statement starts with an ASI-sensitive token such as `[` or `(`, so the output remains syntactically stable.

Fixes #7562.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory). Not applicable.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`. Added `changelog_unreleased/javascript/19791.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

## AI assistance

An AI coding agent prepared the implementation and tests, and I reviewed the diff and verification output before submitting.