### PR TITLE
Keep a trailing comment inside a for-in or for-of head

### DIFF
--- a/changelog_unreleased/javascript/19883.md
+++ b/changelog_unreleased/javascript/19883.md
@@ -1,0 +1,25 @@
+#### Keep a trailing comment inside a for-in or for-of head (#19883 by @Kjubikstronk)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+for (
+  let i of a // Hello
+) {
+}
+
+// Prettier stable (first format)
+for (let i of a) { // Hello
+}
+
+// Prettier stable (second format)
+for (let i of a) {
+  // Hello
+}
+
+// Prettier main
+for (
+  let i of a // Hello
+) {
+}
+```

--- a/src/language-js/print/for-x-statement.js
+++ b/src/language-js/print/for-x-statement.js
@@ -1,18 +1,28 @@
-import { group } from "../../document/index.js";
+import { group, indent, softline, willBreak } from "../../document/index.js";
 import { printForXStatementBody } from "./clause.js";
 
 function printForXStatement(path, options, print) {
   const { node } = path;
   const isForOfStatement = node.type === "ForOfStatement";
-  return group([
-    "for",
-    isForOfStatement && node.await ? " await" : "",
-    " (",
+  const headParts = [
     print("left"),
     " ",
     isForOfStatement ? "of" : "in",
     " ",
     print("right"),
+  ];
+
+  return group([
+    "for",
+    isForOfStatement && node.await ? " await" : "",
+    " (",
+    // Only make the head breakable when something in it forces a break, such as
+    // a trailing line comment. Left flat, that comment has nowhere to go and is
+    // printed after the closing parenthesis instead. Everything else keeps the
+    // flat head so a breaking argument can still hug it.
+    willBreak(headParts)
+      ? group([indent([softline, headParts]), softline])
+      : headParts,
     ")",
     printForXStatementBody(path, options, print),
   ]);

--- a/src/language-js/print/for-x-statement.js
+++ b/src/language-js/print/for-x-statement.js
@@ -1,5 +1,16 @@
-import { group, indent, softline, willBreak } from "../../document/index.js";
+import { group, indent, softline } from "../../document/index.js";
+import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
 import { printForXStatementBody } from "./clause.js";
+
+// A line comment on either side of the head has to be followed by a newline, so a flat head cannot
+// hold it and it ends up after the closing parenthesis instead. Comments nested deeper print inside
+// whatever holds them, so they leave the head alone.
+function headHasLineComment(node) {
+  return (
+    hasComment(node.left, CommentCheckFlags.Line) ||
+    hasComment(node.right, CommentCheckFlags.Line)
+  );
+}
 
 function printForXStatement(path, options, print) {
   const { node } = path;
@@ -16,11 +27,7 @@ function printForXStatement(path, options, print) {
     "for",
     isForOfStatement && node.await ? " await" : "",
     " (",
-    // Only make the head breakable when something in it forces a break, such as
-    // a trailing line comment. Left flat, that comment has nowhere to go and is
-    // printed after the closing parenthesis instead. Everything else keeps the
-    // flat head so a breaking argument can still hug it.
-    willBreak(headParts)
+    headHasLineComment(node)
       ? group([indent([softline, headParts]), softline])
       : headParts,
     ")",

--- a/tests/format/js/for-of/__snapshots__/format.test.js.snap
+++ b/tests/format/js/for-of/__snapshots__/format.test.js.snap
@@ -87,33 +87,106 @@ for(x of
 y);
 
 =====================================output=====================================
-for (x in /*1a*/ //1b
-y) //1c
+for (
+  x in /*1a*/ //1b
+  y
+) //1c
 ;
 
-for (x /*2a*/ in y); //2b //2c
+for (
+  x /*2a*/ in y //2b
+); //2c
 
 for (x /*3a*/ in y); //3b //3c
 
-for (x in //4a
-y);
+for (
+  x in //4a
+  y
+);
 
-for (x in //5a
-y);
+for (
+  x in //5a
+  y
+);
 
-for (x of /*6a*/ //6b
-y) //6c
+for (
+  x of /*6a*/ //6b
+  y
+) //6c
 ;
 
-for (x /*7a*/ of y); //7b //7c
+for (
+  x /*7a*/ of y //7b
+); //7c
 
 for (x /*8a*/ of y); //8b //8c
 
-for (x of //9a
-y);
+for (
+  x of //9a
+  y
+);
 
-for (x of //10a
-y);
+for (
+  x of //10a
+  y
+);
+
+================================================================================
+`;
+
+exports[`issue-12880.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+for (
+  let i of a // Hello
+) {
+}
+
+for (
+  let i in b // Hello
+) {
+}
+
+for (
+  let i of c // Hello
+) {
+  d();
+}
+
+for (const short of items) {
+  e();
+}
+
+for (const srcPath of [123, 123_123_123, 123_123_123_1, 13_123_3123_31_4321]) {
+  f(srcPath);
+}
+
+=====================================output=====================================
+for (
+  let i of a // Hello
+) {
+}
+
+for (
+  let i in b // Hello
+) {
+}
+
+for (
+  let i of c // Hello
+) {
+  d();
+}
+
+for (const short of items) {
+  e();
+}
+
+for (const srcPath of [123, 123_123_123, 123_123_123_1, 13_123_3123_31_4321]) {
+  f(srcPath);
+}
 
 ================================================================================
 `;

--- a/tests/format/js/for-of/issue-12880.js
+++ b/tests/format/js/for-of/issue-12880.js
@@ -1,0 +1,23 @@
+for (
+  let i of a // Hello
+) {
+}
+
+for (
+  let i in b // Hello
+) {
+}
+
+for (
+  let i of c // Hello
+) {
+  d();
+}
+
+for (const short of items) {
+  e();
+}
+
+for (const srcPath of [123, 123_123_123, 123_123_123_1, 13_123_3123_31_4321]) {
+  f(srcPath);
+}

--- a/tests/format/js/for/__snapshots__/format.test.js.snap
+++ b/tests/format/js/for/__snapshots__/format.test.js.snap
@@ -879,9 +879,11 @@ for (var a = (1 || b in c) in {});
 for (var a = (1 + (2 || b in c)) in {});
 for (var a = (() => b in c) in {});
 for (var a = (1 || (() => b in c)) in {});
-for (var a = (() => {
-  b in c;
-}) in {});
+for (
+  var a = (() => {
+    b in c;
+  }) in {}
+);
 for (var a = ([b in c]) in {});
 for (var a = ({ b: b in c }) in {});
 for (var a = ((x = b in c) => {}) in {});
@@ -1056,9 +1058,11 @@ for (var a in 1 || b in c);
 for (var a in 1 + (2 || b in c));
 for (var a in () => b in c);
 for (var a in 1 || (() => b in c));
-for (var a in () => {
-  b in c;
-});
+for (
+  var a in () => {
+    b in c;
+  }
+);
 for (var a in [b in c]);
 for (var a in { b: b in c });
 for (var a in (x = b in c) => {});

--- a/tests/format/js/for/__snapshots__/format.test.js.snap
+++ b/tests/format/js/for/__snapshots__/format.test.js.snap
@@ -879,11 +879,9 @@ for (var a = (1 || b in c) in {});
 for (var a = (1 + (2 || b in c)) in {});
 for (var a = (() => b in c) in {});
 for (var a = (1 || (() => b in c)) in {});
-for (
-  var a = (() => {
-    b in c;
-  }) in {}
-);
+for (var a = (() => {
+  b in c;
+}) in {});
 for (var a = ([b in c]) in {});
 for (var a = ({ b: b in c }) in {});
 for (var a = ((x = b in c) => {}) in {});
@@ -1058,11 +1056,9 @@ for (var a in 1 || b in c);
 for (var a in 1 + (2 || b in c));
 for (var a in () => b in c);
 for (var a in 1 || (() => b in c));
-for (
-  var a in () => {
-    b in c;
-  }
-);
+for (var a in () => {
+  b in c;
+});
 for (var a in [b in c]);
 for (var a in { b: b in c });
 for (var a in (x = b in c) => {});


### PR DESCRIPTION
## Description

Fixes #12880.

The `for-in`/`for-of` head is printed as a flat group, so it can never break. A trailing line comment on it therefore has nowhere to go and is emitted after the closing parenthesis:

```js
// Input
for (
  let i of a // Hello
) {
}

// Prettier stable (first format)
for (let i of a) { // Hello
}

// Prettier stable (second format)
for (let i of a) {
  // Hello
}

// Prettier main
for (
  let i of a // Hello
) {
}
```

The comment moves twice, so the file never settles. Every neighbouring statement already gets this right — `while`, `if`, and the three-clause `for` all break their head and keep the comment where it was written. This makes `for-in`/`for-of` behave the same way.

The head is only made breakable when something in it forces a break. A group that would merely break on width is left flat, so a breaking argument can still hug the head:

```js
for (const srcPath of [
  123, 123_123_123, 123_123_123_1, 13_123_3123_31_4321,
]) {
```

That output is unchanged — an earlier version of this patch made the head always breakable and regressed it to `for (\n  const srcPath of [...]\n) {`, which is why the `willBreak` check is there.

## Worth flagging

Three existing snapshots in `js/for-of/comments.js` and `js/for/comments.js` change, and two of them were recording output that could not survive a second format:

```js
// committed snapshot
for (x in //4a
y);

// what main does when you feed that back in
for (x in y); //4a
```

The comment escapes the parentheses and the semicolon. Those snapshots now record the stable form.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
