### PR TITLE
Fix CSS declaration suffix width calculation

### DIFF
--- a/changelog_unreleased/css/19806.md
+++ b/changelog_unreleased/css/19806.md
@@ -1,0 +1,22 @@
+#### Account for declaration suffixes when wrapping CSS values (#19806 by @edwardlong-ctrl)
+
+Declaration values now include trailing syntax such as `;`, `!important`, SCSS `!default`, and SCSS `!global` when deciding whether the final value line fits within `printWidth`.
+
+<!-- prettier-ignore -->
+```scss
+/* Input */
+.issue-18360 {
+  margin: $really-long-variable-name $another-really-long-name $a-third-long-nam;
+}
+
+/* Prettier stable */
+.issue-18360 {
+  margin: $really-long-variable-name $another-really-long-name $a-third-long-nam;
+}
+
+/* Prettier main */
+.issue-18360 {
+  margin: $really-long-variable-name $another-really-long-name
+    $a-third-long-nam;
+}
+```

--- a/src/language-css/print/css-declaration.js
+++ b/src/language-css/print/css-declaration.js
@@ -1,5 +1,9 @@
 import {
   dedent,
+  DOC_TYPE_FILL,
+  DOC_TYPE_GROUP,
+  DOC_TYPE_INDENT,
+  getDocType,
   group,
   hardline,
   ifBreak,
@@ -18,6 +22,31 @@ import {
 } from "../utilities/index.js";
 import { shouldBreakList } from "./parenthesized-value-group.js";
 import printSequence from "./sequence.js";
+
+function appendSuffixToValue(value, suffix) {
+  if (
+    getDocType(value) === DOC_TYPE_GROUP &&
+    getDocType(value.contents) === DOC_TYPE_INDENT &&
+    getDocType(value.contents.contents) === DOC_TYPE_FILL
+  ) {
+    const fill = value.contents.contents;
+
+    // `fill` only measures its own parts, so include the declaration suffix
+    // in the final value chunk that decides whether the last line fits.
+    return {
+      ...value,
+      contents: {
+        ...value.contents,
+        contents: {
+          ...fill,
+          parts: [...fill.parts.slice(0, -1), [fill.parts.at(-1), suffix]],
+        },
+      },
+    };
+  }
+
+  return [value, suffix];
+}
 
 function printCssDeclaration(path, options, print) {
   const { node, parent } = path;
@@ -79,28 +108,30 @@ function printCssDeclaration(path, options, print) {
     );
   }
 
-  parts.push(value);
+  const suffix = [];
 
   if (node.raws.important) {
-    parts.push(node.raws.important.replace(/\s*!\s*important/i, " !important"));
+    suffix.push(
+      node.raws.important.replace(/\s*!\s*important/i, " !important"),
+    );
   } else if (node.important) {
-    parts.push(" !important");
+    suffix.push(" !important");
   }
 
   if (node.raws.scssDefault) {
-    parts.push(node.raws.scssDefault.replace(/\s*!default/i, " !default"));
+    suffix.push(node.raws.scssDefault.replace(/\s*!default/i, " !default"));
   } else if (node.scssDefault) {
-    parts.push(" !default");
+    suffix.push(" !default");
   }
 
   if (node.raws.scssGlobal) {
-    parts.push(node.raws.scssGlobal.replace(/\s*!global/i, " !global"));
+    suffix.push(node.raws.scssGlobal.replace(/\s*!global/i, " !global"));
   } else if (node.scssGlobal) {
-    parts.push(" !global");
+    suffix.push(" !global");
   }
 
   if (node.nodes) {
-    parts.push([
+    parts.push(value, suffix, [
       " {",
       node.nodes.length > 0
         ? indent([softline, printSequence(path, options, print)])
@@ -108,14 +139,32 @@ function printCssDeclaration(path, options, print) {
       softline,
       "}",
     ]);
-  } else if (!(
-    isTemplatePropNode(node) &&
-    !parent.raws.semicolon &&
-    options.originalText[locEnd(node) - 1] !== ";"
-  )) {
-    parts.push(
-      options.__isHTMLStyleAttribute && path.isLast ? ifBreak(";") : ";",
+  } else {
+    const shouldPrintSemicolon = !(
+      isTemplatePropNode(node) &&
+      !parent.raws.semicolon &&
+      options.originalText[locEnd(node) - 1] !== ";"
     );
+
+    const conditionalSemicolon =
+      shouldPrintSemicolon && options.__isHTMLStyleAttribute && path.isLast;
+
+    if (conditionalSemicolon) {
+      parts.push(
+        ifBreak(
+          appendSuffixToValue(value, [...suffix, ";"]),
+          suffix.length > 0 ? appendSuffixToValue(value, suffix) : value,
+        ),
+      );
+    } else {
+      if (shouldPrintSemicolon) {
+        suffix.push(";");
+      }
+
+      parts.push(
+        suffix.length > 0 ? appendSuffixToValue(value, suffix) : value,
+      );
+    }
   }
 
   return parts;

--- a/tests/format/css/declaration-suffix/__snapshots__/format.test.js.snap
+++ b/tests/format/css/declaration-suffix/__snapshots__/format.test.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`suffix.css format 1`] = `
+====================================options=====================================
+parsers: ["css", "scss", "less"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+.important-suffix {
+  margin: var(--really-long-variable-name) var(--another-really-long-name) !important;
+}
+
+.multiline-important-suffix {
+  margin: var(--really-long-variable-name) var(--another-really-long-name) var(--third-long-variable-name) !important;
+}
+
+=====================================output=====================================
+.important-suffix {
+  margin: var(--really-long-variable-name)
+    var(--another-really-long-name) !important;
+}
+
+.multiline-important-suffix {
+  margin: var(--really-long-variable-name) var(--another-really-long-name)
+    var(--third-long-variable-name) !important;
+}
+
+================================================================================
+`;

--- a/tests/format/css/declaration-suffix/format.test.js
+++ b/tests/format/css/declaration-suffix/format.test.js
@@ -1,0 +1,1 @@
+runFormatTest(import.meta, ["css", "scss", "less"]);

--- a/tests/format/css/declaration-suffix/suffix.css
+++ b/tests/format/css/declaration-suffix/suffix.css
@@ -1,0 +1,7 @@
+.important-suffix {
+  margin: var(--really-long-variable-name) var(--another-really-long-name) !important;
+}
+
+.multiline-important-suffix {
+  margin: var(--really-long-variable-name) var(--another-really-long-name) var(--third-long-variable-name) !important;
+}

--- a/tests/format/html/declaration-suffix/__snapshots__/format.test.js.snap
+++ b/tests/format/html/declaration-suffix/__snapshots__/format.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`style.html format 1`] = `
+====================================options=====================================
+parsers: ["html"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+<div style="color: red;"></div>
+<div style="margin: var(--really-long-variable-name) var(--another-really-long-name);"></div>
+<div style="margin: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;"></div>
+
+=====================================output=====================================
+<div style="color: red"></div>
+<div
+  style="
+    margin: var(--really-long-variable-name) var(--another-really-long-name);
+  "
+></div>
+<div
+  style="
+    margin: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+  "
+></div>
+
+================================================================================
+`;

--- a/tests/format/html/declaration-suffix/format.test.js
+++ b/tests/format/html/declaration-suffix/format.test.js
@@ -1,0 +1,1 @@
+runFormatTest(import.meta, ["html"]);

--- a/tests/format/html/declaration-suffix/style.html
+++ b/tests/format/html/declaration-suffix/style.html
@@ -1,0 +1,3 @@
+<div style="color: red;"></div>
+<div style="margin: var(--really-long-variable-name) var(--another-really-long-name);"></div>
+<div style="margin: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;"></div>

--- a/tests/format/scss/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/scss/comments/__snapshots__/format.test.js.snap
@@ -986,7 +986,8 @@ $var: /* comment 1 */ all /* comment 2 */ !default /* comment 3 */ ; /* comment 
 @mixin text-color {
   /* comment 5 */
   /* comment 6 */
-  $text-color/* comment 7 */ : /* comment 8 */ red /* comment 9 */ !default /* comment 10 */ ; /* comment 11 */
+  $text-color/* comment 7 */ : /* comment 8 */ red
+    /* comment 9 */ !default /* comment 10 */ ; /* comment 11 */
   /* comment 12 */
   color: $text-color;
 }
@@ -994,7 +995,8 @@ $var: /* comment 1 */ all /* comment 2 */ !default /* comment 3 */ ; /* comment 
 .error {
   /* comment 13 */
   /* comment 14 */
-  $text-color/* comment 15 */ : /* comment 16 */ green /* comment 17 */ !global /* comment 18 */ ; /* comment 19 */
+  $text-color/* comment 15 */ : /* comment 16 */ green
+    /* comment 17 */ !global /* comment 18 */ ; /* comment 19 */
   /* comment 20 */
 }
 

--- a/tests/format/scss/declaration-suffix/__snapshots__/format.test.js.snap
+++ b/tests/format/scss/declaration-suffix/__snapshots__/format.test.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`suffix.scss format 1`] = `
+====================================options=====================================
+parsers: ["scss"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+.issue-18360 {
+  margin: $really-long-variable-name $another-really-long-name $a-third-long-na;
+  margin: $really-long-variable-name $another-really-long-name $a-third-long-nam;
+}
+
+$default: $really-long-variable-name $another-really-long-name $third-long-name !default;
+$global: $really-long-variable-name $another-really-long-name $third-long-name !global;
+
+$string-default: "ends with !default";
+$string-global: "ends with !global";
+$function-default: flag-text("ends with !default");
+$function-global: flag-text("ends with !global");
+
+=====================================output=====================================
+.issue-18360 {
+  margin: $really-long-variable-name $another-really-long-name $a-third-long-na;
+  margin: $really-long-variable-name $another-really-long-name
+    $a-third-long-nam;
+}
+
+$default: $really-long-variable-name $another-really-long-name
+  $third-long-name !default;
+$global: $really-long-variable-name $another-really-long-name
+  $third-long-name !global;
+
+$string-default: "ends with !default";
+$string-global: "ends with !global";
+$function-default: flag-text("ends with !default");
+$function-global: flag-text("ends with !global");
+
+================================================================================
+`;

