### PR TITLE
docs: update broken JSX spec link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ title: What is Prettier?
 Prettier is an opinionated code formatter with support for:
 
 - JavaScript (including experimental features)
-- [JSX](https://facebook.github.io/jsx/)
+- [JSX](https://github.com/facebook/jsx)
 - [Angular](https://angular.dev/)
 - [Vue](https://vuejs.org/)
 - [Flow](https://flow.org/)

--- a/website/data/languages.yml
+++ b/website/data/languages.yml
@@ -1,7 +1,7 @@
 - name: JavaScript
   image: /images/languages/tools_js.svg
   variants:
-    - "[JSX](https://facebook.github.io/jsx/)"
+    - "[JSX](https://github.com/facebook/jsx)"
     - "[Flow](https://flow.org/)"
     - "[TypeScript](https://www.typescriptlang.org/)"
     - "[JSON](https://json.org/)"


### PR DESCRIPTION
## Problem

The language list on the docs homepage links JSX to `https://facebook.github.io/jsx/`.

A `curl -L` GET of that URL returns HTTP 404. The JSX spec repo now lives at `https://github.com/facebook/jsx` (GitHub redirects it to `https://github.com/react/jsx`).

## Solution

Point the user-facing JSX link at `https://github.com/facebook/jsx`.

Touched only the source files that publish the language list:

- `docs/index.md` (next docs)
- `website/data/languages.yml` (homepage language chips)

Left historical blog posts and markdown fixture snapshots unchanged.

## Verification

```
curl -sS -L -o NUL -w "%{http_code} %{url_effective}\n" https://facebook.github.io/jsx/
# 404 https://facebook.github.io/jsx/

curl -sS -L -o NUL -w "%{http_code} %{url_effective}\n" https://github.com/facebook/jsx
# 200 https://github.com/react/jsx
```

Searched open and closed PRs/issues for `facebook.github.io/jsx`; no existing docs fix.
