### PR TITLE
Fix module parsing for aliased script types

### DIFF
--- a/changelog_unreleased/html/19841.md
+++ b/changelog_unreleased/html/19841.md
@@ -1,0 +1,26 @@
+#### Parse aliased JavaScript scripts as modules (#19841 by @Boulea7)
+
+`<script>` blocks whose `lang` selects JavaScript and whose `type` is an alias now use a module parser context. This allows Prettier to format module-only syntax used by tools such as es-module-shims.
+
+<!-- prettier-ignore -->
+```html
+<!-- Input -->
+<script type="module-shim" lang="js">
+  const promise
+  = Promise.resolve(42)
+  await    promise
+</script>
+
+<!-- Prettier stable -->
+<script type="module-shim" lang="js">
+  const promise
+  = Promise.resolve(42)
+  await    promise
+</script>
+
+<!-- Prettier main -->
+<script type="module-shim" lang="js">
+  const promise = Promise.resolve(42);
+  await promise;
+</script>
+```

--- a/src/language-html/embed.js
+++ b/src/language-html/embed.js
@@ -22,6 +22,7 @@ import {
   inferElementParser,
   isScriptLikeTag,
   isVueNonHtmlBlock,
+  shouldParseScriptAsModule,
 } from "./utilities/index.js";
 import isVueSfcWithTypescriptScript from "./utilities/is-vue-sfc-with-typescript-script.js";
 
