### PR TITLE
docs: update broken Node.js profiling guide link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ In the above commands:
 - `NODE_ENV=production` ensures Prettier and its dependencies run in production mode.
 - `node --inspect-brk` pauses the script execution until Inspector is connected to the Node process.
 
-In addition to the options above, you can use [`node --prof` and `node --prof-process`](https://nodejs.org/en/docs/guides/simple-profiling/), as well as `node --trace-opt --trace-deopt`, to get more advanced performance insights.
+In addition to the options above, you can use [`node --prof` and `node --prof-process`](https://nodejs.org/en/learn/getting-started/profiling), as well as `node --trace-opt --trace-deopt`, to get more advanced performance insights.
 
 The script [`scripts/benchmark/compare.sh`](scripts/benchmark/compare.sh) can be used to compare performance of two or more commits/branches using [hyperfine](https://github.com/sharkdp/hyperfine). Usage (don't forget to install hyperfine):
 


### PR DESCRIPTION
## Problem

`CONTRIBUTING.md` links to the old Node.js guide at `https://nodejs.org/en/docs/guides/simple-profiling/`.

A `curl -L` GET of that URL returns HTTP 404. Node moved the page to the Learn section.

## Solution

Update the link to the current guide:

`https://nodejs.org/en/learn/getting-started/profiling`

That URL returns HTTP 200 and still documents `node --prof` / `node --prof-process`.

## Verification

```
curl -sS -L -o NUL -w "%{http_code} %{url_effective}\n" \
  https://nodejs.org/en/docs/guides/simple-profiling/
# 404 https://nodejs.org/en/docs/guides/simple-profiling/

curl -sS -L -o NUL -w "%{http_code} %{url_effective}\n" \
  https://nodejs.org/en/learn/getting-started/profiling
# 200 https://nodejs.org/learn/getting-started/profiling
```

Searched open and closed PRs/issues for `simple-profiling` and `nodejs.org/en/docs/guides`; no existing fix.
