### PR TITLE
Keep the indent level after an inline comment in a value group

### DIFF
--- a/changelog_unreleased/scss/19874.md
+++ b/changelog_unreleased/scss/19874.md
@@ -1,0 +1,35 @@
+#### Keep the indent level after an inline comment in a value group (#19874 by @Kjubikstronk)
+
+An inline comment inside a function's arguments left everything after it indented one level too deep, and the closing parentheses unwound from the wrong depth.
+
+<!-- prettier-ignore -->
+```scss
+// Input
+.foo {
+  width: pow(2, pow(2, pow(2,
+  // THIS
+  pow(2, pow(2, pow(2, 2))))));
+}
+
+// Prettier stable
+        // THIS
+        pow(
+            2,
+            pow(
+              2,
+              pow(2, 2)
+            )
+          )
+      )
+
+// Prettier main
+        // THIS
+        pow(
+          2,
+          pow(
+            2,
+            pow(2, 2)
+          )
+        )
+      )
+```

--- a/src/language-css/print/comma-separated-value-group.js
+++ b/src/language-css/print/comma-separated-value-group.js
@@ -433,10 +433,6 @@ function printCommaSeparatedValueGroup(path, options, print) {
 
     // Add `hardline` after inline comment (i.e. `// comment\n foo: bar;`)
     if (isInlineValueCommentNode(iNode)) {
-      if (parentNode.type === "value-paren_group") {
-        parts.push(dedent(hardline), "");
-        continue;
-      }
       parts.push(hardline, "");
       continue;
     }
@@ -587,6 +583,12 @@ function printCommaSeparatedValueGroup(path, options, print) {
   // when type is value-comma_group
   // example @import url("verylongurl") projection,tv
   if (insideURLFunctionInImportAtRuleNode(path)) {
+    return group(fill(parts));
+  }
+
+  // A paren group indents its own contents, so another level here would nest
+  // everything after the comment one step too deep.
+  if (hasInlineComment && parentNode.type === "value-paren_group") {
     return group(fill(parts));
   }
 

--- a/tests/format/scss/comments/19427.scss
+++ b/tests/format/scss/comments/19427.scss
@@ -1,0 +1,11 @@
+.foo {
+  width: someVeryLongFunctionNameForJustAPow(2, someVeryLongFunctionNameForJustAPow(2, someVeryLongFunctionNameForJustAPow(2,
+  // THIS
+  someVeryLongFunctionNameForJustAPow(2, someVeryLongFunctionNameForJustAPow(2, someVeryLongFunctionNameForJustAPow(2, 2))))));
+}
+
+.bar {
+  margin: fn(1,
+  // leading comment
+  2, 3);
+}

--- a/tests/format/scss/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/scss/comments/__snapshots__/format.test.js.snap
@@ -138,6 +138,8 @@ parsers: ["scss"]
         2,
         // This next pow is really powerful
         someVeryLongFunctionNameForJustAPow(
+          2,
+          someVeryLongFunctionNameForJustAPow(
             2,
             someVeryLongFunctionNameForJustAPow(
               2,
@@ -151,10 +153,7 @@ parsers: ["scss"]
                       2,
                       someVeryLongFunctionNameForJustAPow(
                         2,
-                        someVeryLongFunctionNameForJustAPow(
-                          2,
-                          someVeryLongFunctionNameForJustAPow(2, 2)
-                        )
+                        someVeryLongFunctionNameForJustAPow(2, 2)
                       )
                     )
                   )
@@ -162,6 +161,7 @@ parsers: ["scss"]
               )
             )
           )
+        )
       )
     )
   );
@@ -176,9 +176,9 @@ parsers: ["scss"]
         2,
         // This next pow is really powerful
         pow(
-            2,
-            pow(2, pow(2, pow(2, pow(2, pow(2, pow(2, pow(2, pow(2, 2))))))))
-          )
+          2,
+          pow(2, pow(2, pow(2, pow(2, pow(2, pow(2, pow(2, pow(2, 2))))))))
+        )
       )
     )
   );
@@ -208,6 +208,56 @@ $blah: (
   "b": 43,
   "c": 44,
 );
