### PR TITLE
fix(css): don't break inside a track function in a grid value

### DIFF
--- a/changelog_unreleased/css/19810.md
+++ b/changelog_unreleased/css/19810.md
@@ -1,0 +1,24 @@
+#### Keep a single-line `grid` value on one line (#19810 by @Jaybhade)
+
+A `grid` / `grid-template*` value keeps the line structure you wrote, but one that was longer than `printWidth` could still be broken up inside a track's function arguments — and the next run read those new lines back as your own and printed something different again.
+
+<!-- prettier-ignore -->
+```css
+/* Input */
+div {
+  grid-template-columns: minmax(1em, 1fr) minmax(1em, 80ch) minmax(1em, 1fr) minmax(1em, 1fr);
+}
+
+/* Prettier stable */
+div {
+  grid-template-columns: minmax(1em, 1fr) minmax(1em, 80ch) minmax(
+      1em,
+      1fr
+    ) minmax(1em, 1fr);
+}
+
+/* Prettier main */
+div {
+  grid-template-columns: minmax(1em, 1fr) minmax(1em, 80ch) minmax(1em, 1fr) minmax(1em, 1fr);
+}
+```

--- a/src/language-css/print/comma-separated-value-group.js
+++ b/src/language-css/print/comma-separated-value-group.js
@@ -8,6 +8,7 @@ import {
   indent,
   line,
   lineSuffix,
+  removeLines,
   softline,
 } from "../../document/index.js";
 import { locEnd, locStart } from "../loc.js";
