### PR TITLE
Handle comments before switch body

### DIFF
--- a/changelog_unreleased/javascript/19862.md
+++ b/changelog_unreleased/javascript/19862.md
@@ -1,0 +1,22 @@
+#### Handle comments before switch body (#19862 by @rajanpanth)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+switch (a) /* comment */ {
+  case 1:
+    break;
+}
+
+// Prettier stable
+switch (a /* comment */) {
+  case 1:
+    break;
+}
+
+// Prettier main
+switch (a) /* comment */ {
+  case 1:
+    break;
+}
+```

--- a/src/language-js/comments/attach/handle-switch-statement-comments.js
+++ b/src/language-js/comments/attach/handle-switch-statement-comments.js
@@ -18,8 +18,6 @@ function handleSwitchStatementComments({
 }) {
   if (!(
     enclosingNode?.type === "SwitchStatement" &&
-    enclosingNode.cases.length === 0 &&
-    !followingNode &&
     precedingNode === enclosingNode.discriminant
   )) {
     return false;
@@ -30,7 +28,16 @@ function handleSwitchStatementComments({
     locEnd(comment),
   );
 
-  if (nextCharacter === "}") {
+  if (nextCharacter === "{") {
+    addDanglingComment(enclosingNode, comment, "commentAfterDiscriminant");
+    return true;
+  }
+
+  if (
+    nextCharacter === "}" &&
+    enclosingNode.cases.length === 0 &&
+    !followingNode
+  ) {
     addDanglingComment(enclosingNode, comment);
     return true;
   }

--- a/src/language-js/print/switch-statement.js
+++ b/src/language-js/print/switch-statement.js
@@ -6,11 +6,35 @@ import {
   softline,
 } from "../../document/index.js";
 import { printDanglingComments } from "../../main/comments/print.js";
-import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
+import { isLineComment } from "../utilities/comment-types.js";
+import {
+  CommentCheckFlags,
+  getComments,
+  hasComment,
+} from "../utilities/comments.js";
 import { isNextLineEmpty } from "../utilities/is-next-line-empty.js";
 import { printStatementSequence } from "./statement-sequence.js";
 
 function printSwitchStatement(path, options, print) {
+  const commentsAfterDiscriminant = getComments(
+    path.node,
+    CommentCheckFlags.Dangling,
+    (comment) => comment.marker === "commentAfterDiscriminant",
+  );
+  const printedCommentsAfterDiscriminant =
+    commentsAfterDiscriminant.length === 0
+      ? ""
+      : [
+          " ",
+          printDanglingComments(path, options, {
+            marker: "commentAfterDiscriminant",
+          }),
+          commentsAfterDiscriminant.some(isLineComment) ? hardline : "",
+        ];
+  const openingBrace = commentsAfterDiscriminant.some(isLineComment)
+    ? "{"
+    : " {";
+
   return [
     group([
       "switch (",
@@ -18,7 +42,8 @@ function printSwitchStatement(path, options, print) {
       softline,
       ")",
     ]),
-    " {",
+    printedCommentsAfterDiscriminant,
+    openingBrace,
     path.node.cases.length > 0
       ? indent([
           hardline,

--- a/tests/format/js/switch/__snapshots__/format.test.js.snap
+++ b/tests/format/js/switch/__snapshots__/format.test.js.snap
@@ -64,6 +64,24 @@ switch(x) {
     break;}
 }
 
+switch (a) /* comment */ {
+}
+
+switch (a) // comment
+{
+}
+
+switch (a) /* comment */ {
+  case 1:
+    break;
+}
+
+switch (a) // comment
+{
+  case 1:
+    break;
+}
+
 =====================================output=====================================
 switch (true) {
   case true:
@@ -130,6 +148,24 @@ switch (x) {
   default: /* comment */ {
     break;
   }
+}
+
+switch (a) /* comment */ {
+}
+
+switch (a) // comment
+{
+}
+
+switch (a) /* comment */ {
+  case 1:
+    break;
+}
+
+switch (a) // comment
+{
+  case 1:
+    break;
 }
 
 ================================================================================

--- a/tests/format/js/switch/comments.js
+++ b/tests/format/js/switch/comments.js
@@ -56,3 +56,21 @@ switch(x) {
   default: /* comment */ {
     break;}
 }
+
+switch (a) /* comment */ {
+}
+
+switch (a) // comment
+{
+}
+
+switch (a) /* comment */ {
+  case 1:
+    break;
+}
+
+switch (a) // comment
+{
+  case 1:
+    break;
+}


### PR DESCRIPTION
## Description

Fixes #19582.

Preserve comments written between a `switch` discriminant and the opening body brace. These comments were attached to the discriminant and printed inside `switch (...)`; they now print after the closing parenthesis for both empty switches and switches with cases.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

Validation:

- `yarn jest tests/format/js/switch`
- `yarn lint:format-test`
- `yarn prettier src/language-js/comments/attach/handle-switch-statement-comments.js src/language-js/print/switch-statement.js tests/format/js/switch/comments.js tests/format/js/switch/__snapshots__/format.test.js.snap --check`
- `yarn prettier changelog_unreleased/javascript/19862.md --check`
- `yarn lint:changelog`
- `git diff --check`