--- a/tests/format/scss/declaration-suffix/format.test.js
+++ b/tests/format/scss/declaration-suffix/format.test.js
@@ -1,0 +1,1 @@
+runFormatTest(import.meta, ["scss"]);

--- a/tests/format/scss/declaration-suffix/suffix.scss
+++ b/tests/format/scss/declaration-suffix/suffix.scss
@@ -1,0 +1,12 @@
+.issue-18360 {
+  margin: $really-long-variable-name $another-really-long-name $a-third-long-na;
+  margin: $really-long-variable-name $another-really-long-name $a-third-long-nam;
+}
+
+$default: $really-long-variable-name $another-really-long-name $third-long-name !default;
+$global: $really-long-variable-name $another-really-long-name $third-long-name !global;
+
+$string-default: "ends with !default";
+$string-global: "ends with !global";
+$function-default: flag-text("ends with !default");
+$function-global: flag-text("ends with !global");


### PR DESCRIPTION
## Description

Fixes #18360.

CSS declarations could go over printWidth because the width check only considered the value, not the trailing semicolon or flags like !important, !default, and !global.

This changes the last value group so those suffixes are taken into account when checking whether it fits.

For HTML style attributes, the semicolon still follows the existing ifBreak behavior.

I also added tests for CSS/SCSS/Less, HTML style attributes, multiline values, and the 80/81 character boundary cases.

## Tests

- CSS/SCSS/HTML tests
- full test suite
- lint checks
- git diff --check

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made — N/A, no API or CLI changes.
- [x] (If the change is user-facing) I’ve added the changelog entry.
- [x] I’ve read the contributing guidelines.
- [ ] I did _not_ use AI to generate this PR.
- [x] I have reviewed the AI-generated content before submitting.
