### PR TITLE
fix(scss/less): keep trailing line comment on value line after comma

### DIFF
--- a/changelog_unreleased/scss/19816.md
+++ b/changelog_unreleased/scss/19816.md
@@ -1,0 +1,28 @@
+#### Keep trailing line comment on value line after comma (#19816 by @santhiprakash)
+
+This also affects Less lists/maps with the same trailing `//` comment pattern.
+
+<!-- prettier-ignore -->
+```scss
+// Input
+@use "library" with (
+  $size-1: 1rem,
+  $size-2: 2.5rem, // Big
+  $size-3: 3rem
+);
+
+// Prettier stable
+@use "library" with (
+  $size-1: 1rem,
+  $size-2: 2.5rem,
+  // Big
+  $size-3: 3rem
+);
+
+// Prettier main
+@use "library" with (
+  $size-1: 1rem,
+  $size-2: 2.5rem, // Big
+  $size-3: 3rem
+);
+```

--- a/src/language-css/parse/parse-value.js
+++ b/src/language-css/parse/parse-value.js
@@ -119,6 +119,20 @@ function parseValueNode(valueNode, options) {
         continue;
       }
 
+      // A line comment that follows the comma on the same line is a trailing
+      // comment of the value before the comma, not a leading comment of the
+      // next value. Keep it in the current group so it isn't re-associated
+      // with the following entry (e.g. in a SCSS map). See #19047.
+      const nextNode = nodes[i + 1];
+      if (
+        nextNode?.type === "comment" &&
+        nextNode.inline &&
+        nextNode.source?.start?.line === node.source?.end?.line
+      ) {
+        commaGroup.groups.push(nextNode);
+        ++i;
+      }
+
       parenGroup.groups.push(commaGroup);
       commaGroup = {
         groups: [],

--- a/tests/format/less/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/less/comments/__snapshots__/format.test.js.snap
@@ -491,10 +491,8 @@ parsers: ["less"]
   #cccccc; // and round it out with C
 
 @test-comma-separated:
-  #aaaaaa,
-  // Start with A
-  #bbbbbb,
-  // then some B
+  #aaaaaa, // Start with A
+  #bbbbbb, // then some B
   #cccccc; // and round it out with C
 
 ================================================================================

--- a/tests/format/scss/at-rule/__snapshots__/format.test.js.snap
+++ b/tests/format/scss/at-rule/__snapshots__/format.test.js.snap
@@ -19,8 +19,7 @@ parsers: ["scss"]
   @include ag-theme-balham(
     (
       foreground-color: $custom-foreground-color,
-      disabled-foreground-color: null,
-      // TODO some comment
+      disabled-foreground-color: null, // TODO some comment
     )
   );
 }

--- a/tests/format/scss/comments/19047.scss
+++ b/tests/format/scss/comments/19047.scss
@@ -1,0 +1,17 @@
+@use "library" with (
+  $size-1: 1rem,
+  $size-2: 2.5rem, // Big
+  $size-3: 3rem
+);
+
+$map: (
+  "a": 1, // first
+  "b": 2, // second
+  "c": 3
+);
+
+$list: (
+  one, // 1
+  two, // 2
+  three
+);

--- a/tests/format/scss/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/scss/comments/__snapshots__/format.test.js.snap
@@ -52,17 +52,13 @@ $my-map: (
 }
 
 $my-list:
-  "foo",
-  // Comment
+  "foo", // Comment
   "bar"; // Comment
 
 $my-map: (
-  "foo": 1,
-  // Comment
-  "bar": 2,
-  // Comment
-  "buz": calc(1 + 2),
-  // Buz
+  "foo": 1, // Comment
+  "bar": 2, // Comment
+  "buz": calc(1 + 2), // Buz
   "baz": 4, // Baz
 );
 
