### PR TITLE
docs: point CONTRIBUTING at the current run-format-test.js path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ If the list includes `babel`, and the current directory is inside `tests/format/
 
 In addition to Prettier's formatting options, can contain the `errors` property to specify that it's expected that the formatting shouldn't be successful and an error should be thrown for all (`errors: true`) or some combinations of input entries and parsers.
 
-The implementation of `runFormatTest` can be found in [`tests/config/run-format-test.js`](tests/config/run-format-test.js).
+The implementation of `runFormatTest` can be found in [`tests/config/format-test/run-format-test.js`](tests/config/format-test/run-format-test.js).
 
 `tests/format/flow/flow-repo/` contains the Flow test suite and is not supposed to be edited by hand. To update it, clone the Flow repo next to the Prettier repo and run: `node scripts/sync-flow-tests.cjs ../flow/tests/`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ If the list includes `babel`, and the current directory is inside `tests/format/
 
 In addition to Prettier's formatting options, can contain the `errors` property to specify that it's expected that the formatting shouldn't be successful and an error should be thrown for all (`errors: true`) or some combinations of input entries and parsers.
 
-The implementation of `runFormatTest` can be found in [`tests/config/format-test/run-format-test.js`](tests/config/format-test/run-format-test.js).
+The implementation of `runFormatTest` can be found in [`tests/config/format-test/run-format-test.js`](tests/config/format-test/index.js).
 
 `tests/format/flow/flow-repo/` contains the Flow test suite and is not supposed to be edited by hand. To update it, clone the Flow repo next to the Prettier repo and run: `node scripts/sync-flow-tests.cjs ../flow/tests/`.
 


### PR DESCRIPTION
`CONTRIBUTING.md:76` links to `tests/config/run-format-test.js`, deleted in `8fc02d367` (*"Refactor format test (#18747)"*). As a markdown link, it 404s.

`runFormatTest` moved:

- defined at `tests/config/format-test/run-format-test.js:38`
- re-exported from `tests/config/format-test/index.js:1`

Updates the link text and target. No prose changes.

### Checklist

- [ ] I've added tests to confirm my change works. *(n/a: documentation link)*
- [ ] (If changing the API or CLI) I've documented the changes I've made. *(n/a)*
- [ ] (If the change is user-facing) I've added my changes to `changelog_unreleased/`. *(n/a: contributor docs)*
- [x] I've read the contributing guidelines.
- [ ] I did *not* use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

Found by a documentation checker, confirmed against `git log`, reviewed before submitting.
