### PR TITLE
Fix unstable comment before the first element of a sequence expression

### DIFF
--- a/changelog_unreleased/javascript/19894.md
+++ b/changelog_unreleased/javascript/19894.md
@@ -5,10 +5,10 @@
 // Input
 ((/* c */ a), b);
 
-// Prettier stable (first format)
+// Prettier stable (First format)
 (/* c */ a, b);
 
-// Prettier stable (second format)
+// Prettier stable (Second format)
 /* c */ (a, b);
 
 // Prettier main

--- a/changelog_unreleased/javascript/19894.md
+++ b/changelog_unreleased/javascript/19894.md
@@ -1,0 +1,16 @@
+#### Fix unstable comment before the first element of a sequence expression (#19894 by @Kjubikstronk)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+((/* c */ a), b);
+
+// Prettier stable (first format)
+(/* c */ a, b);
+
+// Prettier stable (second format)
+/* c */ (a, b);
+
+// Prettier main
+/* c */ (a, b);
+```

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -93,6 +93,7 @@ function handleOwnLineComment(context) {
     handleTSMappedTypeComments,
     handleBinaryCastExpressionComment,
     handleUnionTypeLeadingComments,
+    handleSequenceExpressionLeadingComment,
   ].some((fn) => fn(context));
 }
 
@@ -127,6 +128,7 @@ function handleEndOfLineComment(context) {
     handlePropertySignatureComments,
     handleBinaryCastExpressionComment,
     handleTaggedTemplateExpressionComments,
+    handleSequenceExpressionLeadingComment,
   ].some((fn) => fn(context));
 }
 
@@ -154,6 +156,7 @@ function handleRemainingComment(context) {
     handlePropertySignatureComments,
     handleBinaryCastExpressionComment,
     handleUnionTypeLeadingComments,
+    handleSequenceExpressionLeadingComment,
   ].some((fn) => fn(context));
 }
 
@@ -1168,6 +1171,28 @@ function handleArrowExpressionComments({
 
   if (!isBeforeArrow) {
     addBlockOrNotComment(followingNode, comment);
+    return true;
+  }
+
+  return false;
+}
+
+function handleSequenceExpressionLeadingComment({
+  comment,
+  enclosingNode,
+  precedingNode,
+  followingNode,
+}) {
+  // A `SequenceExpression` starts at the parentheses of its first element, so
+  // a comment written before that element is inside the sequence now, but ends
+  // up outside it once the parentheses are dropped. Attach it to the sequence
+  // right away, where the next format would move it anyway.
+  if (
+    !precedingNode &&
+    enclosingNode?.type === "SequenceExpression" &&
+    followingNode === enclosingNode.expressions[0]
+  ) {
+    addLeadingComment(enclosingNode, comment);
     return true;
   }
 

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -1183,10 +1183,6 @@ function handleSequenceExpressionLeadingComment({
   precedingNode,
   followingNode,
 }) {
-  // A `SequenceExpression` starts at the parentheses of its first element, so
-  // a comment written before that element is inside the sequence now, but ends
-  // up outside it once the parentheses are dropped. Attach it to the sequence
-  // right away, where the next format would move it anyway.
   if (
     !precedingNode &&
     enclosingNode?.type === "SequenceExpression" &&

--- a/tests/config/format-test/failed-format-tests.js
+++ b/tests/config/format-test/failed-format-tests.js
@@ -20,7 +20,6 @@ const unstableTests = new Map(
     "typescript/prettier-ignore/mapped-types.ts",
     "typescript/prettier-ignore/issue-14238.ts",
     "js/for-of/comments.js",
-    "js/sequence-expression/parenthesized.js",
     "typescript/satisfies-operators/comments-unstable.ts",
     "jsx/comments/in-attributes.js",
     "typescript/import-type/long-module-name/long-module-name4.ts",

--- a/tests/format/js/sequence-expression/__snapshots__/format.test.js.snap
+++ b/tests/format/js/sequence-expression/__snapshots__/format.test.js.snap
@@ -112,8 +112,8 @@ console.log(
 console.log(
   /* 1 */
   /* 2 */
-  (/* 3 */
-  first,
+  /* 3 */
+  (first,
   /* 4 */
   /* 5 */
   /* 6 */


### PR DESCRIPTION
## Description

`js/sequence-expression/parenthesized.js` is one of the `unstableTests` entries in `tests/config/format-test/failed-format-tests.js`. This makes it stable and removes it from the list.

Reduced, the whole thing is one comment moving:

```jsx
// Input
((/* c */ a), b);

// Prettier stable (first format)
(/* c */ a, b);

// Prettier stable (second format)
/* c */ (a, b);
```

Babel starts a `SequenceExpression` at the parentheses of its first element, not at the element itself:

```
((/* c */ a), b);      SequenceExpression [1,15)   comment [2,9)   -> inside
 (/* c */ a, b);       SequenceExpression [9,13)   comment [1,8)   -> outside
```

So in the input the comment is inside the sequence and becomes a leading comment of `a`, which prints it inside the parentheses. Prettier then drops the redundant parentheses around `a`, the sequence's start moves past the comment, and the next format attaches it to the sequence instead and prints it outside. Attaching it to the sequence in the first place is the fixpoint the second format already produces.

Every other node type already does this and is stable, because none of them re-add parentheses around the result:

```jsx
((/* c */ a) + b);   // -> /* c */ a + b;   (unchanged)
((/* c */ a).x);     // -> /* c */ a.x;     (unchanged)
```

A comment on a later element is unaffected, since the sequence's start is before it either way:

```jsx
((a), /* c */ b);    // -> (a, /* c */ b);  (unchanged)
```

And a comment the user actually wrote before a parenthesized sequence keeps its meaning:

```jsx
/* c */ (a, b);      // -> /* c */ (a, b);  (unchanged)
```

The handler needs no "is the first element parenthesized" check: if it were not parenthesized the sequence would start at the element, so the comment could not be inside the sequence at all.

Full `tests/format` run has the same failures before and after.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