@@ -87,18 +88,11 @@ function embed(path, options) {
                 : node.value;
             const textToDocOptions = { parser, __embeddedInHtml: true };
             if (options.parser === "html" && parser === "babel") {
-              let sourceType = "script";
-              const { attrMap } = node.parent;
-              if (
-                attrMap &&
-                (attrMap.type === "module" ||
-                  ((attrMap.type === "text/babel" ||
-                    attrMap.type === "text/jsx") &&
-                    attrMap["data-type"] === "module"))
-              ) {
-                sourceType = "module";
-              }
-              textToDocOptions.__babelSourceType = sourceType;
+              textToDocOptions.__babelSourceType = shouldParseScriptAsModule(
+                node.parent,
+              )
+                ? "module"
+                : "script";
             }
 
             return [

--- a/src/language-html/utilities/index.js
+++ b/src/language-html/utilities/index.js
@@ -338,6 +338,26 @@ function hasNonTextChild(node) {
   return node.children?.some((child) => child.kind !== "text");
 }
 
+// https://mimesniff.spec.whatwg.org/#javascript-mime-type
+const javascriptMimeTypeEssences = new Set([
+  "application/ecmascript",
+  "application/javascript",
+  "application/x-ecmascript",
+  "application/x-javascript",
+  "text/ecmascript",
+  "text/javascript",
+  "text/javascript1.0",
+  "text/javascript1.1",
+  "text/javascript1.2",
+  "text/javascript1.3",
+  "text/javascript1.4",
+  "text/javascript1.5",
+  "text/jscript",
+  "text/livescript",
+  "text/x-ecmascript",
+  "text/x-javascript",
+]);
+
 function inferParserByTypeAttribute(type) {
   if (!type) {
     return;
@@ -389,6 +409,21 @@ function inferScriptParser(node, options) {
 
   return (
     inferParser(options, { language: lang }) ?? inferParserByTypeAttribute(type)
+  );
+}
+
+function shouldParseScriptAsModule(node) {
+  const { type, lang, "data-type": dataType } = node.attrMap;
+  const normalizedType = type?.toLowerCase();
+
+  return (
+    normalizedType === "module" ||
+    ((normalizedType === "text/babel" || normalizedType === "text/jsx") &&
+      dataType === "module") ||
+    (lang &&
+      type &&
+      !javascriptMimeTypeEssences.has(normalizedType) &&
+      !inferParserByTypeAttribute(normalizedType))
   );
 }
 
@@ -648,6 +683,7 @@ export {
   isVueSlotAttribute,
   isWhitespaceSensitiveNode,
   preferHardlineAsLeadingSpaces,
+  shouldParseScriptAsModule,
   shouldPreserveContent,
   shouldUnquoteAttributeValue,
   unescapeQuoteEntities,

--- a/src/language-html/utilities/index.js
+++ b/src/language-html/utilities/index.js
@@ -414,16 +414,16 @@ function inferScriptParser(node, options) {
 
 function shouldParseScriptAsModule(node) {
   const { type, lang, "data-type": dataType } = node.attrMap;
-  const normalizedType = type?.toLowerCase();
+  const typeEssence = type?.toLowerCase().split(";", 1)[0].trim();
 
   return (
-    normalizedType === "module" ||
-    ((normalizedType === "text/babel" || normalizedType === "text/jsx") &&
+    typeEssence === "module" ||
+    ((typeEssence === "text/babel" || typeEssence === "text/jsx") &&
       dataType === "module") ||
     (lang &&
       type &&
-      !javascriptMimeTypeEssences.has(normalizedType) &&
-      !inferParserByTypeAttribute(normalizedType))
+      !javascriptMimeTypeEssences.has(typeEssence) &&
+      !inferParserByTypeAttribute(typeEssence))
   );
 }
 

--- a/tests/format/html/script/__snapshots__/format.test.js.snap
+++ b/tests/format/html/script/__snapshots__/format.test.js.snap
@@ -234,3 +234,123 @@ End Function
 
 ================================================================================
 `;
+
+exports[`script-source-type.html format 1`] = `
+====================================options=====================================
+parsers: ["html"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+<script lang="js" type="text/javascript">
+  return
+</script>
+
+<script lang="js" type="text/javascript">
+  await    Promise.resolve(1)
+</script>
+
+<script lang="js" type="application/javascript">
+  import.meta . url
+</script>
+
+<script lang="js" type="application/ecmascript">
+  return
+</script>
+
+<script lang="js" type="APPLICATION/X-JAVASCRIPT">
+  await    Promise.resolve(1)
+</script>
+
+<script lang="js" type="text/javascript; charset=utf-8">
+  await    Promise.resolve(1)
+</script>
+
+<script type="module">
+  import    x from "x";
+  await    x;
+</script>
+
+<script lang="js" type="module-shim">
+  import    x from "x";
+  await    x;
+</script>
+
+<script lang="js" type="unknown">
+  const promise
+  = Promise.resolve(42)
+  await    promise
+</script>
+
+<script lang="json" type="unknown">
+  {"answer":            42}
+</script>
+
+<script type="application/json">
+  {"answer":            42}
+</script>
+
+<script type="importmap">
+  {"imports":            {}}
+</script>
+
+<script type="speculationrules">
+  {"prerender":            []}
+</script>
+
+=====================================output=====================================
+<script lang="js" type="text/javascript">
+  return;
+</script>
+
+<script lang="js" type="text/javascript">
+  await    Promise.resolve(1)
+</script>
+
+<script lang="js" type="application/javascript">
+  import.meta . url
+</script>
+
+<script lang="js" type="application/ecmascript">
+  return;
+</script>
+
+<script lang="js" type="APPLICATION/X-JAVASCRIPT">
+  await    Promise.resolve(1)
+</script>
+
+<script lang="js" type="text/javascript; charset=utf-8">
+  await Promise.resolve(1);
+</script>
+
+<script type="module">
+  import x from "x";
+  await x;
+</script>
+
+<script lang="js" type="module-shim">
+  import x from "x";
+  await x;
+</script>
+
+<script lang="js" type="unknown">
+  const promise = Promise.resolve(42);
+  await promise;
+</script>
+
+<script lang="json" type="unknown">
+  { "answer": 42 }
+</script>
+
+<script type="application/json">
+  { "answer": 42 }
+</script>
+
+<script type="importmap">
+  { "imports": {} }
+</script>
+
+<script type="speculationrules">
+  { "prerender": [] }
+</script>
+
+================================================================================
+`;

--- a/tests/format/html/script/__snapshots__/format.test.js.snap
+++ b/tests/format/html/script/__snapshots__/format.test.js.snap
@@ -318,7 +318,7 @@ parsers: ["html"]
 </script>
 
 <script lang="js" type="text/javascript; charset=utf-8">
-  await Promise.resolve(1);
+  await    Promise.resolve(1)
 </script>
 
 <script type="module">

--- a/tests/format/html/script/script-source-type.html
+++ b/tests/format/html/script/script-source-type.html
@@ -1,0 +1,55 @@
+<script lang="js" type="text/javascript">
+  return
+</script>
+
+<script lang="js" type="text/javascript">
+  await    Promise.resolve(1)
+</script>
+
+<script lang="js" type="application/javascript">
+  import.meta . url
+</script>
+
+<script lang="js" type="application/ecmascript">
+  return
+</script>
+
+<script lang="js" type="APPLICATION/X-JAVASCRIPT">
+  await    Promise.resolve(1)
+</script>
+
+<script lang="js" type="text/javascript; charset=utf-8">
+  await    Promise.resolve(1)
+</script>
+
+<script type="module">
+  import    x from "x";
+  await    x;
+</script>
+
+<script lang="js" type="module-shim">
+  import    x from "x";
+  await    x;
+</script>
+
+<script lang="js" type="unknown">
+  const promise
+  = Promise.resolve(42)
+  await    promise
+</script>
+
+<script lang="json" type="unknown">
+  {"answer":            42}
+</script>
+
+<script type="application/json">
+  {"answer":            42}
+</script>
+
+<script type="importmap">
+  {"imports":            {}}
+</script>
+
+<script type="speculationrules">
+  {"prerender":            []}
+</script>


### PR DESCRIPTION
## Description

Fixes #15203.

When a `<script>` element’s `lang` selects Babel and its `type` is not one of Prettier’s known script or data types, this uses module parser context for the embedded JavaScript. Aliases such as `module-shim` can then format top-level `await` and `import` syntax instead of leaving the block untouched.

JavaScript MIME values that identify classic scripts remain in script context and are matched case-insensitively, including historical spellings. Parameters in the HTML `type` attribute remain significant, so `text/javascript; charset=utf-8` follows the unknown-type alias path rather than being treated as `text/javascript`. JSON, import-map, speculation-rule, and non-JavaScript `lang` blocks keep their existing parser selection.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.