### PR TITLE
docs: add MegaLinter to related projects

### DIFF
--- a/docs/related-projects.md
+++ b/docs/related-projects.md
@@ -32,4 +32,5 @@ title: Related Projects
 - [csharpier](https://github.com/belav/csharpier) is a port of Prettier for C#
 - [Prettier](https://github.com/jaywcjlove/Prettier) is a Swift version based on Prettier
 - [reviewdog-action-prettier](https://github.com/EPMatt/reviewdog-action-prettier) runs Prettier in GitHub Actions CI/CD workflows
+- [MegaLinter](https://megalinter.io/) is an open-source linters aggregator for CI that runs [Prettier](https://megalinter.io/latest/descriptors/javascript_prettier/) out of the box
 - [monaco-prettier](https://github.com/remcohaszing/monaco-prettier) integrates Prettier into [Monaco editor](https://microsoft.github.io/monaco-editor/)

--- a/website/versioned_docs/version-stable/related-projects.md
+++ b/website/versioned_docs/version-stable/related-projects.md
@@ -32,4 +32,5 @@ title: Related Projects
 - [csharpier](https://github.com/belav/csharpier) is a port of Prettier for C#
 - [Prettier](https://github.com/jaywcjlove/Prettier) is a Swift version based on Prettier
 - [reviewdog-action-prettier](https://github.com/EPMatt/reviewdog-action-prettier) runs Prettier in GitHub Actions CI/CD workflows
+- [MegaLinter](https://megalinter.io/) is an open-source linters aggregator for CI that runs [Prettier](https://megalinter.io/latest/descriptors/javascript_prettier/) out of the box
 - [monaco-prettier](https://github.com/remcohaszing/monaco-prettier) integrates Prettier into [Monaco editor](https://microsoft.github.io/monaco-editor/)


### PR DESCRIPTION
## Description

Small addition to the Related Projects page: [MegaLinter](https://megalinter.io/) is an open-source linters aggregator for CI that ships Prettier out of the box ([descriptor page](https://megalinter.io/latest/descriptors/javascript_prettier/)). I maintain it, and figured it could be worth a line in the Misc list next to the other CI-oriented integrations.

## Checklist

- [ ] I've added tests to confirm my change works. (docs-only change)
- [ ] (If changing the API or CLI) I've documented the changes I've made (in the `docs/` directory).
- [ ] (If the change is user-facing) I've added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I've read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.