+
+================================================================================
+`;
+
+exports[`19427.scss format 1`] = `
+====================================options=====================================
+parsers: ["scss"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+.foo {
+  width: someVeryLongFunctionNameForJustAPow(2, someVeryLongFunctionNameForJustAPow(2, someVeryLongFunctionNameForJustAPow(2,
+  // THIS
+  someVeryLongFunctionNameForJustAPow(2, someVeryLongFunctionNameForJustAPow(2, someVeryLongFunctionNameForJustAPow(2, 2))))));
+}
+
+.bar {
+  margin: fn(1,
+  // leading comment
+  2, 3);
+}
+
+=====================================output=====================================
+.foo {
+  width: someVeryLongFunctionNameForJustAPow(
+    2,
+    someVeryLongFunctionNameForJustAPow(
+      2,
+      someVeryLongFunctionNameForJustAPow(
+        2,
+        // THIS
+        someVeryLongFunctionNameForJustAPow(
+          2,
+          someVeryLongFunctionNameForJustAPow(
+            2,
+            someVeryLongFunctionNameForJustAPow(2, 2)
+          )
+        )
+      )
+    )
+  );
+}
+
+.bar {
+  margin: fn(
+    1,
+    // leading comment
+    2,
+    3
+  );
+}
 
 ================================================================================
 `;


### PR DESCRIPTION
Fixes #19427.

## Description

An inline comment inside a function's arguments pushed everything after it one indent level too deep, and left the closing parens asymmetric:

<!-- prettier-ignore -->
```scss
<!-- Input -->
.foo {
  width: pow(2, pow(2, pow(2,
  // THIS
  pow(2, pow(2, pow(2, 2))))));
}

<!-- Prettier stable -->
        // THIS
        pow(
            2,
            pow(
              2,
              pow(2, 2)
            )
          )
      )

<!-- Prettier main -->
        // THIS
        pow(
          2,
          pow(
            2,
            pow(2, 2)
          )
        )
      )
```

Without the comment the same value indents in clean steps of two and closes symmetrically; the comment is the only difference.

## Cause

A `value-comma_group` returns `group(indent(fill(parts)))`, and when it sits inside a paren group that paren group indents as well. That double indent was being compensated by dedenting the single line break after the comment:

```js
if (isInlineValueCommentNode(iNode)) {
  if (parentNode.type === "value-paren_group") {
    parts.push(dedent(hardline), "");
    continue;
  }
```

That fixes the comment's own line, which is why the comment looks right, but the extra level is still open for everything after it — so the following argument and every nested call inside it are shifted, and the closing parens unwind from the wrong depth.

The comma group only exists here because of the comment: without one, the arguments are printed directly by the paren group with no wrapper.

## Change

Drop the group's own indent when it holds an inline comment and its parent already indents, instead of dedenting one line inside it:

```js
if (hasInlineComment && parentNode.type === "value-paren_group") {
  return group(fill(parts));
}
```

The `dedent(hardline)` special case goes away with it, since the level it was compensating for is no longer added.

## Tests

`tests/format/scss/comments/19427.scss` covers the reported input plus a comment before a plain argument.

One existing snapshot changed, `4878.scss`, which covers this same construct. It was recording the bug — the old output stepped `8 → 12` across the comment and closed at mismatched depths, the new one steps `8 → 10 → 12` and closes symmetrically. Worth a look in the diff to confirm you agree it is the improvement it looks like.

- `tests/format/{css,scss,less}`: 559 tests, 545 snapshots — only that one snapshot changed.
- Checked by hand that a comment before a plain argument, two comments at different depths, block comments, comments outside parens, and SCSS maps are all unaffected, and that each result is idempotent.
- Full suite: 34542 passed. The failures are pre-existing on `main` — three `jsx` suites and `patterns-dirs.js` fail identically with this change stashed, and `cache.js` passes standalone both with and without it (65.9s vs 65.8s), only timing out under full-suite parallel load.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

To be explicit rather than leaving it to an unticked box: this PR was written with AI assistance, and reviewed before submitting.

