### PR TITLE
docs: fix minor typo in rationale.md

### DIFF
--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -35,6 +35,7 @@ You can disable this conditional behavior with the [`objectWrap`](options.md#obj
 
 **Tip:** If you have a multi-line object that you’d like to join up into a single line:
 
+<!-- prettier-ignore -->
 ```js
 const user = {
   name: "John Doe",
@@ -47,7 +48,7 @@ const user = {
 <!-- prettier-ignore -->
 ```js
 const user = {  name: "John Doe",
-  age: 30,
+  age: 30
 };
 ```
 

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -39,7 +39,7 @@ You can disable this conditional behavior with the [`objectWrap`](options.md#obj
 ```js
 const user = {
   name: "John Doe",
-  age: 30,
+  age: 30
 };
 ```
 

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -47,7 +47,7 @@ const user = {
 <!-- prettier-ignore -->
 ```js
 const user = {  name: "John Doe",
-  age: 30
+  age: 30,
 };
 ```
 

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -39,7 +39,7 @@ You can disable this conditional behavior with the [`objectWrap`](options.md#obj
 ```js
 const user = {
   name: "John Doe",
-  age: 30
+  age: 30,
 };
 ```
 
@@ -48,7 +48,7 @@ const user = {
 <!-- prettier-ignore -->
 ```js
 const user = {  name: "John Doe",
-  age: 30
+  age: 30,
 };
 ```
 

--- a/website/versioned_docs/version-stable/rationale.md
+++ b/website/versioned_docs/version-stable/rationale.md
@@ -35,10 +35,11 @@ You can disable this conditional behavior with the [`objectWrap`](options.md#obj
 
 **Tip:** If you have a multi-line object that you’d like to join up into a single line:
 
+<!-- prettier-ignore -->
 ```js
 const user = {
   name: "John Doe",
-  age: 30,
+  age: 30
 };
 ```
 


### PR DESCRIPTION
Fix minor typo that makes you believe that the `,` after last item must also be removed

<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

<!-- Please provide a brief summary of your changes -->
A typo in the example for [Multi-line objects](https://prettier.io/docs/rationale#multi-line-objects) makes you believe that the `,` after the last item must also be removed.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [N/A] I’ve added tests to confirm my change works.
- [N/A] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [N/A] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.
