### PR TITLE
docs: clarify that Prettier is not rule-based

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -11,6 +11,8 @@ Linters have two categories of rules:
 
 Prettier alleviates the need for this whole category of rules! Prettier is going to reprint the entire program from scratch in a consistent way, so it’s not possible for the programmer to make a mistake there anymore :)
 
+Prettier is not a rule-based tool: it has no individual formatting rules that you can enable or disable. It reprints your whole program from scratch instead.
+
 **Code-quality rules**: eg [no-unused-vars](https://eslint.org/docs/rules/no-unused-vars), [no-extra-bind](https://eslint.org/docs/rules/no-extra-bind), [no-implicit-globals](https://eslint.org/docs/rules/no-implicit-globals), [prefer-promise-reject-errors](https://eslint.org/docs/rules/prefer-promise-reject-errors)…
 
 Prettier does nothing to help with those kind of rules. They are also the most important ones provided by linters as they are likely to catch real bugs with your code!

--- a/website/versioned_docs/version-stable/comparison.md
+++ b/website/versioned_docs/version-stable/comparison.md
@@ -11,6 +11,8 @@ Linters have two categories of rules:
 
 Prettier alleviates the need for this whole category of rules! Prettier is going to reprint the entire program from scratch in a consistent way, so it’s not possible for the programmer to make a mistake there anymore :)
 
+Prettier is not a rule-based tool: it has no individual formatting rules that you can enable or disable. It reprints your whole program from scratch instead.
+
 **Code-quality rules**: eg [no-unused-vars](https://eslint.org/docs/rules/no-unused-vars), [no-extra-bind](https://eslint.org/docs/rules/no-extra-bind), [no-implicit-globals](https://eslint.org/docs/rules/no-implicit-globals), [prefer-promise-reject-errors](https://eslint.org/docs/rules/prefer-promise-reject-errors)…
 
 Prettier does nothing to help with those kind of rules. They are also the most important ones provided by linters as they are likely to catch real bugs with your code!


### PR DESCRIPTION
<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

Closes #8432.

Adds a short clarification to the [Prettier vs. Linters](https://prettier.io/docs/en/comparison.html) comparison page, explicitly stating that Prettier is not a rule-based tool and has no individual formatting rules to enable or disable. The same note is added to the stable versioned copy in `website/versioned_docs/version-stable/comparison.md`.

This is a more concise take than the previous unmerged attempt in #19265, which was closed by its author without review feedback.

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

## Verification

- `yarn prettier docs/comparison.md website/versioned_docs/version-stable/comparison.md --check` ✅
- `git diff --check` ✅