@@ -566,6 +567,12 @@ function printCommaSeparatedValueGroup(path, options, print) {
   // example @import url("verylongurl") projection,tv
   if (insideURLFunctionInImportAtRuleNode(path)) {
     return group(fill(parts));
+  }
+
+  // Line breaks in a `grid` value are the author's, so a track must not break
+  // either, or the breaks we add are read back as the author's on the next run
+  if (isGridValue) {
+    return removeLines(group(indent(fill(parts))));
   }
 
   return group(indent(fill(parts)));

--- a/tests/format/css/grid/__snapshots__/format.test.js.snap
+++ b/tests/format/css/grid/__snapshots__/format.test.js.snap
@@ -238,3 +238,46 @@ div {
 
 ================================================================================
 `;
+
+exports[`single-line-value.css format 1`] = `
+====================================options=====================================
+parsers: ["css"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+/* Values written on a single line stay on a single line, functions included. */
+div {
+  grid-template-columns: minmax(1.50em, 1fr) minmax(1em, 80ch) minmax(1em, 1fr) minmax(1em, 1fr);
+  grid-template-rows: repeat(auto-fill, minmax(min(120px, 100%), 1.0fr)) repeat(2, 1fr);
+  grid: repeat(2, 60px) / auto-flow minmax(200px, max-content) minmax(200px, max-content) ;
+  grid-template: "a a a" minmax(40px, calc(100% - 20px)) "b c c" 40px / 1fr minmax(.40ch, 1fr) 1fr;
+}
+
+/* The author's own line breaks are still the ones that are kept. */
+div {
+  grid-template-columns:
+      [full-start] minmax(1em, 1fr)
+      [main-start] minmax(1em, calc(80ch + 2 * var(--gutter, 1.0rem)))
+      [main-end] minmax(1em, 1fr)
+      [full-end];
+}
+
+=====================================output=====================================
+/* Values written on a single line stay on a single line, functions included. */
+div {
+  grid-template-columns: minmax(1.5em, 1fr) minmax(1em, 80ch) minmax(1em, 1fr) minmax(1em, 1fr);
+  grid-template-rows: repeat(auto-fill, minmax(min(120px, 100%), 1fr)) repeat(2, 1fr);
+  grid: repeat(2, 60px) / auto-flow minmax(200px, max-content) minmax(200px, max-content);
+  grid-template: "a a a" minmax(40px, calc(100% - 20px)) "b c c" 40px / 1fr minmax(0.4ch, 1fr) 1fr;
+}
+
+/* The author's own line breaks are still the ones that are kept. */
+div {
+  grid-template-columns:
+    [full-start] minmax(1em, 1fr)
+    [main-start] minmax(1em, calc(80ch + 2 * var(--gutter, 1rem)))
+    [main-end] minmax(1em, 1fr)
+    [full-end];
+}
+
+================================================================================
+`;

--- a/tests/format/css/grid/single-line-value.css
+++ b/tests/format/css/grid/single-line-value.css
@@ -1,0 +1,16 @@
+/* Values written on a single line stay on a single line, functions included. */
+div {
+  grid-template-columns: minmax(1.50em, 1fr) minmax(1em, 80ch) minmax(1em, 1fr) minmax(1em, 1fr);
+  grid-template-rows: repeat(auto-fill, minmax(min(120px, 100%), 1.0fr)) repeat(2, 1fr);
+  grid: repeat(2, 60px) / auto-flow minmax(200px, max-content) minmax(200px, max-content) ;
+  grid-template: "a a a" minmax(40px, calc(100% - 20px)) "b c c" 40px / 1fr minmax(.40ch, 1fr) 1fr;
+}
+
+/* The author's own line breaks are still the ones that are kept. */
+div {
+  grid-template-columns:
+      [full-start] minmax(1em, 1fr)
+      [main-start] minmax(1em, calc(80ch + 2 * var(--gutter, 1.0rem)))
+      [main-end] minmax(1em, 1fr)
+      [full-end];
+}


### PR DESCRIPTION
## Description

A `grid` / `grid-template*` value keeps the line structure the author wrote — tracks that start on the same source line are joined with a literal space, and only the author's own line breaks become hardlines ([`comma-separated-value-group.js`](https://github.com/prettier/prettier/blob/main/src/language-css/print/comma-separated-value-group.js#L449-L463)). That's why a long one-line value like `grid-template-columns: [full-start] 1fr [main-start] 2fr [main-end] 1fr [full-end] 1fr;` is left alone today.

But the tracks themselves are printed as ordinary docs, so when a one-line value is longer than `printWidth` the only break the printer can still take is *inside* a track's function arguments:

<!-- prettier-ignore -->
```css
/* Input */
div {
  grid-template-columns: minmax(1em, 1fr) minmax(1em, 80ch) minmax(1em, 1fr) minmax(1em, 1fr);
  grid: repeat(2, 60px) / auto-flow minmax(200px, max-content) minmax(200px, max-content);
}

/* Prettier stable */
div {
  grid-template-columns: minmax(1em, 1fr) minmax(1em, 80ch) minmax(
      1em,
      1fr
    ) minmax(1em, 1fr);
  grid: repeat(2, 60px) / auto-flow minmax(200px, max-content) minmax(
      200px,
      max-content
    );
}

/* Prettier main */
div {
  grid-template-columns: minmax(1em, 1fr) minmax(1em, 80ch) minmax(1em, 1fr) minmax(1em, 1fr);
  grid: repeat(2, 60px) / auto-flow minmax(200px, max-content) minmax(200px, max-content);
}
```

It also isn't stable. Those inserted breaks put the following tracks on new source lines, so the next run reads them back as the author's own and prints a third, different result — running Prettier twice on the first declaration above gives:

<!-- prettier-ignore -->
```css
div {
  grid-template-columns:
    minmax(1em, 1fr) minmax(1em, 80ch) minmax(1em, 1fr)
    minmax(1em, 1fr);
}
```

The fix wraps a grid value in `removeLines`, which flattens `line`/`softline` but leaves `hardline` alone — so the hardlines that come from the author's own line breaks still print, and nothing else in the value can break. `printCssDeclaration` already uses `removeLines` for the same reason on `composes`.

Since the existing `css/grid` fixtures all fit within `printWidth`, this was invisible to the `second format` check; the new fixture is over 80 columns, and it fails on `main` (`2 failed, 10 passed` under `FULL_TEST=1`) and passes here.

`grid-template-areas` values with an inline comment, SCSS interpolation in a track, and values the author already broke across lines are unaffected — I checked those against `main` as well as through the suite.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
