### PR TITLE
docs: stop mentioning Stylelint on the install page

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -185,7 +185,9 @@ And being able to run Prettier from the command line is still a good fallback, a
 
 ## ESLint (and other linters)
 
-If you use ESLint, install [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier#installation) to make ESLint and Prettier play nice with each other. It turns off all ESLint rules that are unnecessary or might conflict with Prettier. There’s a similar config for Stylelint: [stylelint-config-prettier](https://github.com/prettier/stylelint-config-prettier)
+If you use ESLint, install [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier#installation) to make ESLint and Prettier play nice with each other. It turns off all ESLint rules that are unnecessary or might conflict with Prettier.
+
+If you use Stylelint, you usually don’t need [stylelint-config-prettier](https://github.com/prettier/stylelint-config-prettier): as of [Stylelint v15](https://stylelint.io/migration-guide/to-15#deprecated-stylistic-rules), stylistic rules are deprecated, so the config is only necessary if you are on an older Stylelint version or still enable those deprecated rules.
 
 (See [Prettier vs. Linters](comparison.md) to learn more about formatting vs linting, [Integrating with Linters](integrating-with-linters.md) for more in-depth information on configuring your linters, and [Related projects](related-projects.md) for even more integration possibilities, if needed.)
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -187,8 +187,6 @@ And being able to run Prettier from the command line is still a good fallback, a
 
 If you use ESLint, install [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier#installation) to make ESLint and Prettier play nice with each other. It turns off all ESLint rules that are unnecessary or might conflict with Prettier.
 
-If you use Stylelint, you usually don’t need [stylelint-config-prettier](https://github.com/prettier/stylelint-config-prettier): as of [Stylelint v15](https://stylelint.io/migration-guide/to-15#deprecated-stylistic-rules), stylistic rules are deprecated, so the config is only necessary if you are on an older Stylelint version or still enable those deprecated rules.
-
 (See [Prettier vs. Linters](comparison.md) to learn more about formatting vs linting, [Integrating with Linters](integrating-with-linters.md) for more in-depth information on configuring your linters, and [Related projects](related-projects.md) for even more integration possibilities, if needed.)
 
 ## Git hooks

--- a/website/versioned_docs/version-stable/install.md
+++ b/website/versioned_docs/version-stable/install.md
@@ -185,7 +185,9 @@ And being able to run Prettier from the command line is still a good fallback, a
 
 ## ESLint (and other linters)
 
-If you use ESLint, install [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier#installation) to make ESLint and Prettier play nice with each other. It turns off all ESLint rules that are unnecessary or might conflict with Prettier. There’s a similar config for Stylelint: [stylelint-config-prettier](https://github.com/prettier/stylelint-config-prettier)
+If you use ESLint, install [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier#installation) to make ESLint and Prettier play nice with each other. It turns off all ESLint rules that are unnecessary or might conflict with Prettier.
+
+If you use Stylelint, you usually don’t need [stylelint-config-prettier](https://github.com/prettier/stylelint-config-prettier): as of [Stylelint v15](https://stylelint.io/migration-guide/to-15#deprecated-stylistic-rules), stylistic rules are deprecated, so the config is only necessary if you are on an older Stylelint version or still enable those deprecated rules.
 
 (See [Prettier vs. Linters](comparison.md) to learn more about formatting vs linting, [Integrating with Linters](integrating-with-linters.md) for more in-depth information on configuring your linters, and [Related projects](related-projects.md) for even more integration possibilities, if needed.)
 

--- a/website/versioned_docs/version-stable/install.md
+++ b/website/versioned_docs/version-stable/install.md
@@ -187,8 +187,6 @@ And being able to run Prettier from the command line is still a good fallback, a
 
 If you use ESLint, install [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier#installation) to make ESLint and Prettier play nice with each other. It turns off all ESLint rules that are unnecessary or might conflict with Prettier.
 
-If you use Stylelint, you usually don’t need [stylelint-config-prettier](https://github.com/prettier/stylelint-config-prettier): as of [Stylelint v15](https://stylelint.io/migration-guide/to-15#deprecated-stylistic-rules), stylistic rules are deprecated, so the config is only necessary if you are on an older Stylelint version or still enable those deprecated rules.
-
 (See [Prettier vs. Linters](comparison.md) to learn more about formatting vs linting, [Integrating with Linters](integrating-with-linters.md) for more in-depth information on configuring your linters, and [Related projects](related-projects.md) for even more integration possibilities, if needed.)
 
 ## Git hooks


### PR DESCRIPTION
## Description

The install page mentioned `stylelint-config-prettier`. As of Stylelint v15, stylistic rules are deprecated, and that project's own README already explains when the config is needed.

Per review, this PR now **stops mentioning Stylelint** on the install page instead of restating that guidance. The ESLint paragraph is unchanged.

Fixes #16905

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
