### PR TITLE
Fix markdown table emoji width calculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "micromatch": "4.0.8",
     "minimist": "1.2.8",
     "n-readlines": "3.4.1",
-    "narrow-emojis": "0.0.3",
     "outdent": "0.8.0",
     "oxc-parser": "0.144.0",
     "parse-json": "8.3.0",

--- a/src/utilities/get-string-width.js
+++ b/src/utilities/get-string-width.js
@@ -5,8 +5,6 @@ import {
   // @ts-expect-error -- Private
   _isWide as isWide,
 } from "get-east-asian-width";
-import { isNarrowEmojiCharacter } from "narrow-emojis";
-
 const notAsciiRegex = /[^\x20-\x7F]/;
 // Exclude [`Spacing Mark`](https://www.compart.com/en/unicode/category/Mc) because spacing marks contribute horizontal width.
 const zeroWidthMarkRegex = /[\p{Nonspacing_Mark}\p{Enclosing_Mark}]/u;
@@ -29,7 +27,8 @@ function getStringWidth(text) {
 
   let width = 0;
   text = text.replace(emojiRegex(), (character) => {
-    width += isNarrowEmojiCharacter(character) ? 1 : 2;
+    const isNarrow = !/^\p{Emoji_Presentation}/u.test(character) && character !== "️" && !character.endsWith("\uFE0F");
+    width += isNarrow ? 1 : 2;
     return "";
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7471,13 +7471,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"narrow-emojis@npm:0.0.3":
-  version: 0.0.3
-  resolution: "narrow-emojis@npm:0.0.3"
-  checksum: 10/873587143c5bf5feea0b023c0388bc3527e290004da97f41123724898a2f65c88bacc07a4bcd9c651249888f24d7ef7da177e0c1bad119810dd9a67089418b21
-  languageName: node
-  linkType: hard
-
 "natural-compare@npm:^1.4.0":
   version: 1.4.0
   resolution: "natural-compare@npm:1.4.0"
@@ -8307,7 +8300,6 @@ __metadata:
     minimist: "npm:1.2.8"
     n-readlines: "npm:3.4.1"
     nano-spawn: "npm:2.1.0"
-    narrow-emojis: "npm:0.0.3"
     node-style-text: "npm:2.1.2"
     npm-run-all2: "npm:9.0.3"
     open-editor: "npm:6.0.0"


### PR DESCRIPTION
Fixes #19831.

This PR replaces the `narrow-emojis` dependency with a native regex check `/^\p{Emoji_Presentation}/u` (with fallback for `\uFE0F`) which correctly handles U+26A0 (⚠) as width 1 without VS16, matching the standard and the behavior of `string-width`.