### PR TITLE
Strip blockquote markers from a setext heading's continuation lines

### DIFF
--- a/changelog_unreleased/markdown/19878.md
+++ b/changelog_unreleased/markdown/19878.md
@@ -1,0 +1,20 @@
+#### Strip blockquote markers from a setext heading's continuation lines (#19878 by @Kjubikstronk)
+
+A setext heading spanning multiple lines inside a blockquote kept the `>` marker of its continuation lines as literal text.
+
+<!-- prettier-ignore -->
+```md
+<!-- Input -->
+> Multi
+> Line
+> ===
+
+<!-- Prettier stable -->
+> Multi > Line
+> ===
+
+<!-- Prettier main -->
+> Multi
+> Line
+> ===
+```

--- a/src/language-markdown/print/preprocess.js
+++ b/src/language-markdown/print/preprocess.js
@@ -183,8 +183,11 @@ function splitTextIntoSentences(ast) {
     // Using `node.value`, we don't need to care about markers like `\n > ` in `blockquote`s.
     let text = node.raw;
 
+    // A setext heading's text can span multiple raw source lines too, e.g.
+    // `> Title\n> continued\n> ===`.
     const paragraphIndex = parentStack.findIndex(
-      (ancestor) => ancestor?.type === "paragraph",
+      (ancestor) =>
+        ancestor?.type === "paragraph" || ancestor?.type === "heading",
     );
 
     const paragraphNode =

--- a/tests/format/markdown/heading/setext/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/heading/setext/__snapshots__/format.test.js.snap
@@ -1,5 +1,40 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`blockquote.md format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+> Multi
+> Line
+> ===
+
+> Multi
+> Line
+> Three
+> ---
+
+> > Multi
+> > Line
+> > ===
+
+=====================================output=====================================
+> Multi
+> Line
+> ===
+
+> Multi
+> Line
+> Three
+> ---
+
+> > Multi
+> > Line
+> > ===
+
+================================================================================
+`;
+
 exports[`child.md format 1`] = `
 ====================================options=====================================
 parsers: ["markdown"]

--- a/tests/format/markdown/heading/setext/blockquote.md
+++ b/tests/format/markdown/heading/setext/blockquote.md
@@ -1,0 +1,12 @@
+> Multi
+> Line
+> ===
+
+> Multi
+> Line
+> Three
+> ---
+
+> > Multi
+> > Line
+> > ===


### PR DESCRIPTION
## Description

A setext heading whose text spans multiple lines inside a blockquote loses the continuation lines' `>` markers into the printed text instead of stripping them:

<!-- prettier-ignore -->
```md
<!-- Input -->
> Multi
> Line
> ===

<!-- Prettier stable -->
> Multi > Line
> ===

<!-- Prettier main -->
> Multi
> Line
> ===
```

Found this while working on #19847; the output is stable, so it wouldn't show up as an idempotency problem, but it changes what the blockquote renders as — the `>` becomes part of the heading text.

## Cause

`getBlockquoteRawText`, which strips the leading `>` markers a multi-line raw text node picks up from its continuation lines inside a blockquote, is only invoked when the text node has a `paragraph` ancestor. A setext heading's text node sits under `heading`, not `paragraph`, so the check never runs and the marker survives as a literal `>` character. `splitText` then treats it as its own word, and `shouldPreventBreak` in the whitespace printer suppresses the line break before it (a leading `>` can otherwise start a new blockquote on reformat), which is why the two lines collapse onto one with a bare `>` in between.

## Change

One line: the ancestor search that gates `getBlockquoteRawText` now also matches `heading`. ATX headings can't span multiple raw lines in CommonMark, so this only changes behavior for setext ones.

## Tests

`tests/format/markdown/heading/setext/blockquote.md`, covering a two-line and three-line setext heading and one nested a level deeper. Checked meaning is preserved by parsing input and output back to an AST and comparing, over 105 generated combinations of heading line count/content, underline character, and blockquote nesting depth (plain, single, and nested) — no instability, no case where the parsed tree changed.

`tests/format/{markdown,mdx}`: 1512 tests, 1501 snapshots, only the new fixture added. Full suite unchanged against a stashed tree — same four failing suites either way.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

This PR was written with AI assistance, and reviewed before submitting. Changelog entry will follow once this has a PR number.
