### PR TITLE
Preserve escaped character references in Markdown links

### DIFF
--- a/changelog_unreleased/markdown/19825.md
+++ b/changelog_unreleased/markdown/19825.md
@@ -1,0 +1,15 @@
+#### Preserve escaped character references in Markdown links (#19825 by @SR0725)
+
+An escaped semicolon can keep part of a URL from being parsed as a character reference. Prettier now preserves that escape, so formatting the same Markdown twice does not change the URL.
+
+<!-- prettier-ignore -->
+```markdown
+<!-- Input -->
+[test](/hello?foo=&quot\;bar)
+
+<!-- Prettier stable -->
+[test](/hello?foo=&quot;bar)
+
+<!-- Prettier main -->
+[test](/hello?foo=&quot\;bar)
+```

--- a/src/language-markdown/parse/micromark/mdast-util-preserve-escaped-character-reference.js
+++ b/src/language-markdown/parse/micromark/mdast-util-preserve-escaped-character-reference.js
@@ -1,5 +1,4 @@
 /**
- * @import {Definition, Image, Link} from "mdast";
  * @import {CompileContext, Extension, Handle} from "mdast-util-from-markdown";
  */
 
@@ -25,9 +24,10 @@ function preserveEscapedCharacterReference() {
 function onExitDestinationString(token) {
   const url = this.resume();
   const rawUrl = this.sliceSerialize(token);
-  const node = /** @type {Definition | Image | Link} */ (this.stack.at(-1));
+  const node = this.stack.at(-1);
 
   // Removing this escape would let the next parse decode the character reference.
+  // @ts-expect-error -- Destination strings are only used by nodes with URLs.
   node.url = escapedCharacterReferenceEnd.test(rawUrl) ? rawUrl : url;
 }
 

--- a/src/language-markdown/parse/micromark/mdast-util-preserve-escaped-character-reference.js
+++ b/src/language-markdown/parse/micromark/mdast-util-preserve-escaped-character-reference.js
@@ -1,0 +1,34 @@
+/**
+ * @import {Definition, Image, Link} from "mdast";
+ * @import {CompileContext, Extension, Handle} from "mdast-util-from-markdown";
+ */
+
+const escapedCharacterReferenceEnd =
+  /&(?:#(?:[xX][\dA-Fa-f]+|\d+)|[A-Za-z][\dA-Za-z]*)\\;/u;
+
+/**
+ * @returns {Extension}
+ */
+function preserveEscapedCharacterReference() {
+  return {
+    exit: {
+      definitionDestinationString: onExitDestinationString,
+      resourceDestinationString: onExitDestinationString,
+    },
+  };
+}
+
+/**
+ * @this {CompileContext}
+ * @type {Handle}
+ */
+function onExitDestinationString(token) {
+  const url = this.resume();
+  const rawUrl = this.sliceSerialize(token);
+  const node = /** @type {Definition | Image | Link} */ (this.stack.at(-1));
+
+  // Removing this escape would let the next parse decode the character reference.
+  node.url = escapedCharacterReferenceEnd.test(rawUrl) ? rawUrl : url;
+}
+
+export { preserveEscapedCharacterReference };

--- a/src/language-markdown/parse/parse-markdown.js
+++ b/src/language-markdown/parse/parse-markdown.js
@@ -6,6 +6,7 @@ import { gfm as gfmSyntax } from "micromark-extension-gfm";
 import { math as mathSyntax } from "micromark-extension-math";
 import parseFrontMatter from "../../main/front-matter/parse.js";
 import { gfmFromMarkdown } from "./micromark/mdast-util-gfm.js";
+import { preserveEscapedCharacterReference } from "./micromark/mdast-util-preserve-escaped-character-reference.js";
 import { overrideHtmlTextSyntax } from "./micromark/micromark-extension-html-text.js";
 import {
   liquidFromMarkdown,
@@ -32,6 +33,7 @@ function getMarkdownParseOptions() {
       mathFromMarkdown(),
       wikiLinkFromMarkdown(),
       liquidFromMarkdown(),
+      preserveEscapedCharacterReference(),
     ],
   });
 }

--- a/tests/format/markdown/link/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/link/__snapshots__/format.test.js.snap
@@ -129,6 +129,31 @@ proseWrap: "always"
 ================================================================================
 `;
 
+exports[`escaped-entity.md - {"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+proseWrap: "always"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+[named](/hello?foo=&quot\\;bar)
+[ampersand](/hello?foo=&amp\\;bar)
+[decimal](/hello?foo=&#34\\;bar)
+[hexadecimal](/hello?foo=&#x22\\;bar)
+![image](/hello?foo=&quot\\;bar)
+[reference][escaped]
+
+[escaped]: /hello?foo=&quot\\;bar
+
+=====================================output=====================================
+[named](/hello?foo=&quot\\;bar) [ampersand](/hello?foo=&amp\\;bar)
+[decimal](/hello?foo=&#34\\;bar) [hexadecimal](/hello?foo=&#x22\\;bar)
+![image](/hello?foo=&quot\\;bar) [reference][escaped]
+
+[escaped]: /hello?foo=&quot\\;bar
+
+================================================================================
+`;
+
 exports[`long.md - {"proseWrap":"always"} format 1`] = `
 ====================================options=====================================
 parsers: ["markdown"]

--- a/tests/format/markdown/link/escaped-entity.md
+++ b/tests/format/markdown/link/escaped-entity.md
@@ -1,0 +1,8 @@
+[named](/hello?foo=&quot\;bar)
+[ampersand](/hello?foo=&amp\;bar)
+[decimal](/hello?foo=&#34\;bar)
+[hexadecimal](/hello?foo=&#x22\;bar)
+![image](/hello?foo=&quot\;bar)
+[reference][escaped]
+
+[escaped]: /hello?foo=&quot\;bar


### PR DESCRIPTION
## Description

A Markdown link destination such as `&quot\;` is parsed as the literal text `&quot;`. Printing it without the backslash makes the next parse decode it to `"`, so a second Prettier run changes the output again.

This preserves the raw destination when the semicolon ending a named or numeric character reference was escaped. It covers inline links, images, and reference definitions; other destinations keep their existing normalization.

Fixes #19588.

Verified with:

- `FULL_TEST=1 corepack yarn jest tests/format/markdown/link`
- `corepack yarn lint:typecheck`
- `corepack yarn eslint src/language-markdown/parse/micromark/mdast-util-preserve-escaped-character-reference.js src/language-markdown/parse/parse-markdown.js`
- `corepack yarn prettier src/language-markdown/parse/micromark/mdast-util-preserve-escaped-character-reference.js src/language-markdown/parse/parse-markdown.js tests/format/markdown/link/escaped-entity.md --check`
- `corepack yarn node ./bin/prettier.cjs --parser markdown --debug-check`

The behavior change is limited to destination strings containing an escaped character-reference terminator. The format tests cover named, decimal, and hexadecimal references across the affected node types.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.