### PR TITLE
Fix unstable trailing comment on a nested parenthesized assignment

### DIFF
--- a/changelog_unreleased/javascript/19893.md
+++ b/changelog_unreleased/javascript/19893.md
@@ -1,0 +1,16 @@
+#### Fix unstable trailing comment on a nested parenthesized assignment (#19893 by @Kjubikstronk)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+assigned = (a = c /* comment */);
+
+// Prettier stable (first format)
+assigned = a = c /* comment */;
+
+// Prettier stable (second format)
+assigned = a = c; /* comment */
+
+// Prettier main
+assigned = a = c; /* comment */
+```

--- a/changelog_unreleased/javascript/19893.md
+++ b/changelog_unreleased/javascript/19893.md
@@ -5,10 +5,10 @@
 // Input
 assigned = (a = c /* comment */);
 
-// Prettier stable (first format)
+// Prettier stable (First format)
 assigned = a = c /* comment */;
 
-// Prettier stable (second format)
+// Prettier stable (Second format)
 assigned = a = c; /* comment */
 
 // Prettier main

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -1217,13 +1217,14 @@ function handleParenthesizedExpressionTrailingComment({
       enclosingNode.type === "AssignmentExpression" &&
       enclosingNode.right === precedingNode
     ) {
-      const statement = getEnclosingAssignmentChainExpressionStatement(
-        enclosingNode,
-        ancestors.slice(1),
-      );
+      const expressionStatement =
+        getEnclosingAssignmentChainExpressionStatement(
+          enclosingNode,
+          ancestors.slice(1),
+        );
 
-      if (statement) {
-        addTrailingComment(statement, comment);
+      if (expressionStatement) {
+        addTrailingComment(expressionStatement, comment);
         return true;
       }
     }

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -55,7 +55,6 @@ import {
   precedingNode: Node,
   enclosingNode: Node,
   followingNode: Node,
-  // `enclosingNode` first, then its parents up to the root.
   ancestors: Node[],
   text: string,
   options: any,
@@ -1176,11 +1175,7 @@ function handleArrowExpressionComments({
   return false;
 }
 
-/*
-Find the statement an assignment chain belongs to, walking up from `node`
-through the right hand side of every enclosing assignment.
-*/
-function getEnclosingAssignmentChainStatement(node, ancestors) {
+function getEnclosingAssignmentChainExpressionStatement(node, ancestors) {
   let child = node;
 
   for (const ancestor of ancestors) {
@@ -1223,7 +1218,7 @@ function handleParenthesizedExpressionTrailingComment({
       enclosingNode.type === "AssignmentExpression" &&
       enclosingNode.right === precedingNode
     ) {
-      const statement = getEnclosingAssignmentChainStatement(
+      const statement = getEnclosingAssignmentChainExpressionStatement(
         enclosingNode,
         ancestors.slice(1),
       );

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -1207,7 +1207,6 @@ function handleParenthesizedExpressionTrailingComment({
       return true;
     }
 
-    const isSequence = precedingNode.type === "SequenceExpression";
     const isAssignment = precedingNode.type === "AssignmentExpression";
 
     // `a = (b = c /* comment */);` drops the parentheses, so the comment ends
@@ -1228,6 +1227,8 @@ function handleParenthesizedExpressionTrailingComment({
         return true;
       }
     }
+
+    const isSequence = precedingNode.type === "SequenceExpression";
 
     if (
       (isSequence || isAssignment) &&

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -55,7 +55,7 @@ import {
   precedingNode: Node,
   enclosingNode: Node,
   followingNode: Node,
-  ancestors: Node[],
+  ancestors: readonly Node[],
   text: string,
   options: any,
   ast: NodeMap["File"] | NodeMap["Program"],

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -55,6 +55,8 @@ import {
   precedingNode: Node,
   enclosingNode: Node,
   followingNode: Node,
+  // `enclosingNode` first, then its parents up to the root.
+  ancestors: Node[],
   text: string,
   options: any,
   ast: NodeMap["File"] | NodeMap["Program"],
@@ -1174,11 +1176,32 @@ function handleArrowExpressionComments({
   return false;
 }
 
+/*
+Find the statement an assignment chain belongs to, walking up from `node`
+through the right hand side of every enclosing assignment.
+*/
+function getEnclosingAssignmentChainStatement(node, ancestors) {
+  let child = node;
+
+  for (const ancestor of ancestors) {
+    if (ancestor.type === "AssignmentExpression" && ancestor.right === child) {
+      child = ancestor;
+      continue;
+    }
+
+    return ancestor.type === "ExpressionStatement" &&
+      ancestor.expression === child
+      ? ancestor
+      : undefined;
+  }
+}
+
 function handleParenthesizedExpressionTrailingComment({
   comment,
   enclosingNode,
   precedingNode,
   followingNode,
+  ancestors,
 }) {
   if (!followingNode && enclosingNode && precedingNode) {
     if (
@@ -1191,6 +1214,25 @@ function handleParenthesizedExpressionTrailingComment({
 
     const isSequence = precedingNode.type === "SequenceExpression";
     const isAssignment = precedingNode.type === "AssignmentExpression";
+
+    // `a = (b = c /* comment */);` drops the parentheses, so the comment ends
+    // up trailing the whole statement anyway. Attach it there right away
+    // instead of leaving it on `c` for the next format to move.
+    if (
+      isAssignment &&
+      enclosingNode.type === "AssignmentExpression" &&
+      enclosingNode.right === precedingNode
+    ) {
+      const statement = getEnclosingAssignmentChainStatement(
+        enclosingNode,
+        ancestors.slice(1),
+      );
+
+      if (statement) {
+        addTrailingComment(statement, comment);
+        return true;
+      }
+    }
 
     if (
       (isSequence || isAssignment) &&

--- a/src/main/comments/attach.js
+++ b/src/main/comments/attach.js
@@ -106,7 +106,7 @@ function decorateComment(
     }
   }
 
-  return { enclosingNode, precedingNode, followingNode };
+  return { enclosingNode, precedingNode, followingNode, ancestors };
 }
 
 const returnFalse = () => false;

--- a/tests/config/format-test/failed-format-tests.js
+++ b/tests/config/format-test/failed-format-tests.js
@@ -31,7 +31,6 @@ const unstableTests = new Map(
     "typescript/call/callee-comments.ts",
     "js/arrows/arrow-chain-with-trailing-comments.js",
     "typescript/as/comments/18160.ts",
-    "js/sequence-expression/parenthesized-trailing-comment-unstable.js",
     "typescript/union/consistent-with-flow/single-type.ts",
   ].map((fixture) => {
     const [file, isUnstable = () => true] = Array.isArray(fixture)

--- a/tests/format/js/sequence-expression/__snapshots__/format.test.js.snap
+++ b/tests/format/js/sequence-expression/__snapshots__/format.test.js.snap
@@ -168,7 +168,10 @@ const x22 = (a = c) /* comment */;
 
 assigned = (a, b, c /* comment */);
 assigned = (a, b, c) /* comment */;
-// assigned = (a = c /* comment */);
+assigned = (a = c /* comment */);
+x = y = (a = c /* comment */);
+obj.p = (a = c /* comment */);
+assigned = ((a = c) /* comment */);
 
 function f() {
   return (a, b, c /* comment */);
@@ -205,30 +208,16 @@ foo(); /* comment */
 
 assigned = (a, b, c /* comment */);
 assigned = (a, b, c); /* comment */
-// assigned = (a = c /* comment */);
+assigned = a = c; /* comment */
+x = y = a = c; /* comment */
+obj.p = a = c; /* comment */
+assigned = a = c; /* comment */
 
 function f() {
   return (a, b, c /* comment */);
   return (a, b, c); /* comment */
   return (a = c /* comment */);
 }
-
-================================================================================
-`;
-
-exports[`parenthesized-trailing-comment-unstable.js format 1`] = `
-====================================options=====================================
-parsers: ["babel", "flow", "typescript"]
-                                                      printWidth: 80 (default) |
-=====================================input======================================
-// TODO: Enable tests in parenthesized-trailing-comment.js when they are stable
-
-assigned = (a = c /* comment */);
-
-=====================================output=====================================
-// TODO: Enable tests in parenthesized-trailing-comment.js when they are stable
-
-assigned = a = c /* comment */;
 
 ================================================================================
 `;

