### PR TITLE
fix(markdown): preserve list continuation indentation for multiline inline code

### DIFF
--- a/changelog_unreleased/markdown/19797.md
+++ b/changelog_unreleased/markdown/19797.md
@@ -1,0 +1,27 @@
+#### Preserve list continuation indentation for multiline inline code (#19797 by @santhiprakash)
+
+With `proseWrap: preserve`, an inline code span containing a newline inside a list item kept its continuation line at column 0, which breaks the list item under CommonMark. The continuation now preserves the list's indentation.
+
+<!-- prettier-ignore -->
+```markdown
+<!-- Input -->
+- Top-level:
+  - Sub-bullet wraps and contains
+    `someInlineCode(arg1, arg2,
+    arg3, arg4)` and continues with more text after the
+    code span closes.
+
+<!-- Prettier stable -->
+- Top-level:
+  - Sub-bullet wraps and contains
+    `someInlineCode(arg1, arg2,
+arg3, arg4)` and continues with more text after the
+    code span closes.
+
+<!-- Prettier main -->
+- Top-level:
+  - Sub-bullet wraps and contains
+    `someInlineCode(arg1, arg2,
+    arg3, arg4)` and continues with more text after the
+    code span closes.
+```

--- a/src/language-markdown/print/mdast.js
+++ b/src/language-markdown/print/mdast.js
@@ -192,7 +192,13 @@ function printMdast(path, options, print) {
         (/^[\n ]/.test(code) && /[\n ]$/.test(code) && /[^\n ]/.test(code))
           ? " "
           : "";
-      return [backtickString, padding, code, padding, backtickString];
+      // When `proseWrap` is `preserve`, the code can contain newlines. Re-apply
+      // the surrounding indentation to continuation lines so they aren't emitted
+      // at column 0, which would break the enclosing list item's continuation.
+      const content = code.includes("\n")
+        ? replaceEndOfLine(code, markAsRoot(literalline))
+        : code;
+      return [backtickString, padding, content, padding, backtickString];
     }
     case "wikiLink": {
       let contents;

--- a/tests/format/markdown/inlineCode/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/inlineCode/__snapshots__/format.test.js.snap
@@ -238,6 +238,63 @@ culpa qui officia deserunt mollit anim id est laborum.
 ================================================================================
 `;
 
+exports[`inline-code-newline-in-list.md - {"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+proseWrap: "always"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+- Top-level:
+  - Sub-bullet wraps and contains
+    \`someInlineCode(arg1, arg2,
+    arg3, arg4)\` and continues with more text after the
+    code span closes.
+
+1. Ordered list:
+   1. Nested item with \`code spanning
+      two lines\` inside it.
+
+=====================================output=====================================
+- Top-level:
+  - Sub-bullet wraps and contains \`someInlineCode(arg1, arg2, arg3, arg4)\` and
+    continues with more text after the code span closes.
+
+1. Ordered list:
+   1. Nested item with \`code spanning two lines\` inside it.
+
+================================================================================
+`;
+
+exports[`inline-code-newline-in-list.md - {"proseWrap":"preserve"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+proseWrap: "preserve"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+- Top-level:
+  - Sub-bullet wraps and contains
+    \`someInlineCode(arg1, arg2,
+    arg3, arg4)\` and continues with more text after the
+    code span closes.
+
+1. Ordered list:
+   1. Nested item with \`code spanning
+      two lines\` inside it.
+
+=====================================output=====================================
+- Top-level:
+  - Sub-bullet wraps and contains
+    \`someInlineCode(arg1, arg2,
+    arg3, arg4)\` and continues with more text after the
+    code span closes.
+
+1. Ordered list:
+   1. Nested item with \`code spanning
+      two lines\` inside it.
+
+================================================================================
+`;
+
 exports[`long.md - {"proseWrap":"always"} format 1`] = `
 ====================================options=====================================
 parsers: ["markdown"]

--- a/tests/format/markdown/inlineCode/inline-code-newline-in-list.md
+++ b/tests/format/markdown/inlineCode/inline-code-newline-in-list.md
@@ -1,0 +1,9 @@
+- Top-level:
+  - Sub-bullet wraps and contains
+    `someInlineCode(arg1, arg2,
+    arg3, arg4)` and continues with more text after the
+    code span closes.
+
+1. Ordered list:
+   1. Nested item with `code spanning
+      two lines` inside it.


### PR DESCRIPTION
## Description

Closes #19116.

When `proseWrap: "preserve"` is set, an inline code span containing a newline inside a list item was printed with its continuation line at column 0, breaking the list item's continuation under CommonMark.

For example, given:

<!-- prettier-ignore -->
```markdown
- Top-level:
  - Sub-bullet wraps and contains
    `someInlineCode(arg1, arg2,
    arg3, arg4)` and continues with more text after the
    code span closes.
```

Prettier previously produced:

<!-- prettier-ignore -->
```markdown
- Top-level:
  - Sub-bullet wraps and contains
    `someInlineCode(arg1, arg2,
arg3, arg4)` and continues with more text after the
    code span closes.
```

The `arg3, arg4)` line drops to column 0, which terminates the nested list item.

The fix uses `replaceEndOfLine(code, markAsRoot(literalline))` so that continuation lines inside the inline code inherit the surrounding indentation instead of being emitted at column 0. This only affects code containing newlines, so single-line spans are unchanged.

## Test plan

- Added `tests/format/markdown/inlineCode/inline-code-newline-in-list.md` covering bulleted and ordered list continuations.
- `npx jest tests/format/markdown/inlineCode` passes (2 new snapshots written).
- `npx jest tests/format/markdown` and `npx jest tests/format/mdx` pass with no other snapshot changes.
- `npx eslint src/language-markdown/print/mdast.js` and `npx prettier --check` on changed files pass.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.