### PR TITLE
Fix placement of `// @ts-expect-error` comments in member chains

### DIFF
--- a/changelog_unreleased/typescript/19808.md
+++ b/changelog_unreleased/typescript/19808.md
@@ -1,0 +1,19 @@
+#### Fix placement of `// @ts-expect-error` comments in member chains (#19808 by @santhiprakash)
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+blablablablablablablabla.hellohellohellohellohellohellohellohellohellohello
+  // @ts-expect-error
+  .dayOfWeek
+
+// Prettier stable
+// @ts-expect-error
+blablablablablablablabla.hellohellohellohellohellohellohellohellohellohello
+  .dayOfWeek;
+
+// Prettier main
+blablablablablablablabla.hellohellohellohellohellohellohellohellohellohello
+  // @ts-expect-error
+  .dayOfWeek;
+```

--- a/changelog_unreleased/typescript/19809.md
+++ b/changelog_unreleased/typescript/19809.md
@@ -1,4 +1,4 @@
-#### Fix placement of `// @ts-expect-error` comments in member chains (#19808 by @santhiprakash)
+#### Fix placement of `// @ts-expect-error` comments in member chains (#19809 by @santhiprakash)
 
 <!-- prettier-ignore -->
 ```tsx

--- a/src/language-js/comments/will-print-own-comments.js
+++ b/src/language-js/comments/will-print-own-comments.js
@@ -1,7 +1,13 @@
+import { locEnd, locStart } from "../location/index.js";
+import { hasComment } from "../utilities/comments.js";
 import { createTypeCheckFunction } from "../utilities/create-type-check-function.js";
 import { hasNodeIgnoreComment } from "../utilities/has-node-ignore-comment.js";
 import { isIifeCalleeOrTaggedTemplateExpressionTag } from "../utilities/is-iife-callee-or-tagged-template-expression-tag.js";
-import { isJsxElement, isUnionType } from "../utilities/node-types.js";
+import {
+  isJsxElement,
+  isMemberExpression,
+  isUnionType,
+} from "../utilities/node-types.js";
 import { shouldExpressionStatementPrintOwnComments } from "../utilities/should-expression-statement-print-own-comments.js";
 import { shouldUnionTypePrintOwnComments } from "../utilities/union-type-print.js";
 
@@ -58,6 +64,19 @@ function willPrintOwnComments(path, options) {
   }
 
   if (isJsxElement(node)) {
+    return true;
+  }
+
+  if (
+    isMemberExpression(node) &&
+    hasComment(
+      node,
+      (comment) =>
+        !comment.trailing &&
+        locStart(comment) > locEnd(node.object) &&
+        locEnd(comment) < locStart(node.property),
+    )
+  ) {
     return true;
   }
 

--- a/src/language-js/print/member.js
+++ b/src/language-js/print/member.js
@@ -5,7 +5,10 @@ import {
   lineSuffixBoundary,
   softline,
 } from "../../document/index.js";
+import { printComments } from "../../main/comments/print.js";
+import { locEnd, locStart } from "../location/index.js";
 import { getCallArguments } from "../utilities/call-arguments.js";
+import { hasComment } from "../utilities/comments.js";
 import {
   isCallExpression,
   isChainElementWrapper,
@@ -46,19 +49,53 @@ function printMemberExpression(path, options, print) {
     (node) => !isChainElementWrapper(node),
   );
 
+  const shouldPrintOwnComments = hasComment(
+    node,
+    (comment) =>
+      !comment.trailing &&
+      locStart(comment) > locEnd(node.object) &&
+      locEnd(comment) < locStart(node.property),
+  );
+
   const shouldInline =
-    firstNonMemberParent.type === "BindExpression" ||
-    (firstNonMemberParent.type === "AssignmentExpression" &&
-      firstNonMemberParent.left.type !== "Identifier") ||
-    shouldInlineNewExpressionCallee(path) ||
-    node.computed ||
-    (node.object.type === "Identifier" &&
-      node.property.type === "Identifier" &&
-      !isMemberExpression(firstNonChainElementWrapperParent)) ||
-    ((firstNonChainElementWrapperParent.type === "AssignmentExpression" ||
-      firstNonChainElementWrapperParent.type === "VariableDeclarator") &&
-      (isCallExpressionWithArguments(stripChainElementWrappers(node.object)) ||
-        objectDoc.label?.memberChain));
+    !shouldPrintOwnComments &&
+    (firstNonMemberParent.type === "BindExpression" ||
+      (firstNonMemberParent.type === "AssignmentExpression" &&
+        firstNonMemberParent.left.type !== "Identifier") ||
+      shouldInlineNewExpressionCallee(path) ||
+      node.computed ||
+      (node.object.type === "Identifier" &&
+        node.property.type === "Identifier" &&
+        !isMemberExpression(firstNonChainElementWrapperParent)) ||
+      ((firstNonChainElementWrapperParent.type === "AssignmentExpression" ||
+        firstNonChainElementWrapperParent.type === "VariableDeclarator") &&
+        (isCallExpressionWithArguments(
+          stripChainElementWrappers(node.object),
+        ) ||
+          objectDoc.label?.memberChain)));
+
+  if (shouldPrintOwnComments) {
+    const isCommentBeforeObject = (comment) =>
+      comment.leading && locEnd(comment) <= locStart(node.object);
+
+    const isCommentBetweenObjectAndProperty = (comment) =>
+      !comment.trailing &&
+      locStart(comment) > locEnd(node.object) &&
+      locEnd(comment) < locStart(node.property);
+
+    const objectDocWithComments = printComments(path, objectDoc, options, {
+      filter: isCommentBeforeObject,
+    });
+    const lookupDocWithComments = printComments(path, lookupDoc, options, {
+      filter: isCommentBetweenObjectAndProperty,
+    });
+
+    return label(objectDocWithComments.label, [
+      objectDocWithComments,
+      lineSuffixBoundary,
+      group(indent([softline, lookupDocWithComments])),
+    ]);
+  }
 
   return label(objectDoc.label, [
     objectDoc,

--- a/src/language-js/print/member.js
+++ b/src/language-js/print/member.js
@@ -90,7 +90,7 @@ function printMemberExpression(path, options, print) {
       filter: isCommentBetweenObjectAndProperty,
     });
 
-    return label(objectDocWithComments.label, [
+    return label(objectDoc.label, [
       objectDocWithComments,
       lineSuffixBoundary,
       group(indent([softline, lookupDocWithComments])),

--- a/tests/format/typescript/comments/18121.ts
+++ b/tests/format/typescript/comments/18121.ts
@@ -1,0 +1,3 @@
+blablablablablablablabla.hellohellohellohellohellohellohellohellohellohello
+  // @ts-expect-error
+  .dayOfWeek

--- a/tests/format/typescript/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/comments/__snapshots__/format.test.js.snap
@@ -564,6 +564,23 @@ class A {
 ================================================================================
 `;
 
