### PR TITLE
docs: fix dead upstream source links in comments

### DIFF
--- a/src/config/resolve-config.js
+++ b/src/config/resolve-config.js
@@ -127,7 +127,7 @@ function mergeOverrides(configResult, filePath) {
   return options;
 }
 
-// Based on ESLint: https://github.com/eslint/eslint/blob/master/lib/config/config-ops.js
+// Based on ESLint: https://github.com/eslint/eslint/blob/v5.16.0/lib/config/config-ops.js
 function pathMatchesGlobs(filePath, patterns, excludedPatterns) {
   const patternList = Array.isArray(patterns) ? patterns : [patterns];
   // micromatch always matches against basename when the option is enabled

--- a/src/language-js/utilities/is-node-matches.js
+++ b/src/language-js/utilities/is-node-matches.js
@@ -1,4 +1,4 @@
-// Copied from https://github.com/sindresorhus/eslint-plugin-unicorn/blob/d53d935951aa815c763fc9441aa452c763294715/rules/utilities/is-node-matches.js
+// Copied from https://github.com/sindresorhus/eslint-plugin-unicorn/blob/d53d935951aa815c763fc9441aa452c763294715/rules/utils/is-node-matches.js
 
 /**
  * @import {Node} from "../types/estree.js"

--- a/website/plugins/llms-txt-plugin.mjs
+++ b/website/plugins/llms-txt-plugin.mjs
@@ -1,5 +1,5 @@
 // https://github.com/facebook/docusaurus/issues/10899
-// https://github.com/defi-wonderland/handbook/blob/dev/plugins/llmsTxtPlugin.ts
+// https://github.com/defi-wonderland/handbook/blob/dev/packages/common-config/plugins/llmsTxtPlugin.ts
 import fs from "node:fs/promises";
 import path from "node:path";
 


### PR DESCRIPTION
## Problem

Three source comments link to upstream files that no longer exist at the linked location, and all three links return 404:

1. `src/config/resolve-config.js` line 130 credits `pathMatchesGlobs` as "Based on ESLint" and links to `https://github.com/eslint/eslint/blob/master/lib/config/config-ops.js`. ESLint removed `lib/config/config-ops.js` long ago (the file only exists in eslint v5 and earlier; eslint v6 moved the remnant to `lib/shared/`, and v9+ has no config-ops at all). The function `pathMatchesGlobs` with the matching semantics last exists in eslint v5.16.0.

2. `src/language-js/utilities/is-node-matches.js` line 1 says "Copied from" `https://github.com/sindresorhus/eslint-plugin-unicorn/blob/d53d935951aa815c763fc9441aa452c763294715/rules/utilities/is-node-matches.js`. The eslint-plugin-unicorn repo restructured `rules/utilities/` into `rules/utils/`, so the pinned-commit path 404s. The same commit with the `rules/utils/` path resolves (HTTP 200) and contains the file this code was copied from.

3. `website/plugins/llms-txt-plugin.mjs` line 2 credits `https://github.com/defi-wonderland/handbook/blob/dev/plugins/llmsTxtPlugin.ts`. The handbook repo moved the plugin into `packages/common-config/plugins/`, so the old path 404s. The file now lives at `packages/common-config/plugins/llmsTxtPlugin.ts` (HTTP 200).

## Solution

Update the three comment links to the verified locations:

1. Pin the ESLint credit link to the last release that contains `pathMatchesGlobs` in `lib/config/config-ops.js`: `https://github.com/eslint/eslint/blob/v5.16.0/lib/config/config-ops.js`
2. `rules/utilities/` to `rules/utils/` at the same pinned commit
3. `plugins/` to `packages/common-config/plugins/`

## Verification

All old links verified as HTTP 404 and all new links verified as HTTP 200 with `curl -L` (following redirects):

- old 1: 404 / new 1: 200
- old 2: 404 / new 2: 200
- old 3: 404 / new 3: 200

Comments only; no runtime code changed.
