### PR TITLE
fix(html): do not format Salesforce Aura `{! ... }` event handlers

### DIFF
--- a/src/language-html/embed/event-handler.js
+++ b/src/language-html/embed/event-handler.js
@@ -12,7 +12,14 @@ const htmlEventAttributes = new Set(htmlEventAttributesArray);
 const isEventHandler = ({ node }, options) =>
   htmlEventAttributes.has(node.fullName) &&
   !options.parentParser &&
-  !node.value.includes("{{");
+  // Respect `embeddedLanguageFormatting: "off"`, which opts out of formatting
+  // quoted embedded code (including inline event handlers).
+  options.embeddedLanguageFormatting === "auto" &&
+  // `{{` is the Vue/Angular interpolation marker and `{!` is the Salesforce
+  // Aura expression-binding marker (e.g. `onclick="{!c.submit}"`). Feeding
+  // either to the Babel parser destroys the binding, so leave them untouched.
+  !node.value.includes("{{") &&
+  !node.value.includes("{!");
 
 /** @type {AttributeValuePrint} */
 const printEventHandler = (textToDoc, print, path /* , options*/) =>

--- a/tests/format/html/attributes/__snapshots__/format.test.js.snap
+++ b/tests/format/html/attributes/__snapshots__/format.test.js.snap
@@ -568,6 +568,13 @@ parsers: ["html"]
   console.log(onclick)
   ">Click</button>
 
+<!-- Salesforce Aura expression bindings (\`{! ... }\`) must be left untouched (#18890) -->
+<button onclick="{!c.submit}">Submit</button>
+
+<button onclick="{!c.handleClick}" onmouseover="{!c.showTooltip}" onmouseout="{!c.hideTooltip}">Hover me</button>
+
+<a onclick="{!c.navigate}" ondragstart="{!c.onDrag}">Link</a>
+
 =====================================output=====================================
 <button onclick="alert('1')">click me!</button>
 
@@ -626,6 +633,19 @@ parsers: ["html"]
 >
   Click
 </button>
+
+<!-- Salesforce Aura expression bindings (\`{! ... }\`) must be left untouched (#18890) -->
+<button onclick="{!c.submit}">Submit</button>
+
+<button
+  onclick="{!c.handleClick}"
+  onmouseover="{!c.showTooltip}"
+  onmouseout="{!c.hideTooltip}"
+>
+  Hover me
+</button>
+
+<a onclick="{!c.navigate}" ondragstart="{!c.onDrag}">Link</a>
 
 ================================================================================
 `;

--- a/tests/format/html/attributes/embedded-language-formatting-off/__snapshots__/format.test.js.snap
+++ b/tests/format/html/attributes/embedded-language-formatting-off/__snapshots__/format.test.js.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`event-attributes.html - {"embeddedLanguageFormatting":"off"} format 1`] = `
+====================================options=====================================
+embeddedLanguageFormatting: "off"
+parsers: ["html"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+<!-- With \`embeddedLanguageFormatting: "off"\`, inline event handlers are not reformatted. -->
+<button onclick="alert(    '1')">click me!</button>
+
+<div onclick="handleClick(  event  )" onmouseover="showTooltip( this )">Hover me</div>
+
+<button onclick="api.user.get(  123  ).then(  data =>   updateUI( data )  )">API Call</button>
+
+<input onfocus="highlightField(  this  )" onblur="validateField( this.value )" />
+
+<button onclick="(event) =>   {  console.log('clicked');  handleClick(  event  );  }">Modern JS</button>
+
+<!-- Salesforce Aura bindings (\`{! ... }\`) are left untouched regardless of the option -->
+<button onclick="{!c.submit}">Submit</button>
+
+=====================================output=====================================
+<!-- With \`embeddedLanguageFormatting: "off"\`, inline event handlers are not reformatted. -->
+<button onclick="alert(    '1')">click me!</button>
+
+<div onclick="handleClick(  event  )" onmouseover="showTooltip( this )">
+  Hover me
+</div>
+
+<button onclick="api.user.get(  123  ).then(  data =>   updateUI( data )  )">
+  API Call
+</button>
+
+<input
+  onfocus="highlightField(  this  )"
+  onblur="validateField( this.value )"
+/>
+
+<button
+  onclick="(event) =>   {  console.log('clicked');  handleClick(  event  );  }"
+>
+  Modern JS
+</button>
+
+<!-- Salesforce Aura bindings (\`{! ... }\`) are left untouched regardless of the option -->
+<button onclick="{!c.submit}">Submit</button>
+
+================================================================================
+`;