--- a/tests/format/js/sequence-expression/parenthesized-trailing-comment-unstable.js
+++ b/tests/format/js/sequence-expression/parenthesized-trailing-comment-unstable.js
@@ -1,3 +1,0 @@
-// TODO: Enable tests in parenthesized-trailing-comment.js when they are stable
-
-assigned = (a = c /* comment */);

--- a/tests/format/js/sequence-expression/parenthesized-trailing-comment.js
+++ b/tests/format/js/sequence-expression/parenthesized-trailing-comment.js
@@ -34,7 +34,10 @@ const x22 = (a = c) /* comment */;
 
 assigned = (a, b, c /* comment */);
 assigned = (a, b, c) /* comment */;
-// assigned = (a = c /* comment */);
+assigned = (a = c /* comment */);
+x = y = (a = c /* comment */);
+obj.p = (a = c /* comment */);
+assigned = ((a = c) /* comment */);
 
 function f() {
   return (a, b, c /* comment */);


### PR DESCRIPTION
## Description

Fixes the remaining case in #19271.

#19276 made `(a = c /* comment */);` stable by attaching the trailing comment to the `ExpressionStatement`. The nested form was left out and is still unstable on `main`:

```jsx
// Input
assigned = (a = c /* comment */);

// First format
assigned = a = c /* comment */;

// Second format
assigned = a = c; /* comment */
```

The second format is already the fixpoint, so this makes the first one produce it too.

`handleParenthesizedExpressionTrailingComment` does fire here — it just attaches the comment inward to `c`. Once the parentheses are dropped the comment is at the end of the statement, and the next run attaches it to the statement instead, which is where the instability comes from.

Attaching to the statement on the first pass needs the statement, and the handler only had `enclosingNode`. For a chain like `x = y = (a = c /* comment */)` that is the *middle* assignment, not the outermost, so walking up is the only way to reach it. `decorateComment` already builds the ancestor chain and threads it through the recursion for `canAttachComment`, it just wasn't returned, so this returns it and walks up through the right hand side of each enclosing assignment.

Scope is deliberately narrow, since #19273 was reverted once already. Only assignment chains that end in an `ExpressionStatement` are affected — everywhere else the parentheses are kept, so nothing was unstable to begin with:

```jsx
const v = (a = c /* comment */);        // unchanged, parens kept
function f() { return (a = c /* c */); } // unchanged, parens kept
assigned = (a, b /* comment */);         // unchanged, sequences unaffected
```

Two related variants are still unstable, both unchanged by this PR and both failing identically on `main`:

```jsx
assigned = (a = (c /* comment */));      // comment parenthesized around `c`
assigned = (a = c /* comment */), other; // inside a sequence
```

They need a wider change than this one and I'd rather not fold them in here.

`parenthesized-trailing-comment-unstable.js` existed only for this case, with a TODO to move it back once stable, so it's removed along with its `failed-format-tests.js` entry and the case is enabled in `parenthesized-trailing-comment.js`.

Full `tests/format` run has the same failures before and after.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
