### PR TITLE
Fix unstable assignment when a member chain object has a leading comment

### DIFF
--- a/changelog_unreleased/typescript/19882.md
+++ b/changelog_unreleased/typescript/19882.md
@@ -1,0 +1,26 @@
+#### Fix unstable assignment when a member chain object has a leading comment (#19882 by @Kjubikstronk)
+
+<!-- prettier-ignore -->
+```ts
+// Input
+const generate = (
+  // @ts-expect-error requireOutside Babel transform
+  requireOutside("@babel/generator") as typeof import("@babel/generator")
+).default;
+
+// Prettier stable (first format)
+const generate = // @ts-expect-error requireOutside Babel transform
+(requireOutside("@babel/generator") as typeof import("@babel/generator"))
+  .default;
+
+// Prettier stable (second format)
+const generate = // @ts-expect-error requireOutside Babel transform
+  (requireOutside("@babel/generator") as typeof import("@babel/generator"))
+    .default;
+
+// Prettier main
+const generate =
+  // @ts-expect-error requireOutside Babel transform
+  (requireOutside("@babel/generator") as typeof import("@babel/generator"))
+    .default;
+```

--- a/src/language-js/print/assignment.js
+++ b/src/language-js/print/assignment.js
@@ -140,7 +140,7 @@ function chooseLayout(path, options, print, leftDoc, rightPropertyName) {
   if (
     isHeadOfLongChain ||
     (isUnionType(rightNode) && !shouldHugUnionType(rightNode)) ||
-    hasLeadingOwnLineComment(options.originalText, rightNode) ||
+    startsWithOwnLineComment(options.originalText, rightNode) ||
     hasComment(rightNode, CommentCheckFlags.Leading, isIndentableBlockComment)
   ) {
     return "break-after-operator";
@@ -195,6 +195,26 @@ function chooseLayout(path, options, print, leftDoc, rightPropertyName) {
   }
 
   return "fluid";
+}
+
+/**
+ * A comment on the object of a member chain is printed before the whole chain, so
+ * the assignment has to break as if the comment led the right-hand side itself.
+ * Otherwise the next format sees a comment that does lead it and picks a different
+ * layout, and the output never settles.
+ */
+function startsWithOwnLineComment(text, node) {
+  for (
+    let current = node;
+    current;
+    current = isMemberExpression(current) ? current.object : undefined
+  ) {
+    if (hasLeadingOwnLineComment(text, current)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function shouldBreakAfterOperator(path, options, print, hasShortKey) {

--- a/tests/config/format-test/failed-format-tests.js
+++ b/tests/config/format-test/failed-format-tests.js
@@ -18,7 +18,6 @@ const unstableTests = new Map(
     "flow/hook/hook-type-annotation.js",
     "flow/comments/type_annotations.js",
     "typescript/prettier-ignore/mapped-types.ts",
-    "typescript/prettier-ignore/issue-14238.ts",
     "js/for-of/comments.js",
     "js/sequence-expression/parenthesized.js",
     "typescript/satisfies-operators/comments-unstable.ts",

--- a/tests/format/typescript/comments/10851.ts
+++ b/tests/format/typescript/comments/10851.ts
@@ -1,0 +1,26 @@
+const generate = (
+  // @ts-expect-error requireOutside Babel transform
+  requireOutside('@babel/generator') as typeof import('@babel/generator')
+).default;
+
+const asExpression = (
+  // comment
+  a as T
+).b;
+
+const logicalExpression = (
+  // comment
+  a || b
+).c;
+
+const deepMemberChain = (
+  // comment
+  a as T
+).b.c.d;
+
+async function awaitExpression() {
+  return (
+    // comment
+    await a
+  ).b;
+}

--- a/tests/format/typescript/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/comments/__snapshots__/format.test.js.snap
@@ -69,6 +69,66 @@ type D2 =
 ================================================================================
 `;
 
+exports[`10851.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+const generate = (
+  // @ts-expect-error requireOutside Babel transform
+  requireOutside('@babel/generator') as typeof import('@babel/generator')
+).default;
+
+const asExpression = (
+  // comment
+  a as T
+).b;
+
+const logicalExpression = (
+  // comment
+  a || b
+).c;
+
+const deepMemberChain = (
+  // comment
+  a as T
+).b.c.d;
+
+async function awaitExpression() {
+  return (
+    // comment
+    await a
+  ).b;
+}
+
+=====================================output=====================================
+const generate =
+  // @ts-expect-error requireOutside Babel transform
+  (requireOutside("@babel/generator") as typeof import("@babel/generator"))
+    .default;
+
+const asExpression =
+  // comment
+  (a as T).b;
+
+const logicalExpression =
+  // comment
+  (a || b).c;
+
+const deepMemberChain =
+  // comment
+  (a as T).b.c.d;
+
+async function awaitExpression() {
+  return (
+    // comment
+    (await a).b
+  );
+}
+
+================================================================================
+`;
+
 exports[`11662.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/prettier-ignore/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/prettier-ignore/__snapshots__/format.test.js.snap
@@ -11,8 +11,9 @@ export const foo = (
 ).qux;
 
 =====================================output=====================================
-export const foo = // prettier-ignore
-(bar as Baz).qux;
+export const foo =
+  // prettier-ignore
+  (bar as Baz).qux;
 
 ================================================================================
 `;


### PR DESCRIPTION
## Description

Fixes #10851.

A comment on the object of a member chain is printed before the whole chain, because the printer adds the parentheses and `printComments` then wraps the result:

```ts
const generate = (
  // @ts-expect-error requireOutside Babel transform
  requireOutside("@babel/generator") as typeof import("@babel/generator")
).default;
```

After one format the comment leads the right-hand side, which is a state the original source was not in:

```ts
const generate = // @ts-expect-error requireOutside Babel transform
(requireOutside("@babel/generator") as typeof import("@babel/generator"))
  .default;
```

So the second format takes a different branch — `hasLeadingOwnLineComment` is now true, `chooseLayout` returns `break-after-operator`, and the value is indented. Two formats, two outputs.

`chooseLayout` now looks down the member chain for that comment, so the first format already produces what the second one would:

```ts
const generate =
  // @ts-expect-error requireOutside Babel transform
  (requireOutside("@babel/generator") as typeof import("@babel/generator"))
    .default;
```

This also puts the `@ts-expect-error` back above the line it suppresses, rather than leaving it stranded after the `=`.

The same shape shows up whenever the object needs parentheses — `as`, `await`, and binary expressions all reproduce it, and all three are covered in the fixture.

## Worth flagging

The one existing snapshot this changes, `typescript/prettier-ignore/issue-14238.ts`, was recording the unstable output:

```ts
export const foo = // prettier-ignore
(bar as Baz).qux;
```

Feeding that text back through `main` gives a different result, so that snapshot could not survive a second format either. It now records the stable form.

I did not touch the parenthesis/comment ordering in `ast-to-doc.js`, which is where the comment actually moves. That looked like a much larger change than the bug warranted, and this fix makes the output stable without it — but if you would rather see it solved there, say so and I will look.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
