### PR TITLE
test(markdown): add useTabs regression test for fenced code blocks

### DIFF
--- a/src/language-markdown/embed.js
+++ b/src/language-markdown/embed.js
@@ -28,13 +28,7 @@ function embed(path, options) {
       }
 
       return async (textToDoc) => {
-        const textToDocOptions = {
-          parser,
-          useTabs: options.useTabs,
-          tabWidth: options.tabWidth,
-          printWidth: options.printWidth,
-          proseWrap: options.proseWrap,
-        };
+        const textToDocOptions = { parser };
 
         // Override the filepath option.
         // This is because whether the trailing comma of type parameters

--- a/src/language-markdown/embed.js
+++ b/src/language-markdown/embed.js
@@ -28,7 +28,13 @@ function embed(path, options) {
       }
 
       return async (textToDoc) => {
-        const textToDocOptions = { parser };
+        const textToDocOptions = {
+          parser,
+          useTabs: options.useTabs,
+          tabWidth: options.tabWidth,
+          printWidth: options.printWidth,
+          proseWrap: options.proseWrap,
+        };
 
         // Override the filepath option.
         // This is because whether the trailing comma of type parameters

--- a/tests/format/markdown/use-tabs-fenced-code/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/use-tabs-fenced-code/__snapshots__/format.test.js.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`use-tabs-fenced-code.md - {"useTabs":true} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+useTabs: true
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+\`\`\`html
+<table style="min-width: 300px">
+  <tbody>
+    <tr>
+      <th colspan="2">Results</th>
+    </tr>
+    <tr>
+      <td><strong>Good</strong></td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <td><strong>Bad</strong></td>
+      <td>0</td>
+    </tr>
+  </tbody>
+</table>
+\`\`\`
+
+=====================================output=====================================
+\`\`\`html
+<table style="min-width: 300px">
+	<tbody>
+		<tr>
+			<th colspan="2">Results</th>
+		</tr>
+		<tr>
+			<td><strong>Good</strong></td>
+			<td>1</td>
+		</tr>
+		<tr>
+			<td><strong>Bad</strong></td>
+			<td>0</td>
+		</tr>
+	</tbody>
+</table>
+\`\`\`
+
+================================================================================
+`;

--- a/tests/format/markdown/use-tabs-fenced-code/format.test.js
+++ b/tests/format/markdown/use-tabs-fenced-code/format.test.js
@@ -1,0 +1,1 @@
+runFormatTest(import.meta, ["markdown"], { useTabs: true });

--- a/tests/format/markdown/use-tabs-fenced-code/use-tabs-fenced-code.md
+++ b/tests/format/markdown/use-tabs-fenced-code/use-tabs-fenced-code.md
@@ -1,0 +1,17 @@
+```html
+<table style="min-width: 300px">
+  <tbody>
+    <tr>
+      <th colspan="2">Results</th>
+    </tr>
+    <tr>
+      <td><strong>Good</strong></td>
+      <td>1</td>
+    </tr>
+    <tr>
+      <td><strong>Bad</strong></td>
+      <td>0</td>
+    </tr>
+  </tbody>
+</table>
+```


### PR DESCRIPTION
## Description

Adds a regression test covering HTML fenced code blocks inside Markdown when `useTabs` is enabled.

As @fisker noted, `textToDoc` in `src/main/multiparser.js` already merges the parent formatter options (`{ ...parentOptions, ...partialNextOptions }`), so the embedded HTML/JS/CSS/etc. formatter inherits `useTabs`, `tabWidth`, `printWidth`, and `proseWrap` without an explicit pass-through in `src/language-markdown/embed.js`. I removed that change.

The test still passes on current `main`, so this PR now only adds coverage for the behavior described in #19399.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

Refs #19399