### PR TITLE
fix(angular): normalize spaces around = in @for let clauses with multiple bindings

### DIFF
--- a/changelog_unreleased/angular/19813.md
+++ b/changelog_unreleased/angular/19813.md
@@ -1,0 +1,19 @@
+#### Normalize spaces around `=` in multi-binding `@for` `let` clauses (#19813 by @santhiprakash)
+
+<!-- prettier-ignore -->
+```html
+<!-- Input -->
+@for (item of items; track item.id; let i=$index, f=$first) {
+  <p>{{ item }}</p>
+}
+
+<!-- Prettier stable -->
+@for (item of items; track item.id; let i=$index, f=$first) {
+  <p>{{ item }}</p>
+}
+
+<!-- Prettier main -->
+@for (item of items; track item.id; let i = $index, f = $first) {
+  <p>{{ item }}</p>
+}
+```

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -59,8 +59,16 @@ function genericPrint(path, options, print) {
       return printAngularControlFlowBlock(path, options, print);
     case "angularControlFlowBlockParameters":
       return printAngularControlFlowBlockParameters(path, options, print);
-    case "angularControlFlowBlockParameter":
-      return htmlWhitespace.trim(node.expression);
+    case "angularControlFlowBlockParameter": {
+      const expression = htmlWhitespace.trim(node.expression);
+      // Normalize spaces around '=' in multi-binding @for let clauses
+      // (e.g. 'let i=$index, f=$first') when the embed path falls back
+      // to the raw parameter printer.
+      if (/^let\s/.test(expression)) {
+        return expression.replaceAll(/\s*=\s*/g, " = ");
+      }
+      return expression;
+    }
 
     case "angularLetDeclaration":
       // print like "break-after-operator" layout assignment in estree printer

--- a/tests/format/angular/control-flow/__snapshots__/format.test.js.snap
+++ b/tests/format/angular/control-flow/__snapshots__/format.test.js.snap
@@ -418,6 +418,24 @@ item of
   <div *ngFor="item of items; let i = $index; let count = $count; track block"></div>
 </div>
 
+<div>
+  @for (item of items; track item.id; let i=$index, f=$first) {
+    <p>{{ item }}</p>
+  }
+</div>
+
+<div>
+  @for (item of items; track item.id; let i=$index, f=$first, e=$even) {
+    <p>{{ item }}</p>
+  }
+</div>
+
+<div>
+  @for (item of items; track item.id; let i=$index, f=$first; let count=$count) {
+    <p>{{ item }}</p>
+  }
+</div>
+
 =====================================output=====================================
 <ul>
   @for (let item of items; index as i; trackBy: trackByFn) {
@@ -477,6 +495,29 @@ item of
   <div
     *ngFor="item of items; let i = $index; let count = $count; track block"
   ></div>
+</div>
+
+<div>
+  @for (item of items; track item.id; let i = $index, f = $first) {
+    <p>{{ item }}</p>
+  }
+</div>
+
+<div>
+  @for (item of items; track item.id; let i = $index, f = $first, e = $even) {
+    <p>{{ item }}</p>
+  }
+</div>
+
+<div>
+  @for (
+    item of items;
+    track item.id;
+    let i = $index, f = $first;
+    let count = $count
+  ) {
+    <p>{{ item }}</p>
+  }
 </div>
 
 ================================================================================

--- a/tests/format/angular/control-flow/for.html
+++ b/tests/format/angular/control-flow/for.html
@@ -64,3 +64,21 @@ item of
 
   <div *ngFor="item of items; let i = $index; let count = $count; track block"></div>
 </div>
+
+<div>
+  @for (item of items; track item.id; let i=$index, f=$first) {
+    <p>{{ item }}</p>
+  }
+</div>
+
+<div>
+  @for (item of items; track item.id; let i=$index, f=$first, e=$even) {
+    <p>{{ item }}</p>
+  }
+</div>
+
+<div>
+  @for (item of items; track item.id; let i=$index, f=$first; let count=$count) {
+    <p>{{ item }}</p>
+  }
+</div>


### PR DESCRIPTION
## Description

Fixes #19081.

When an `@for` control-flow block contains a multi-binding `let` clause (e.g. `let i=$index, f=$first`), the printer falls back to the `angularControlFlowBlockParameter` case and returns the raw expression unchanged. A single-binding `let` clause is routed through a different path that already adds spaces around `=`, so the two cases were inconsistent.

This change normalizes whitespace around `=` for any `let` control-flow parameter expression, so multi-binding clauses are now formatted as `let i = $index, f = $first`.

## Verification

- Added regression cases to `tests/format/angular/control-flow/for.html` with updated Jest snapshot.
- `yarn jest tests/format/angular/control-flow` — 16/16 passed.
- `npx eslint src/language-html/printer-html.js` passed.
- `npx prettier --check src/language-html/printer-html.js` passed.
- `yarn lint` passed.
- `yarn lint:changelog` passed after adding `changelog_unreleased/angular/19813.md`.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.