### PR TITLE
docs: fix lowercase license file link in plugin READMEs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ title: What is Prettier?
 Prettier is an opinionated code formatter with support for:
 
 - JavaScript (including experimental features)
-- [JSX](https://facebook.github.io/jsx/)
+- [JSX](https://github.com/facebook/jsx)
 - [Angular](https://angular.dev/)
 - [Vue](https://vuejs.org/)
 - [Flow](https://flow.org/)

--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -1,7 +1,7 @@
 # @prettier/plugin-hermes
 
 [![Npm Version](https://img.shields.io/npm/v/@prettier/plugin-hermes.svg?style=flat-square)](https://www.npmjs.com/package/@prettier/plugin-hermes)
-[![MIT License](https://img.shields.io/npm/l/@prettier/plugin-hermes.svg?style=flat-square)](https://github.com/prettier/prettier/blob/main/license)
+[![MIT License](https://img.shields.io/npm/l/@prettier/plugin-hermes.svg?style=flat-square)](https://github.com/prettier/prettier/blob/main/LICENSE)
 
 > Prettier [Hermes](https://github.com/facebook/hermes/blob/main/README.md) plugin.
 

--- a/packages/plugin-oxc/README.md
+++ b/packages/plugin-oxc/README.md
@@ -1,7 +1,7 @@
 # @prettier/plugin-oxc
 
 [![Npm Version](https://img.shields.io/npm/v/@prettier/plugin-oxc.svg?style=flat-square)](https://www.npmjs.com/package/@prettier/plugin-oxc)
-[![MIT License](https://img.shields.io/npm/l/@prettier/plugin-oxc.svg?style=flat-square)](https://github.com/prettier/prettier/blob/main/license)
+[![MIT License](https://img.shields.io/npm/l/@prettier/plugin-oxc.svg?style=flat-square)](https://github.com/prettier/prettier/blob/main/LICENSE)
 
 > Prettier [Oxc](https://oxc.rs/) plugin.
 

--- a/packages/plugin-yuku/README.md
+++ b/packages/plugin-yuku/README.md
@@ -1,7 +1,7 @@
 # @prettier/plugin-yuku
 
 [![Npm Version](https://img.shields.io/npm/v/@prettier/plugin-yuku.svg?style=flat-square)](https://www.npmjs.com/package/@prettier/plugin-yuku)
-[![MIT License](https://img.shields.io/npm/l/@prettier/plugin-yuku.svg?style=flat-square)](https://github.com/prettier/prettier/blob/main/license)
+[![MIT License](https://img.shields.io/npm/l/@prettier/plugin-yuku.svg?style=flat-square)](https://github.com/prettier/prettier/blob/main/LICENSE)
 
 > Prettier [yuku](https://yuku.fyi/) plugin.
 

--- a/website/data/languages.yml
+++ b/website/data/languages.yml
@@ -1,7 +1,7 @@
 - name: JavaScript
   image: /images/languages/tools_js.svg
   variants:
-    - "[JSX](https://facebook.github.io/jsx/)"
+    - "[JSX](https://github.com/facebook/jsx)"
     - "[Flow](https://flow.org/)"
     - "[TypeScript](https://www.typescriptlang.org/)"
     - "[JSON](https://json.org/)"


### PR DESCRIPTION
## Problem

The MIT license badge links in three plugin package READMEs point to `https://github.com/prettier/prettier/blob/main/license` (lowercase `license`), but the file in this repository is named `LICENSE` (uppercase). The links return 404:

- `packages/plugin-oxc/README.md` line 4
- `packages/plugin-hermes/README.md` line 4
- `packages/plugin-yuku/README.md` line 4

Verified with curl GET (follows redirects):

```
$ curl -sS -L -o /dev/null -w "%{http_code}" https://github.com/prettier/prettier/blob/main/license
404
$ curl -sS -L -o /dev/null -w "%{http_code}" https://github.com/prettier/prettier/blob/main/LICENSE
200
```

## Solution

Update the badge link in all three READMEs from `blob/main/license` to `blob/main/LICENSE`.

## Verification

- Only the link target changed; no content or wording modified.
- `git diff --check` passes with no whitespace errors.
