### PR TITLE
docs: clarify that editorconfig is not a config-file option

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -55,7 +55,11 @@ const formatted = await prettier.format(text, {
 });
 ```
 
-If `options.editorconfig` is `true` and an [`.editorconfig` file](https://editorconfig.org/) is in your project, Prettier will parse it and convert its properties to the corresponding Prettier configuration. This configuration will be overridden by `.prettierrc`, etc. Currently, the following EditorConfig properties are supported:
+If `options.editorconfig` is `true` and an [`.editorconfig` file](https://editorconfig.org/) is in your project, Prettier will parse it and convert its properties to the corresponding Prettier configuration. This configuration will be overridden by `.prettierrc`, etc.
+
+This option exists only on `prettier.resolveConfig()` (default `false`). It is **not** valid in a Prettier config file such as `.prettierrc`. The CLI reads `.editorconfig` by default; see [`--no-editorconfig`](cli.md#--no-editorconfig) and [EditorConfig](configuration.md#editorconfig).
+
+Currently, the following EditorConfig properties are supported:
 
 - `end_of_line`
 - `indent_style`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -164,7 +164,7 @@ This option adds support to editor integrations where users define their default
 
 ## `--no-editorconfig`
 
-Don’t take `.editorconfig` into account when parsing configuration. See the [`prettier.resolveConfig` docs](api.md) for details.
+Don’t take `.editorconfig` into account when parsing configuration. The CLI reads `.editorconfig` by default; this flag disables that. See [EditorConfig](configuration.md#editorconfig) and [`prettier.resolveConfig`](api.md#prettierresolveconfigfileurlorpath--options) for details.
 
 ## `--with-node-modules`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -218,6 +218,15 @@ If a [`.editorconfig` file](https://editorconfig.org/) is in your project, Prett
 
 :::note
 
+`editorconfig` is **not** a Prettier configuration-file option. Adding `editorconfig: true` to `.prettierrc` (or similar) produces an “Ignored unknown option” warning.
+
+- **CLI:** reads `.editorconfig` by default. Disable with [`--no-editorconfig`](cli.md#--no-editorconfig).
+- **Node.js API:** pass `{ editorconfig: true }` to [`prettier.resolveConfig()`](api.md#prettierresolveconfigfileurlorpath--options) when you want EditorConfig settings included. The option defaults to `false` in the API.
+
+:::
+
+:::note
+
 Unlike the EditorConfig spec, the search for `.editorconfig` file will stop on the project root and won't proceed further.
 
 :::


### PR DESCRIPTION
## Description

Fixes #15255.

Clarify EditorConfig behavior across the docs:

- `editorconfig` is **not** valid in `.prettierrc` (causes “Ignored unknown option”)
- The **CLI** reads `.editorconfig` by default (`--no-editorconfig` to disable)
- The **API** requires `{ editorconfig: true }` on `prettier.resolveConfig()` (default `false`)

Updates `docs/configuration.md`, `docs/api.md`, and `docs/cli.md`.

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.