### PR TITLE
Fix `isSetextHeading`

### DIFF
--- a/src/language-markdown/utilities.js
+++ b/src/language-markdown/utilities.js
@@ -317,8 +317,10 @@ function hasPrettierIgnore(path) {
 }
 
 function isSetextHeading(node) {
-  const { start, end } = node.position;
-  return start.line !== end.line;
+  return (
+    node.type === "heading" &&
+    node.position.start.line !== node.position.end.line
+  );
 }
 
 const isNewLine = (node) => node?.type === "whitespace" && node.value === "\n";

--- a/src/language-markdown/utilities.js
+++ b/src/language-markdown/utilities.js
@@ -319,7 +319,7 @@ function hasPrettierIgnore(path) {
 function isSetextHeading(node) {
   return (
     node.type === "heading" &&
-    node.position.start.line !== node.position.end.line
+    node.position.start.line < node.position.end.line
   );
 }
 

--- a/src/language-markdown/utilities.js
+++ b/src/language-markdown/utilities.js
@@ -318,8 +318,7 @@ function hasPrettierIgnore(path) {
 
 function isSetextHeading(node) {
   return (
-    node.type === "heading" &&
-    node.position.start.line < node.position.end.line
+    node.type === "heading" && node.position.start.line < node.position.end.line
   );
 }
 


### PR DESCRIPTION
<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

<!-- Please provide a brief summary of your changes -->

Add missing type check

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.
