### PR TITLE
Fix unstable comment before the first heritage clause element

### DIFF
--- a/changelog_unreleased/typescript/16228.md
+++ b/changelog_unreleased/typescript/16228.md
@@ -1,0 +1,30 @@
+#### Fix unstable comment before the first heritage clause element (#16228 by @koreahghg)
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+class MyClass extends MySuperClass implements /* foo */ ISomething, /* bar */ IOtherThing, /* baz */ IThirdThing {
+}
+
+// Prettier stable (First format)
+class MyClass
+  extends MySuperClass
+  implements
+    /* foo */ ISomething,
+    /* bar */ IOtherThing,
+    /* baz */ IThirdThing {}
+
+// Prettier stable (Second format)
+class MyClass
+  extends MySuperClass
+  /* foo */
+  implements ISomething, /* bar */ IOtherThing, /* baz */ IThirdThing {}
+
+// Prettier main
+class MyClass
+  extends MySuperClass
+  implements
+    /* foo */ ISomething,
+    /* bar */ IOtherThing,
+    /* baz */ IThirdThing {}
+```

--- a/changelog_unreleased/typescript/19896.md
+++ b/changelog_unreleased/typescript/19896.md
@@ -1,4 +1,4 @@
-#### Fix unstable comment before the first heritage clause element (#16228 by @koreahghg)
+#### Fix unstable comment before the first heritage clause element (#19896 by @koreahghg)
 
 <!-- prettier-ignore -->
 ```tsx

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -316,6 +316,7 @@ function handleClassComments({
   precedingNode,
   enclosingNode,
   followingNode,
+  text,
 }) {
   if (isClassLikeNode(enclosingNode)) {
     // @ts-expect-error -- Safe
@@ -348,6 +349,18 @@ function handleClassComments({
 
       for (const prop of ["implements", "extends", "mixins"]) {
         if (enclosingNode[prop] && followingNode === enclosingNode[prop][0]) {
+          // A comment glued to the first heritage clause element (e.g.,
+          // `implements /* foo */ Foo`) documents that element specifically,
+          // the same way a comment before the second, third, etc. element
+          // would. Keep it there instead of bouncing it to the previous
+          // node/the clause keyword, which isn't idempotent: reformatting
+          // moves the keyword onto its own line, turning this into an
+          // own-line comment and changing which branch below handles it.
+          if (!hasNewline(text, locEnd(comment))) {
+            addLeadingComment(followingNode, comment);
+            return true;
+          }
+
           if (
             precedingNode &&
             (precedingNode === enclosingNode.id ||

--- a/tests/format/typescript/class-comment/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/class-comment/__snapshots__/format.test.js.snap
@@ -263,6 +263,39 @@ class G4<
 ================================================================================
 `;
 
+exports[`issue-16228.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript", "flow"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+class MyClass1 extends MySuperClass implements /* foo */ ISomething, /* bar */ IOtherThing, /* baz */ IThirdThing {
+}
+
+class MyClass2
+  extends MySuperClass
+  implements
+    /* foo */ ISomething,
+    /* bar */ IOtherThing,
+    /* baz */ IThirdThing {}
+
+=====================================output=====================================
+class MyClass1
+  extends MySuperClass
+  implements
+    /* foo */ ISomething,
+    /* bar */ IOtherThing,
+    /* baz */ IThirdThing {}
+
+class MyClass2
+  extends MySuperClass
+  implements
+    /* foo */ ISomething,
+    /* bar */ IOtherThing,
+    /* baz */ IThirdThing {}
+
+================================================================================
+`;
+
 exports[`misc.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript", "flow"]

--- a/tests/format/typescript/class-comment/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/class-comment/__snapshots__/format.test.js.snap
@@ -271,22 +271,8 @@ parsers: ["typescript", "flow"]
 class MyClass1 extends MySuperClass implements /* foo */ ISomething, /* bar */ IOtherThing, /* baz */ IThirdThing {
 }
 
-class MyClass2
-  extends MySuperClass
-  implements
-    /* foo */ ISomething,
-    /* bar */ IOtherThing,
-    /* baz */ IThirdThing {}
-
 =====================================output=====================================
 class MyClass1
-  extends MySuperClass
-  implements
-    /* foo */ ISomething,
-    /* bar */ IOtherThing,
-    /* baz */ IThirdThing {}
-
-class MyClass2
   extends MySuperClass
   implements
     /* foo */ ISomething,

--- a/tests/format/typescript/class-comment/issue-16228.ts
+++ b/tests/format/typescript/class-comment/issue-16228.ts
@@ -1,0 +1,9 @@
+class MyClass1 extends MySuperClass implements /* foo */ ISomething, /* bar */ IOtherThing, /* baz */ IThirdThing {
+}
+
+class MyClass2
+  extends MySuperClass
+  implements
+    /* foo */ ISomething,
+    /* bar */ IOtherThing,
+    /* baz */ IThirdThing {}

--- a/tests/format/typescript/class-comment/issue-16228.ts
+++ b/tests/format/typescript/class-comment/issue-16228.ts
@@ -1,9 +1,2 @@
 class MyClass1 extends MySuperClass implements /* foo */ ISomething, /* bar */ IOtherThing, /* baz */ IThirdThing {
 }
-
-class MyClass2
-  extends MySuperClass
-  implements
-    /* foo */ ISomething,
-    /* bar */ IOtherThing,
-    /* baz */ IThirdThing {}


### PR DESCRIPTION
## Description

Fixes #16228.

A comment glued to the first `implements`/`extends`/`mixins` element (e.g.
`implements /* foo */ Foo`) documents that element specifically, the same way
a comment before the second, third, etc. element would. Previously it was
reattached as a trailing comment of the preceding class header node
(the class name or the superclass) whenever that comment happened to start
on its own line — which is exactly what happens once the class has already
been reformatted onto multiple lines. That made the output non-idempotent:
formatting a second time moved the comment in front of the `implements`
keyword instead of leaving it on the element it was meant to document.

```tsx
// Input
class MyClass extends MySuperClass implements /* foo */ ISomething, /* bar */ IOtherThing, /* baz */ IThirdThing {
}

// Before this PR (second format)
class MyClass
  extends MySuperClass
  /* foo */
  implements ISomething, /* bar */ IOtherThing, /* baz */ IThirdThing {}

// After this PR (stable on every format)
class MyClass
  extends MySuperClass
  implements
    /* foo */ ISomething,
    /* bar */ IOtherThing,
    /* baz */ IThirdThing {}
```

The fix only changes behavior when there is no newline between the comment
and the element it precedes, so a comment that is fully alone on its own
line (documenting the whole clause, e.g. the existing `class a3` fixture in
`class-implements.ts`) keeps printing before the `implements`/`extends`
keyword as before.

## Checklist

- [x] I've added tests to confirm my change works.
- [ ] (If changing the API or CLI) I've documented the changes I've made (in the `docs/` directory).
- [x] (If the change is user-facing) I've added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I've read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.