### PR TITLE
Fix escaped character in links

### DIFF
--- a/changelog_unreleased/markdown/19849.md
+++ b/changelog_unreleased/markdown/19849.md
@@ -1,18 +1,14 @@
-#### Keep escaped character references in link destinations (#19849 by @Kjubikstronk)
-
-A character reference that was escaped to stop it resolving, such as `&quot\;`, was printed back without its escape. That turned it into a real character reference, so the destination changed on the first format and again on the second.
-
-Destinations that cannot resolve, such as `?language=DE&currency=EUR`, are unchanged.
+#### Fix escaped character in links (#19849 by @Kjubikstronk)
 
 <!-- prettier-ignore -->
 ```markdown
 <!-- Input -->
 [test](/hello?foo&quot\;bar)
 
-<!-- Prettier stable -->
+<!-- Prettier stable (First format)  -->
 [test](/hello?foo&quot;bar)
 
-<!-- Prettier stable, second run -->
+<!-- Prettier stable (Second format) -->
 [test](/hello?foo"bar)
 
 <!-- Prettier main -->

--- a/changelog_unreleased/markdown/19849.md
+++ b/changelog_unreleased/markdown/19849.md
@@ -1,0 +1,20 @@
+#### Keep escaped character references in link destinations (#19849 by @Kjubikstronk)
+
+A character reference that was escaped to stop it resolving, such as `&quot\;`, was printed back without its escape. That turned it into a real character reference, so the destination changed on the first format and again on the second.
+
+Destinations that cannot resolve, such as `?language=DE&currency=EUR`, are unchanged.
+
+<!-- prettier-ignore -->
+```markdown
+<!-- Input -->
+[test](/hello?foo&quot\;bar)
+
+<!-- Prettier stable -->
+[test](/hello?foo&quot;bar)
+
+<!-- Prettier stable, second run -->
+[test](/hello?foo"bar)
+
+<!-- Prettier main -->
+[test](/hello?foo\&quot;bar)
+```

--- a/src/language-markdown/print/mdast.js
+++ b/src/language-markdown/print/mdast.js
@@ -478,9 +478,6 @@ function shouldRemainTheSameContent(path) {
   );
 }
 
-// The parser resolves character references in link destinations and titles, so
-// printing a resolved value verbatim lets it be resolved a second time and the
-// original text is lost. Escaping the `&` keeps it literal.
 // https://spec.commonmark.org/0.31.2/#entity-and-numeric-character-references
 const characterReferenceRegex = /&(?=(?:#x[\da-f]+|#\d+|[\da-z]+);)/gi;
 
@@ -497,7 +494,6 @@ function printUrl(url, unwrapBalancedParens) {
   // escape sequence, so must itself be escaped.
   url = url.replaceAll(/\\(?![^!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/g, "\\\\");
 
-  // After the escaping above, so the backslash this adds is not doubled in turn.
   url = escapeCharacterReferences(url);
 
   // CommonMark forbids ASCII controls, space, unbalanced parentheses, and
@@ -538,14 +534,12 @@ function printTitle(title, options, printSpace = true) {
     !title.includes(")")
   ) {
     title = title.replaceAll("\\", "\\\\");
-    // after the backslash doubling above, so this escape is not doubled too
     title = escapeCharacterReferences(title);
     return `(${title})`; // avoid escaped quotes
   }
   const quote = getPreferredQuote(title, options.singleQuote);
   title = title.replaceAll("\\", "\\\\");
   title = title.replaceAll(quote, `\\${quote}`);
-  // after the backslash doubling above, so this escape is not doubled too
   title = escapeCharacterReferences(title);
   return `${quote}${title}${quote}`;
 }

--- a/src/language-markdown/print/mdast.js
+++ b/src/language-markdown/print/mdast.js
@@ -482,7 +482,7 @@ function shouldRemainTheSameContent(path) {
 // printing a resolved value verbatim lets it be resolved a second time and the
 // original text is lost. Escaping the `&` keeps it literal.
 // https://spec.commonmark.org/0.31.2/#entity-and-numeric-character-references
-const characterReferenceRegex = /&(?=(?:#x[\da-f]+|#\d+|[\da-z]+);)/giu;
+const characterReferenceRegex = /&(?=(?:#x[\da-f]+|#\d+|[\da-z]+);)/gi;
 
 const escapeCharacterReferences = (value) =>
   value.replaceAll(characterReferenceRegex, String.raw`\&`);

--- a/src/language-markdown/print/mdast.js
+++ b/src/language-markdown/print/mdast.js
@@ -480,7 +480,6 @@ function shouldRemainTheSameContent(path) {
 
 // https://spec.commonmark.org/0.31.2/#entity-and-numeric-character-references
 const characterReferenceRegex = /&(?=(?:#x[\da-f]+|#\d+|[\da-z]+);)/gi;
-
 const escapeCharacterReferences = (value) =>
   value.replaceAll(characterReferenceRegex, String.raw`\&`);
 

--- a/src/language-markdown/print/mdast.js
+++ b/src/language-markdown/print/mdast.js
@@ -492,7 +492,6 @@ function printUrl(url, unwrapBalancedParens) {
   // Backslash followed by ASCII punctuation would be misinterpreted as an
   // escape sequence, so must itself be escaped.
   url = url.replaceAll(/\\(?![^!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/g, "\\\\");
-
   url = escapeCharacterReferences(url);
 
   // CommonMark forbids ASCII controls, space, unbalanced parentheses, and

--- a/src/language-markdown/print/mdast.js
+++ b/src/language-markdown/print/mdast.js
@@ -478,6 +478,15 @@ function shouldRemainTheSameContent(path) {
   );
 }
 
+// The parser resolves character references in link destinations and titles, so
+// printing a resolved value verbatim lets it be resolved a second time and the
+// original text is lost. Escaping the `&` keeps it literal.
+// https://spec.commonmark.org/0.31.2/#entity-and-numeric-character-references
+const characterReferenceRegex = /&(?=(?:#x[\da-f]+|#\d+|[\da-z]+);)/giu;
+
+const escapeCharacterReferences = (value) =>
+  value.replaceAll(characterReferenceRegex, String.raw`\&`);
+
 /**
  * @param {string} url
  * @param {boolean} unwrapBalancedParens
@@ -487,6 +496,9 @@ function printUrl(url, unwrapBalancedParens) {
   // Backslash followed by ASCII punctuation would be misinterpreted as an
   // escape sequence, so must itself be escaped.
   url = url.replaceAll(/\\(?![^!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/g, "\\\\");
+
+  // After the escaping above, so the backslash this adds is not doubled in turn.
+  url = escapeCharacterReferences(url);
 
   // CommonMark forbids ASCII controls, space, unbalanced parentheses, and
   // initial <, unless wrapped in <> with any inner < or > escaped. CommonMark
@@ -526,11 +538,15 @@ function printTitle(title, options, printSpace = true) {
     !title.includes(")")
   ) {
     title = title.replaceAll("\\", "\\\\");
+    // after the backslash doubling above, so this escape is not doubled too
+    title = escapeCharacterReferences(title);
     return `(${title})`; // avoid escaped quotes
   }
   const quote = getPreferredQuote(title, options.singleQuote);
   title = title.replaceAll("\\", "\\\\");
   title = title.replaceAll(quote, `\\${quote}`);
+  // after the backslash doubling above, so this escape is not doubled too
+  title = escapeCharacterReferences(title);
   return `${quote}${title}${quote}`;
 }
 

--- a/tests/format/markdown/link/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/link/__snapshots__/format.test.js.snap
@@ -141,48 +141,64 @@ proseWrap: "always"
 =====================================input======================================
 [Test](http://localhost:8080/test?language=DE&currency=EUR)
 
-[escaped named reference](/a?x&quot\\;b)
+[Test](/a?x&quot\\;b)
 
-[escaped decimal reference](/a?x&#34\\;b)
+[Test](/a?x&#34\\;b)
 
-[escaped hex reference](/a?x&#x22\\;b)
+[Test](/a?x&#x22\\;b)
 
-![escaped reference in an image](/a?x&quot\\;b)
+![Test](/a?x&quot\\;b)
 
-[escaped reference in a title](/a "x&quot\\;b")
+[Test](/a "x&quot\\;b")
 
-[escaped reference in a destination with a space](</a b?x&quot\\;c>)
+[Test](</a b?x&quot\\;c>)
 
-[escaped reference in a definition]: /a?x&quot\\;b
+[Test]: /a?x&quot\\;b
 
-[escaped ampersand](/a?x\\&amp;b)
+[Test](/a?x\\&amp;b)
 
-[escaped ampersand in a title](/a "x\\&amp;b")
+[Test](/a?x\\&amp;quot;b)
 
-[unescaped named reference](/a?x&amp;b)
+[Test](/a "x\\&amp;b")
+
+[Test](/a "x\\&amp;quot;b")
+
+[Test](/a?x&amp;b)
+
+[Test](/a?x&amp;quot;b)
+
+[Test](/a "/a?x&amp;quot;b")
 
 =====================================output=====================================
 [Test](http://localhost:8080/test?language=DE&currency=EUR)
 
-[escaped named reference](/a?x\\&quot;b)
+[Test](/a?x\\&quot;b)
 
-[escaped decimal reference](/a?x\\&#34;b)
+[Test](/a?x\\&#34;b)
 
-[escaped hex reference](/a?x\\&#x22;b)
+[Test](/a?x\\&#x22;b)
 
-![escaped reference in an image](/a?x\\&quot;b)
+![Test](/a?x\\&quot;b)
 
-[escaped reference in a title](/a "x\\&quot;b")
+[Test](/a "x\\&quot;b")
 
-[escaped reference in a destination with a space](</a b?x\\&quot;c>)
+[Test](</a b?x\\&quot;c>)
 
-[escaped reference in a definition]: /a?x\\&quot;b
+[Test]: /a?x\\&quot;b
 
-[escaped ampersand](/a?x\\&amp;b)
+[Test](/a?x\\&amp;b)
 
-[escaped ampersand in a title](/a "x\\&amp;b")
+[Test](/a?x\\&amp;quot;b)
 
-[unescaped named reference](/a?x&b)
+[Test](/a "x\\&amp;b")
+
+[Test](/a "x\\&amp;quot;b")
+
+[Test](/a?x&b)
+
+[Test](/a?x\\&quot;b)
+
+[Test](/a "/a?x\\&quot;b")
 
 ================================================================================
 `;

--- a/tests/format/markdown/link/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/link/__snapshots__/format.test.js.snap
@@ -155,6 +155,12 @@ proseWrap: "always"
 
 [escaped reference in a definition]: /a?x&quot\\;b
 
+[escaped ampersand](/a?x\\&amp;b)
+
+[escaped ampersand in a title](/a "x\\&amp;b")
+
+[unescaped named reference](/a?x&amp;b)
+
 =====================================output=====================================
 [Test](http://localhost:8080/test?language=DE&currency=EUR)
 
@@ -171,6 +177,12 @@ proseWrap: "always"
 [escaped reference in a destination with a space](</a b?x\\&quot;c>)
 
 [escaped reference in a definition]: /a?x\\&quot;b
+
+[escaped ampersand](/a?x\\&amp;b)
+
+[escaped ampersand in a title](/a "x\\&amp;b")
+
+[unescaped named reference](/a?x&b)
 
 ================================================================================
 `;

--- a/tests/format/markdown/link/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/link/__snapshots__/format.test.js.snap
@@ -141,8 +141,36 @@ proseWrap: "always"
 =====================================input======================================
 [Test](http://localhost:8080/test?language=DE&currency=EUR)
 
+[escaped named reference](/a?x&quot\\;b)
+
+[escaped decimal reference](/a?x&#34\\;b)
+
+[escaped hex reference](/a?x&#x22\\;b)
+
+![escaped reference in an image](/a?x&quot\\;b)
+
+[escaped reference in a title](/a "x&quot\\;b")
+
+[escaped reference in a destination with a space](</a b?x&quot\\;c>)
+
+[escaped reference in a definition]: /a?x&quot\\;b
+
 =====================================output=====================================
 [Test](http://localhost:8080/test?language=DE&currency=EUR)
+
+[escaped named reference](/a?x\\&quot;b)
+
+[escaped decimal reference](/a?x\\&#34;b)
+
+[escaped hex reference](/a?x\\&#x22;b)
+
+![escaped reference in an image](/a?x\\&quot;b)
+
+[escaped reference in a title](/a "x\\&quot;b")
+
+[escaped reference in a destination with a space](</a b?x\\&quot;c>)
+
+[escaped reference in a definition]: /a?x\\&quot;b
 
 ================================================================================
 `;

--- a/tests/format/markdown/link/entity.md
+++ b/tests/format/markdown/link/entity.md
@@ -13,3 +13,9 @@
 [escaped reference in a destination with a space](</a b?x&quot\;c>)
 
 [escaped reference in a definition]: /a?x&quot\;b
+
+[escaped ampersand](/a?x\&amp;b)
+
+[escaped ampersand in a title](/a "x\&amp;b")
+
+[unescaped named reference](/a?x&amp;b)

--- a/tests/format/markdown/link/entity.md
+++ b/tests/format/markdown/link/entity.md
@@ -1,21 +1,29 @@
 [Test](http://localhost:8080/test?language=DE&currency=EUR)
 
-[escaped named reference](/a?x&quot\;b)
+[Test](/a?x&quot\;b)
 
-[escaped decimal reference](/a?x&#34\;b)
+[Test](/a?x&#34\;b)
 
-[escaped hex reference](/a?x&#x22\;b)
+[Test](/a?x&#x22\;b)
 
-![escaped reference in an image](/a?x&quot\;b)
+![Test](/a?x&quot\;b)
 
-[escaped reference in a title](/a "x&quot\;b")
+[Test](/a "x&quot\;b")
 
-[escaped reference in a destination with a space](</a b?x&quot\;c>)
+[Test](</a b?x&quot\;c>)
 
-[escaped reference in a definition]: /a?x&quot\;b
+[Test]: /a?x&quot\;b
 
-[escaped ampersand](/a?x\&amp;b)
+[Test](/a?x\&amp;b)
 
-[escaped ampersand in a title](/a "x\&amp;b")
+[Test](/a?x\&amp;quot;b)
 
-[unescaped named reference](/a?x&amp;b)
+[Test](/a "x\&amp;b")
+
+[Test](/a "x\&amp;quot;b")
+
+[Test](/a?x&amp;b)
+
+[Test](/a?x&amp;quot;b)
+
+[Test](/a "/a?x&amp;quot;b")

--- a/tests/format/markdown/link/entity.md
+++ b/tests/format/markdown/link/entity.md
@@ -1,1 +1,15 @@
 [Test](http://localhost:8080/test?language=DE&currency=EUR)
+
+[escaped named reference](/a?x&quot\;b)
+
+[escaped decimal reference](/a?x&#34\;b)
+
+[escaped hex reference](/a?x&#x22\;b)
+
+![escaped reference in an image](/a?x&quot\;b)
+
+[escaped reference in a title](/a "x&quot\;b")
+
+[escaped reference in a destination with a space](</a b?x&quot\;c>)
+
+[escaped reference in a definition]: /a?x&quot\;b


### PR DESCRIPTION


## Description

Fixes #19588.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.