--- a/tests/format/html/attributes/embedded-language-formatting-off/event-attributes.html
+++ b/tests/format/html/attributes/embedded-language-formatting-off/event-attributes.html
@@ -1,0 +1,13 @@
+<!-- With `embeddedLanguageFormatting: "off"`, inline event handlers are not reformatted. -->
+<button onclick="alert(    '1')">click me!</button>
+
+<div onclick="handleClick(  event  )" onmouseover="showTooltip( this )">Hover me</div>
+
+<button onclick="api.user.get(  123  ).then(  data =>   updateUI( data )  )">API Call</button>
+
+<input onfocus="highlightField(  this  )" onblur="validateField( this.value )" />
+
+<button onclick="(event) =>   {  console.log('clicked');  handleClick(  event  );  }">Modern JS</button>
+
+<!-- Salesforce Aura bindings (`{! ... }`) are left untouched regardless of the option -->
+<button onclick="{!c.submit}">Submit</button>

--- a/tests/format/html/attributes/embedded-language-formatting-off/format.test.js
+++ b/tests/format/html/attributes/embedded-language-formatting-off/format.test.js
@@ -1,0 +1,1 @@
+runFormatTest(import.meta, ["html"], { embeddedLanguageFormatting: "off" });

--- a/tests/format/html/attributes/event-attributes.html
+++ b/tests/format/html/attributes/event-attributes.html
@@ -35,3 +35,10 @@
   'use strict'
   console.log(onclick)
   ">Click</button>
+
+<!-- Salesforce Aura expression bindings (`{! ... }`) must be left untouched (#18890) -->
+<button onclick="{!c.submit}">Submit</button>
+
+<button onclick="{!c.handleClick}" onmouseover="{!c.showTooltip}" onmouseout="{!c.hideTooltip}">Hover me</button>
+
+<a onclick="{!c.navigate}" ondragstart="{!c.onDrag}">Link</a>


### PR DESCRIPTION
## Description

Fixes #18890

Inline HTML event-handler attributes such as `onclick="{!c.submit}"` were being fed to the Babel parser. Babel parsed `{` as a block statement and `!c.submit` as a logical-NOT expression, then Prettier injected a semicolon and line breaks:

```html
<button
  onclick="
    {
      !c.submit;
    }
  "
></button>
```

This destroys the Salesforce Aura `{! ... }` expression binding and breaks components at runtime.

## Root cause

`src/language-html/embed/event-handler.js` only skipped event-attribute formatting when `node.value.includes("{{")` — the Vue/Angular interpolation escape hatch added in #17909. Aura uses `{!` instead of `{{`, so it was not protected. Additionally, `embeddedLanguageFormatting: "off"` did **not** suppress this path because the formatting is hard-wired in the HTML attribute printer rather than routed through the embedded-language-formatting subsystem.

## Changes

The `isEventHandler` predicate now also skips formatting when:

- `options.embeddedLanguageFormatting === "auto"` is false (i.e. `"off"`), consistent with how the rest of the embedded-language-formatting subsystem behaves; and
- the attribute value contains the Aura expression-binding marker `{!`.

The existing Vue/Angular `{{ ... }}` escape hatch is unchanged.

```diff
 const isEventHandler = ({ node }, options) =>
   htmlEventAttributes.has(node.fullName) &&
   !options.parentParser &&
-  !node.value.includes("{{");
+  options.embeddedLanguageFormatting === "auto" &&
+  !node.value.includes("{{") &&
+  !node.value.includes("{!");
```

## Verification

- `tests/format/html/attributes/` — 23 tests pass (6 suites), including the new `embedded-language-formatting-off` suite.
- `node ./scripts/format-test-lint.js` — Pass.

## Checklist

- [x] Prettier no longer corrupts Aura `onclick="{!c.submit}"`.
- [x] `embeddedLanguageFormatting: "off"` suppresses event-handler attribute reformatting.
- [x] Existing Vue/Angular `{{ ... }}` event-handler behavior is unchanged.
- [x] Tests added; existing test suite passes.

Closes #18890