### PR TITLE
Ignore Sass flags inside quoted strings

### DIFF
--- a/changelog_unreleased/scss/19875.md
+++ b/changelog_unreleased/scss/19875.md
@@ -1,0 +1,18 @@
+#### Ignore Sass flags inside quoted strings (#19875 by @Kjubikstronk)
+
+`!default` and `!global` were matched anywhere in a declaration value, so one inside a string was treated as a flag and the string was reprinted with a space in it.
+
+<!-- prettier-ignore -->
+```scss
+// Input
+$a: "!default";
+$c: url("x!global");
+
+// Prettier stable
+$a: " !default";
+$c: url("x !global");
+
+// Prettier main
+$a: "!default";
+$c: url("x!global");
+```

--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -19,8 +19,42 @@ import { hasIgnorePragma, hasPragma } from "./pragma.js";
 import isModuleRuleName from "./utilities/is-module-rule-name.js";
 import isScssNestedPropertyNode from "./utilities/is-scss-nested-property-node.js";
 
-const DEFAULT_SCSS_DIRECTIVE = /(\s*)(!default).*$/;
-const GLOBAL_SCSS_DIRECTIVE = /(\s*)(!global).*$/;
+// A Sass flag follows the value, so it only counts outside a quoted span --
+// `$a: "!default"` is a string, not a flagged declaration.
+function findScssDirective(value, directive) {
+  let quote;
+  let index = -1;
+
+  for (let i = 0; i < value.length; i++) {
+    const character = value[i];
+
+    if (quote) {
+      if (character === "\\") {
+        i++;
+      } else if (character === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+
+    if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === "!" && value.startsWith(directive, i)) {
+      index = i;
+    }
+  }
+
+  if (index === -1) {
+    return null;
+  }
+
+  let start = index;
+  while (start > 0 && /\s/u.test(value[start - 1])) {
+    start--;
+  }
+
+  return { index: start, text: value.slice(start) };
+}
 
 function parseNestedCSS(node, options) {
   if (isObject(node)) {
@@ -163,25 +197,25 @@ function parseNestedCSS(node, options) {
     }
 
     if (value.trim().length > 0) {
-      const defaultSCSSDirectiveIndex = value.match(DEFAULT_SCSS_DIRECTIVE);
+      const defaultSCSSDirective = findScssDirective(value, "!default");
 
-      if (defaultSCSSDirectiveIndex) {
-        value = value.slice(0, defaultSCSSDirectiveIndex.index);
+      if (defaultSCSSDirective) {
+        value = value.slice(0, defaultSCSSDirective.index);
         node.scssDefault = true;
 
-        if (defaultSCSSDirectiveIndex[0].trim() !== "!default") {
-          node.raws.scssDefault = defaultSCSSDirectiveIndex[0];
+        if (defaultSCSSDirective.text.trim() !== "!default") {
+          node.raws.scssDefault = defaultSCSSDirective.text;
         }
       }
 
-      const globalSCSSDirectiveIndex = value.match(GLOBAL_SCSS_DIRECTIVE);
+      const globalSCSSDirective = findScssDirective(value, "!global");
 
-      if (globalSCSSDirectiveIndex) {
-        value = value.slice(0, globalSCSSDirectiveIndex.index);
+      if (globalSCSSDirective) {
+        value = value.slice(0, globalSCSSDirective.index);
         node.scssGlobal = true;
 
-        if (globalSCSSDirectiveIndex[0].trim() !== "!global") {
-          node.raws.scssGlobal = globalSCSSDirectiveIndex[0];
+        if (globalSCSSDirective.text.trim() !== "!global") {
+          node.raws.scssGlobal = globalSCSSDirective.text;
         }
       }
 

--- a/tests/format/scss/flag/19203.scss
+++ b/tests/format/scss/flag/19203.scss
@@ -1,0 +1,9 @@
+$a: "!default";
+$b: unquote("!default");
+$c: url("x!global");
+$d: 'single !default';
+$e: "it's !default" !default;
+$f: "a" !default;
+$g: 1px !default;
+$h: 1px !global;
+$i: "escaped \" !default";

--- a/tests/format/scss/flag/__snapshots__/format.test.js.snap
+++ b/tests/format/scss/flag/__snapshots__/format.test.js.snap
@@ -83,3 +83,63 @@ $global: "very-long-long-long-long-long-long-long-long-long-long-long-value" !gl
 
 ================================================================================
 `;
+
+exports[`19203.scss - {"trailingComma":"es5"} format 1`] = `
+====================================options=====================================
+parsers: ["scss"]
+trailingComma: "es5"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+$a: "!default";
+$b: unquote("!default");
+$c: url("x!global");
+$d: 'single !default';
+$e: "it's !default" !default;
+$f: "a" !default;
+$g: 1px !default;
+$h: 1px !global;
+$i: "escaped \\" !default";
+
+=====================================output=====================================
+$a: "!default";
+$b: unquote("!default");
+$c: url("x!global");
+$d: "single !default";
+$e: "it's !default" !default;
+$f: "a" !default;
+$g: 1px !default;
+$h: 1px !global;
+$i: 'escaped " !default';
+
+================================================================================
+`;
+
+exports[`19203.scss - {"trailingComma":"none"} format 1`] = `
+====================================options=====================================
+parsers: ["scss"]
+trailingComma: "none"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+$a: "!default";
+$b: unquote("!default");
+$c: url("x!global");
+$d: 'single !default';
+$e: "it's !default" !default;
+$f: "a" !default;
+$g: 1px !default;
+$h: 1px !global;
+$i: "escaped \\" !default";
+
+=====================================output=====================================
+$a: "!default";
+$b: unquote("!default");
+$c: url("x!global");
+$d: "single !default";
+$e: "it's !default" !default;
+$f: "a" !default;
+$g: 1px !default;
+$h: 1px !global;
+$i: 'escaped " !default';
+
+================================================================================
+`;


### PR DESCRIPTION
Fixes #19203.

## Description

`!default` and `!global` were matched anywhere in a declaration value, so they were picked up inside strings and the value was reprinted with the flag's normalising space in it:

<!-- prettier-ignore -->
```scss
<!-- Input -->
$a: "!default";
$b: unquote("!default");
$c: url("x!global");

<!-- Prettier stable -->
$a: " !default";
$b: unquote(" !default");
$c: url("x !global");

<!-- Prettier main -->
$a: "!default";
$b: unquote("!default");
$c: url("x!global");
```

`url("x !global")` is the one that actually breaks something — the URL no longer resolves.

## Cause

`DEFAULT_SCSS_DIRECTIVE` / `GLOBAL_SCSS_DIRECTIVE` are plain regexes over the raw value:

```js
const DEFAULT_SCSS_DIRECTIVE = /(\s*)(!default).*$/;
```

For `$a: "!default"` that matches at index 1, so the value is truncated to the opening quote and `scssDefault` is set. The printer then appends ` !default`, and the string has gained a space.

## Change

Replaced both regexes with a scan that tracks quote state and only accepts a flag outside a quoted span. A Sass flag always follows the value, so the last unquoted match wins, and the surrounding whitespace is captured the same way the regex did to keep `node.raws` behaviour unchanged.

## Tests

`tests/format/scss/flag/19203.scss` covers both flags inside double and single quotes, inside `unquote()` and `url()`, a string containing a flag followed by a real flag, an escaped quote inside the string, and plain flagged declarations.

`tests/format/{css,scss,less}`: 559 tests, 545 snapshots, none changed — no existing fixture relied on the old behaviour.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

This PR was written with AI assistance, and reviewed before submitting.

