### PR TITLE
Replace unmaintained hugo-post plugin entry

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -60,6 +60,7 @@ Strings provided to `plugins` are ultimately passed to [`import()` expression](h
 ## Community Plugins
 
 - [`@htnabe/prettier-plugin-go-template`](https://github.com/htnabe/prettier-plugin-go-template) by [**@htnabe**](https://github.com/htnabe)
+- [`@htnabe/prettier-plugin-hugo-post`](https://github.com/htnabe/prettier-plugin-hugo-post) by [**@htnabe**](https://github.com/htnabe)
 - [`@poliklot/prettier-plugin-handlebars`](https://github.com/Poliklot/prettier-plugin-handlebars) by [**@Poliklot**](https://github.com/Poliklot)
 - [`prettier-plugin-apex`](https://github.com/dangmai/prettier-plugin-apex) by [**@dangmai**](https://github.com/dangmai)
 - [`prettier-plugin-astro`](https://github.com/withastro/prettier-plugin-astro) by [**@withastro contributors**](https://github.com/withastro/prettier-plugin-astro/graphs/contributors)
@@ -68,7 +69,6 @@ Strings provided to `plugins` are ultimately passed to [`import()` expression](h
 - [`prettier-plugin-erb`](https://github.com/adamzapasnik/prettier-plugin-erb) by [**@adamzapasnik**](https://github.com/adamzapasnik)
 - [`prettier-plugin-gherkin`](https://github.com/mapado/prettier-plugin-gherkin) by [**@mapado**](https://github.com/mapado)
 - [`prettier-plugin-glsl`](https://github.com/NaridaL/glsl-language-toolkit/tree/main/packages/prettier-plugin-glsl) by [**@NaridaL**](https://github.com/NaridaL)
-- [`prettier-plugin-hugo-post`](https://github.com/metcalfc/prettier-plugin-hugo-post) by [**@metcalfc**](https://github.com/metcalfc)
 - [`prettier-plugin-java`](https://github.com/jhipster/prettier-java) by [**@JHipster**](https://github.com/jhipster)
 - [`prettier-plugin-jinja-template`](https://github.com/davidodenwald/prettier-plugin-jinja-template) by [**@davidodenwald**](https://github.com/davidodenwald)
 - [`prettier-plugin-jte`](https://github.com/sgruendel/prettier-plugin-jte) by [**@sgruendel**](https://github.com/sgruendel)

--- a/website/versioned_docs/version-stable/plugins.md
+++ b/website/versioned_docs/version-stable/plugins.md
@@ -60,6 +60,7 @@ Strings provided to `plugins` are ultimately passed to [`import()` expression](h
 ## Community Plugins
 
 - [`@htnabe/prettier-plugin-go-template`](https://github.com/htnabe/prettier-plugin-go-template) by [**@htnabe**](https://github.com/htnabe)
+- [`@htnabe/prettier-plugin-hugo-post`](https://github.com/htnabe/prettier-plugin-hugo-post) by [**@htnabe**](https://github.com/htnabe)
 - [`@poliklot/prettier-plugin-handlebars`](https://github.com/Poliklot/prettier-plugin-handlebars) by [**@Poliklot**](https://github.com/Poliklot)
 - [`prettier-plugin-apex`](https://github.com/dangmai/prettier-plugin-apex) by [**@dangmai**](https://github.com/dangmai)
 - [`prettier-plugin-astro`](https://github.com/withastro/prettier-plugin-astro) by [**@withastro contributors**](https://github.com/withastro/prettier-plugin-astro/graphs/contributors)
@@ -68,7 +69,6 @@ Strings provided to `plugins` are ultimately passed to [`import()` expression](h
 - [`prettier-plugin-erb`](https://github.com/adamzapasnik/prettier-plugin-erb) by [**@adamzapasnik**](https://github.com/adamzapasnik)
 - [`prettier-plugin-gherkin`](https://github.com/mapado/prettier-plugin-gherkin) by [**@mapado**](https://github.com/mapado)
 - [`prettier-plugin-glsl`](https://github.com/NaridaL/glsl-language-toolkit/tree/main/packages/prettier-plugin-glsl) by [**@NaridaL**](https://github.com/NaridaL)
-- [`prettier-plugin-hugo-post`](https://github.com/metcalfc/prettier-plugin-hugo-post) by [**@metcalfc**](https://github.com/metcalfc)
 - [`prettier-plugin-java`](https://github.com/jhipster/prettier-java) by [**@JHipster**](https://github.com/jhipster)
 - [`prettier-plugin-jinja-template`](https://github.com/davidodenwald/prettier-plugin-jinja-template) by [**@davidodenwald**](https://github.com/davidodenwald)
 - [`prettier-plugin-jte`](https://github.com/sgruendel/prettier-plugin-jte) by [**@sgruendel**](https://github.com/sgruendel)


### PR DESCRIPTION
<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

<!-- Please provide a brief summary of your changes -->

Replaced prettier-plugin-hugo-post plugin which will not be maintained, with `@htnabe/prettier-plugin-hugo-post`.

- Removed:
  - [`prettier-plugin-hugo-post`](https://github.com/metcalfc/prettier-plugin-hugo-post) by [**@metcalfc**](https://github.com/metcalfc)
- Added:
  - [`@htnabe/prettier-plugin-hugo-post`](https://github.com/htnabe/prettier-plugin-hugo-post) by [**@htnabe**](https://github.com/htnabe)

Context:
- The previous plugin will not be maintained and will be archived: https://github.com/metcalfc/prettier-plugin-hugo-post/issues/13
- This PR updates the plugins list to reference the actively maintained replacement.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.