### PR TITLE
docs(website): fix moved MDX v1 fixture link in playground code samples

### DIFF
--- a/website/playground/codeSamples.mjs
+++ b/website/playground/codeSamples.mjs
@@ -181,7 +181,7 @@ export default function getCodeSamples(parser) {
         "Curabitur consectetur maximus risus, sed maximus tellus tincidunt et.",
       ].join("\n");
     case "mdx":
-      // modified from https://github.com/mdx-js/mdx/blob/master/packages/mdx/test/fixtures/blog-post.md
+      // modified from https://github.com/mdx-js/mdx/blob/v1/packages/mdx/test/fixtures/blog-post.mdx
       return [
         "import     {     Baz } from     './Fixture'",
         "import { Buz  }   from './Fixture'",


### PR DESCRIPTION
## Problem

A source comment in `website/playground/codeSamples.mjs` (line 184) credits the MDX sample as "modified from" `https://github.com/mdx-js/mdx/blob/master/packages/mdx/test/fixtures/blog-post.md`. That URL returns 404: MD v1 work moved to the `v1` branch, and on that branch the fixture is named `blog-post.mdx`, not `blog-post.md`.

## Solution

Update the comment URL to the location that still serves this exact fixture: `https://github.com/mdx-js/mdx/blob/v1/packages/mdx/test/fixtures/blog-post.mdx`.

## Verification

Old URL 404, new URL 200, and the new URL's raw content matches the sample it is credited for (starts with `import { Baz } from './Fixture'`):

```
$ curl -s -o /dev/null -w "%{http_code}" -L https://github.com/mdx-js/mdx/blob/master/packages/mdx/test/fixtures/blog-post.md
404
$ curl -s -o /dev/null -w "%{http_code}" -L https://github.com/mdx-js/mdx/blob/v1/packages/mdx/test/fixtures/blog-post.mdx
200
$ curl -s -L https://raw.githubusercontent.com/mdx-js/mdx/v1/packages/mdx/test/fixtures/blog-post.mdx | head -2
import { Baz } from './Fixture'
import { Buz } from './Fixture'
```