+exports[`18121.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+blablablablablablablabla.hellohellohellohellohellohellohellohellohellohello
+  // @ts-expect-error
+  .dayOfWeek
+
+=====================================output=====================================
+blablablablablablablabla.hellohellohellohellohellohellohellohellohellohello
+  // @ts-expect-error
+  .dayOfWeek;
+
+================================================================================
+`;
+
 exports[`abstract-class.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]


### PR DESCRIPTION
## Description

Fixes #18121

When a `// @ts-expect-error` comment is placed on its own line before a member-chain continuation, Prettier was attaching it as a leading comment of the whole member expression and printing it before the first member. This moved the TypeScript directive away from the line it is meant to suppress.

The member-expression printer now detects non-trailing comments located between `object` and `property` and prints them before the lookup, keeping the directive on the correct continuation line.

## Verification

- Added `tests/format/typescript/comments/18121.ts` with a Jest snapshot covering the reported case.
- `yarn test tests/format/js tests/format/typescript` — 25,509 tests passed.
- `yarn test tests/format/typescript/comments/format.test.js` — 104 tests passed.
- `yarn lint:eslint src/language-js/print/member.js src/language-js/comments/will-print-own-comments.js` passed.
- `yarn prettier --check` on changed files passed.
- `yarn lint:changelog` passed.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.