### PR TITLE
docs: update renamed prettier-plugin-nginx repository link

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -77,7 +77,7 @@ Strings provided to `plugins` are ultimately passed to [`import()` expression](h
 - [`prettier-plugin-marko`](https://github.com/marko-js/prettier) by [**@marko-js**](https://github.com/marko-js)
 - [`prettier-plugin-motoko`](https://github.com/dfinity/prettier-plugin-motoko) by [**@dfinity**](https://github.com/dfinity)
 - [`prettier-plugin-mustache`](https://github.com/Poliklot/prettier-plugin-mustache) by [**@Poliklot**](https://github.com/Poliklot)
-- [`prettier-plugin-nginx`](https://github.com/joedeandev/prettier-plugin-nginx) by [**@joedeandev**](https://github.com/joedeandev)
+- [`prettier-plugin-nginx`](https://github.com/jxddk/prettier-plugin-nginx) by [**@jxddk**](https://github.com/jxddk)
 - [`prettier-plugin-nunjucks`](https://github.com/Poliklot/prettier-plugin-nunjucks) by [**@Poliklot**](https://github.com/Poliklot)
 - [`prettier-plugin-prisma`](https://github.com/umidbekk/prettier-plugin-prisma) by [**@umidbekk**](https://github.com/umidbekk)
 - [`prettier-plugin-properties`](https://github.com/eemeli/prettier-plugin-properties) by [**@eemeli**](https://github.com/eemeli)

--- a/website/versioned_docs/version-stable/plugins.md
+++ b/website/versioned_docs/version-stable/plugins.md
@@ -77,7 +77,7 @@ Strings provided to `plugins` are ultimately passed to [`import()` expression](h
 - [`prettier-plugin-marko`](https://github.com/marko-js/prettier) by [**@marko-js**](https://github.com/marko-js)
 - [`prettier-plugin-motoko`](https://github.com/dfinity/prettier-plugin-motoko) by [**@dfinity**](https://github.com/dfinity)
 - [`prettier-plugin-mustache`](https://github.com/Poliklot/prettier-plugin-mustache) by [**@Poliklot**](https://github.com/Poliklot)
-- [`prettier-plugin-nginx`](https://github.com/joedeandev/prettier-plugin-nginx) by [**@joedeandev**](https://github.com/joedeandev)
+- [`prettier-plugin-nginx`](https://github.com/jxddk/prettier-plugin-nginx) by [**@jxddk**](https://github.com/jxddk)
 - [`prettier-plugin-nunjucks`](https://github.com/Poliklot/prettier-plugin-nunjucks) by [**@Poliklot**](https://github.com/Poliklot)
 - [`prettier-plugin-prisma`](https://github.com/umidbekk/prettier-plugin-prisma) by [**@umidbekk**](https://github.com/umidbekk)
 - [`prettier-plugin-properties`](https://github.com/eemeli/prettier-plugin-properties) by [**@eemeli**](https://github.com/eemeli)


### PR DESCRIPTION
## Problem

The `prettier-plugin-nginx` entry in the community plugins list links to `https://github.com/joedeandev/prettier-plugin-nginx`, which returns 404. The plugin author renamed their GitHub account from `joedeandev` to `jxddk`, and the repository moved to `https://github.com/jxddk/prettier-plugin-nginx` (GitHub redirects the renamed user page but the stale repo URL in this doc no longer resolves).

## Solution

Update the plugin link and the author handle in both `docs/plugins.md` and `website/versioned_docs/version-stable/plugins.md` to the renamed account `jxddk`.

## Verification

```
$ curl -s -o /dev/null -w "%{http_code}" -L https://github.com/joedeandev/prettier-plugin-nginx
404
$ curl -s -o /dev/null -w "%{http_code}" -L https://github.com/jxddk/prettier-plugin-nginx
200
$ gh api users/joedeandev
{"message":"Not Found","status":"404"}
$ gh api users/jxddk --jq .login
"jxddk"
```
