### PR TITLE
Keep a comment between the switch discriminant and its body

### DIFF
--- a/changelog_unreleased/javascript/19876.md
+++ b/changelog_unreleased/javascript/19876.md
@@ -1,0 +1,15 @@
+#### Keep a comment between the switch discriminant and its body (#19876 by @Kjubikstronk)
+
+A comment written after the `)` was pulled inside the parentheses, which also forced the discriminant to break. Every other block statement leaves it where it was written.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+switch (a) /*c*/{}
+
+// Prettier stable
+switch (a /*c*/) {}
+
+// Prettier main
+switch (a) /*c*/ {}
+```

--- a/src/language-js/comments/attach/handle-switch-statement-comments.js
+++ b/src/language-js/comments/attach/handle-switch-statement-comments.js
@@ -16,12 +16,10 @@ function handleSwitchStatementComments({
   followingNode,
   text,
 }) {
-  if (!(
-    enclosingNode?.type === "SwitchStatement" &&
-    enclosingNode.cases.length === 0 &&
-    !followingNode &&
-    precedingNode === enclosingNode.discriminant
-  )) {
+  if (
+    enclosingNode?.type !== "SwitchStatement" ||
+    precedingNode !== enclosingNode.discriminant
+  ) {
     return false;
   }
 
@@ -30,7 +28,19 @@ function handleSwitchStatementComments({
     locEnd(comment),
   );
 
-  if (nextCharacter === "}") {
+  // Between the discriminant and the body, where every other block statement
+  // keeps it: `switch (a) /* comment */ {`. Without this the comment attaches
+  // to the discriminant and is printed inside the parentheses.
+  if (nextCharacter === "{") {
+    addDanglingComment(enclosingNode, comment, "body");
+    return true;
+  }
+
+  if (
+    nextCharacter === "}" &&
+    enclosingNode.cases.length === 0 &&
+    !followingNode
+  ) {
     addDanglingComment(enclosingNode, comment);
     return true;
   }

--- a/src/language-js/print/switch-statement.js
+++ b/src/language-js/print/switch-statement.js
@@ -6,21 +6,37 @@ import {
   softline,
 } from "../../document/index.js";
 import { printDanglingComments } from "../../main/comments/print.js";
+import hasNewline from "../../utilities/has-newline.js";
+import hasNewlineInRange from "../../utilities/has-newline-in-range.js";
+import { locEnd, locStart } from "../location/index.js";
 import { isLineComment } from "../utilities/comment-types.js";
-import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
+import {
+  CommentCheckFlags,
+  getComments,
+  hasComment,
+} from "../utilities/comments.js";
 import { isNextLineEmpty } from "../utilities/is-next-line-empty.js";
 import { printStatementSequence } from "./statement-sequence.js";
 
 function printSwitchStatement(path, options, print) {
-  const commentsBeforeBody = printDanglingComments(path, options, {
-    marker: "body",
-  });
-  // A line comment would otherwise swallow the brace that follows it.
-  const bodyOnNextLine = hasComment(
+  const bodyComments = getComments(
     path.node,
     CommentCheckFlags.Dangling,
-    (comment) => comment.marker === "body" && isLineComment(comment),
+    (comment) => comment.marker === "body",
   );
+  const [firstBodyComment] = bodyComments;
+  const text = options.originalText;
+  // Same condition `printClause` uses for the other block statements.
+  const bodyCommentOnOwnLine =
+    firstBodyComment &&
+    (hasNewlineInRange(
+      text,
+      locStart(firstBodyComment),
+      locEnd(firstBodyComment),
+    ) ||
+      hasNewline(text, locStart(firstBodyComment), { backwards: true }));
+  // A line comment would otherwise swallow the brace that follows it.
+  const bodyOnNextLine = bodyComments.some((comment) => isLineComment(comment));
 
   return [
     group([
@@ -29,8 +45,12 @@ function printSwitchStatement(path, options, print) {
       softline,
       ")",
     ]),
-    commentsBeforeBody
-      ? [" ", commentsBeforeBody, bodyOnNextLine ? hardline : " "]
+    firstBodyComment
+      ? [
+          bodyCommentOnOwnLine ? hardline : " ",
+          printDanglingComments(path, options, { marker: "body" }),
+          bodyOnNextLine ? hardline : " ",
+        ]
       : " ",
     "{",
     path.node.cases.length > 0

--- a/src/language-js/print/switch-statement.js
+++ b/src/language-js/print/switch-statement.js
@@ -6,11 +6,20 @@ import {
   softline,
 } from "../../document/index.js";
 import { printDanglingComments } from "../../main/comments/print.js";
+import { isLineComment } from "../utilities/comment-types.js";
 import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
 import { isNextLineEmpty } from "../utilities/is-next-line-empty.js";
 import { printStatementSequence } from "./statement-sequence.js";
 
 function printSwitchStatement(path, options, print) {
+  const commentsBeforeBody = printDanglingComments(path, options, {
+    marker: "body",
+  });
+  // A line comment would otherwise swallow the brace that follows it.
+  const bodyOnNextLine = path.node.comments?.some(
+    (comment) => comment.marker === "body" && isLineComment(comment),
+  );
+
   return [
     group([
       "switch (",
@@ -18,7 +27,10 @@ function printSwitchStatement(path, options, print) {
       softline,
       ")",
     ]),
-    " {",
+    commentsBeforeBody
+      ? [" ", commentsBeforeBody, bodyOnNextLine ? hardline : " "]
+      : " ",
+    "{",
     path.node.cases.length > 0
       ? indent([
           hardline,

--- a/src/language-js/print/switch-statement.js
+++ b/src/language-js/print/switch-statement.js
@@ -16,7 +16,9 @@ function printSwitchStatement(path, options, print) {
     marker: "body",
   });
   // A line comment would otherwise swallow the brace that follows it.
-  const bodyOnNextLine = path.node.comments?.some(
+  const bodyOnNextLine = hasComment(
+    path.node,
+    CommentCheckFlags.Dangling,
     (comment) => comment.marker === "body" && isLineComment(comment),
   );
 

--- a/tests/format/js/comments/while-like/__snapshots__/format.test.js.snap
+++ b/tests/format/js/comments/while-like/__snapshots__/format.test.js.snap
@@ -149,7 +149,8 @@ switch (true) // 2
 {
 }
 
-switch (true) // 22
+switch (true)
+// 22
 {
 }
 

--- a/tests/format/js/comments/while-like/__snapshots__/format.test.js.snap
+++ b/tests/format/js/comments/while-like/__snapshots__/format.test.js.snap
@@ -145,21 +145,18 @@ switch (
 ) {
 }
 
-switch (
-  true // 2
-) {
+switch (true) // 2
+{
 }
 
-switch (
-  true
-  // 22
-) {
+switch (true) // 22
+{
 }
 
 switch (true) {
 } // 3
 
-switch (true /*4*/) {
+switch (true) /*4*/ {
 }
 
 switch (


### PR DESCRIPTION
Fixes #19582.

`switch` moves a comment that sits between `)` and `{` inside the parentheses. Every other block statement leaves it alone:

<!-- prettier-ignore -->
```jsx
// Input
if (a) /*c*/{}
while (a) /*c*/{}
switch (a) /*c*/{}

// Prettier stable
if (a) /*c*/ {}
while (a) /*c*/ {}
switch (a /*c*/) {}

// Prettier main
if (a) /*c*/ {}
while (a) /*c*/ {}
switch (a) /*c*/ {}
```

`for`, `for…of`, `try` and function bodies all behave like `if` here, so `switch` was the only one out of step.

`handleSwitchStatementComments` only claimed a comment when the next character was `}` — the empty-body case. With `{` following, nothing claimed it, so it became a trailing comment of the discriminant. It now attaches as a dangling comment with a `body` marker, and the printer emits it between the `)` and the `{`.

Line comments need the brace on the next line or they swallow it, which is what `if` already does:

```js
switch (true) // 2
{
}
```

One existing snapshot changed, `js/comments/while-like/switch.js`. It was recording the old behaviour, including the discriminant being forced to break to make room for the comment:

```diff
- switch (
-   true // 2
- ) {
+ switch (true) // 2
+ {
```

`tests/format/js` and `tests/format/typescript`: 25162 passed. The three failing `jsx` suites fail identically with this change stashed.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

This PR was written with AI assistance, and reviewed before submitting.