@@ -207,6 +203,51 @@ $blah: (
   /* test test test test test test test test test test test test test test test*/
   "b": 43,
   "c": 44,
+);
+
+================================================================================
+`;
+
+exports[`19047.scss format 1`] = `
+====================================options=====================================
+parsers: ["scss"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+@use "library" with (
+  $size-1: 1rem,
+  $size-2: 2.5rem, // Big
+  $size-3: 3rem
+);
+
+$map: (
+  "a": 1, // first
+  "b": 2, // second
+  "c": 3
+);
+
+$list: (
+  one, // 1
+  two, // 2
+  three
+);
+
+=====================================output=====================================
+@use "library" with (
+  $size-1: 1rem,
+  $size-2: 2.5rem, // Big
+  $size-3: 3rem
+);
+
+$map: (
+  "a": 1, // first
+  "b": 2, // second
+  "c": 3,
+);
+
+$list: (
+  one, // 1
+  two, // 2
+  three
 );
 
 ================================================================================
@@ -669,8 +710,7 @@ $my-list2:
 
 =====================================output=====================================
 $my-list:
-  "foo",
-  // Foo
+  "foo", // Foo
   "bar"; // Bar
 
 $my-list2: a // a
@@ -691,8 +731,7 @@ $my-map: (
 
 =====================================output=====================================
 $my-map: (
-  "foo": 1,
-  // Foo
+  "foo": 1, // Foo
   "bar": 2, // Bar
 );
 

--- a/tests/format/scss/trailing-comma/__snapshots__/format.test.js.snap
+++ b/tests/format/scss/trailing-comma/__snapshots__/format.test.js.snap
@@ -192,8 +192,7 @@ $z-indexes: (
 $z-indexes: (
   header: 1035,
   header: 1035,
-  overlay: 1202,
-  // TODO
+  overlay: 1202, // TODO
   header: 1035,
   header: 1035,
 );
@@ -243,8 +242,7 @@ $z-indexes: (
 $z-indexes: (
   header: 1035,
   header: 1035,
-  overlay: 1202,
-  // TODO
+  overlay: 1202, // TODO
   header: 1035,
   header: 1035
 );
@@ -301,8 +299,7 @@ $my-map: (
 
 =====================================output=====================================
 $my-map: (
-  "foo": 1,
-  // Comment
+  "foo": 1, // Comment
   "bar": 2, // Comment
 );
 
@@ -322,8 +319,7 @@ $my-map: (
 
 =====================================output=====================================
 $my-map: (
-  "foo": 1,
-  // Comment
+  "foo": 1, // Comment
   "bar": 2 // Comment
 );
 


### PR DESCRIPTION
## Description

Closes #19047.

A `//` line comment that follows a comma on the same line in an SCSS map or `@use ... with (...)` was being moved to its own line and visually re-associated with the following entry:

```scss
/* input */
@use "library" with (
  $size-1: 1rem,
  $size-2: 2.5rem, // Big
  $size-3: 3rem
);

/* output before this fix */
@use "library" with (
  $size-1: 1rem,
  $size-2: 2.5rem,
  // Big
  $size-3: 3rem
);
```

In `src/language-css/parse/parse-value.js`, when a `comma` token was reached the current comma-group was closed and a new one was started. A comment immediately after the comma was added to the new group, becoming a leading comment of the next value. Now, if the next node is an inline `//` comment on the same line as the comma, it is attached to the group being closed so it stays a trailing comment of the preceding value.

## Test plan

- Added `tests/format/scss/comments/19047.scss` covering `@use ... with`, a map, and a list.
- Updated existing SCSS/Less snapshots affected by the new behavior; every change keeps the comment on its value's line.
- Added `changelog_unreleased/scss/19816.md` describing the change.
- `yarn test tests/format/scss tests/format/less tests/format/css` passes (100 suites, 421 tests).
- `yarn lint:prettier`, `yarn lint:eslint`, `yarn lint:changelog`, `yarn lint:format-test` pass.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.