### PR TITLE
Fix extra indentation for inline array/object in logical chains

### DIFF
--- a/changelog_unreleased/javascript/19792.md
+++ b/changelog_unreleased/javascript/19792.md
@@ -1,0 +1,23 @@
+#### Fix extra indentation for inline array/object in logical chains (#19792 by @santhiprakash)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+const x = $abilities ?? ["foo", "bar", "bar"] ?? ["foo", "bar", "bar", "veryVeryVeryVeryVeryVeryVeryVeryVeryLongKey"];
+
+// Prettier stable
+const x = $abilities ?? ["foo", "bar", "bar"] ?? [
+    "foo",
+    "bar",
+    "bar",
+    "veryVeryVeryVeryVeryVeryVeryVeryVeryLongKey",
+  ];
+
+// Prettier main
+const x = $abilities ?? ["foo", "bar", "bar"] ?? [
+  "foo",
+  "bar",
+  "bar",
+  "veryVeryVeryVeryVeryVeryVeryVeryVeryLongKey",
+];
+```

--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -33,6 +33,26 @@ import { shouldFlatten } from "../utilities/should-flatten.js";
 /** @import {Doc} from "../../document/index.js" */
 
 let uid = 0;
+
+function isInlineLogicalExpression(node) {
+  if (node.type !== "LogicalExpression") {
+    return false;
+  }
+
+  if (!shouldInlineLogicalExpression(node)) {
+    return false;
+  }
+
+  if (
+    isBinaryish(node.left) &&
+    shouldFlatten(node.operator, node.left.operator)
+  ) {
+    return isInlineLogicalExpression(node.left);
+  }
+
+  return true;
+}
+
 /*
 - `BinaryExpression`
 - `LogicalExpression`
@@ -122,12 +142,9 @@ function printBinaryishExpression(path, options, print) {
     parent.type === "ClassPrivateProperty" ||
     isObjectProperty(parent);
 
-  const samePrecedenceSubExpression =
-    isBinaryish(node.left) && shouldFlatten(node.operator, node.left.operator);
-
   if (
     shouldNotIndent ||
-    (shouldInlineLogicalExpression(node) && !samePrecedenceSubExpression) ||
+    isInlineLogicalExpression(node) ||
     (!shouldInlineLogicalExpression(node) && shouldIndentIfInlining)
   ) {
     return group(parts);

--- a/tests/format/js/nullish-coalescing/__snapshots__/format.test.js.snap
+++ b/tests/format/js/nullish-coalescing/__snapshots__/format.test.js.snap
@@ -1,5 +1,41 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`array-chain.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+$var = $abilities ?? ["foo", "bar", "bar"] ?? ["foo", "bar", "bar", "veryVeryVeryVeryVeryVeryVeryVeryVeryLongKey"];
+
+const x = $abilities ?? ["foo", "bar", "bar"] ?? ["foo", "bar", "bar", "veryVeryVeryVeryVeryVeryVeryVeryVeryLongKey"];
+
+const y = $abilities ?? { a: 1, b: 2 } ?? { a: 1, b: 2, c: 3, veryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: true };
+
+=====================================output=====================================
+$var = $abilities ?? ["foo", "bar", "bar"] ?? [
+  "foo",
+  "bar",
+  "bar",
+  "veryVeryVeryVeryVeryVeryVeryVeryVeryLongKey",
+];
+
+const x = $abilities ?? ["foo", "bar", "bar"] ?? [
+  "foo",
+  "bar",
+  "bar",
+  "veryVeryVeryVeryVeryVeryVeryVeryVeryLongKey",
+];
+
+const y = $abilities ?? { a: 1, b: 2 } ?? {
+  a: 1,
+  b: 2,
+  c: 3,
+  veryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: true,
+};
+
+================================================================================
+`;
+
 exports[`comments.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]

--- a/tests/format/js/nullish-coalescing/array-chain.js
+++ b/tests/format/js/nullish-coalescing/array-chain.js
@@ -1,0 +1,5 @@
+$var = $abilities ?? ["foo", "bar", "bar"] ?? ["foo", "bar", "bar", "veryVeryVeryVeryVeryVeryVeryVeryVeryLongKey"];
+
+const x = $abilities ?? ["foo", "bar", "bar"] ?? ["foo", "bar", "bar", "veryVeryVeryVeryVeryVeryVeryVeryVeryLongKey"];
+
+const y = $abilities ?? { a: 1, b: 2 } ?? { a: 1, b: 2, c: 3, veryVeryVeryVeryVeryVeryVeryVeryVeryLongKey: true };


### PR DESCRIPTION
## Description

Fix an extra level of indentation that Prettier adds to the contents of an array or object literal when it appears as the last operand of a logical chain (`??`, `&&`, `||`) and every operand in the chain is an inline array/object/JSX literal.

When `printBinaryishExpression` determined it should use the chain layout, it wrapped the whole tail in `indent()`, which compounded with the array/object's own indentation. The new `isInlineLogicalExpression` helper checks whether the entire flattened chain consists of inline right-hand operands; if so, the outer `indent()` is skipped and the array/object contents align with the surrounding expression instead of being shifted one extra level.

Fixes #5183

## Checklist

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.