### PR TITLE
Map EditorConfig `max_line_length = unset` to infinite `printWidth`

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -57,6 +57,8 @@ In other words, don’t try to use printWidth as if it was ESLint’s [max-len](
 
 Setting `max_line_length` in an [`.editorconfig` file](https://editorconfig.org/) will configure Prettier’s print width, unless overridden.
 
+Valid values are a positive integer, `off`, or `unset`. A positive integer sets `printWidth` to that value; `unset` (per the EditorConfig spec) and `off` (for backward compatibility) both mean no line wrapping, mapping to `printWidth: Infinity`.
+
 (If you don’t want line wrapping when formatting Markdown, you can set the [Prose Wrap](#prose-wrap) option to disable it.)
 
 ## Tab Width

--- a/src/config/editorconfig/editorconfig-to-prettier.js
+++ b/src/config/editorconfig/editorconfig-to-prettier.js
@@ -29,7 +29,7 @@ function editorConfigToPrettier(editorConfig) {
     result.tabWidth = tab_width;
   }
 
-  if (max_line_length === "off") {
+  if (max_line_length === "off" || max_line_length === "unset") {
     result.printWidth = Number.POSITIVE_INFINITY;
   } else if (isPositiveInteger(max_line_length)) {
     result.printWidth = max_line_length;

--- a/tests/integration/__tests__/config-resolution.js
+++ b/tests/integration/__tests__/config-resolution.js
@@ -133,6 +133,18 @@ test("API resolveConfig with file arg and .editorconfig (key = unset)", async ()
   ).resolves.not.toMatchObject({ tabWidth: "unset" });
 });
 
+test("API resolveConfig with file arg and .editorconfig (max_line_length = unset)", async () => {
+  const file = new URL(
+    "../cli/config/editorconfig/max_line_length=unset.js",
+    import.meta.url,
+  );
+  await expect(
+    prettier.resolveConfig(file, { editorconfig: true }),
+  ).resolves.toMatchObject({
+    printWidth: Number.POSITIVE_INFINITY,
+  });
+});
+
 test("API resolveConfig with nested file arg and .editorconfig", async () => {
   const file = new URL(
     "../cli/config/editorconfig/lib/file.js",

--- a/tests/integration/cli/config/editorconfig/.editorconfig
+++ b/tests/integration/cli/config/editorconfig/.editorconfig
@@ -16,3 +16,6 @@ indent_size = tab
 
 [tab_width=unset.js]
 tab_width = unset
+
+[max_line_length=unset.js]
+max_line_length = unset

--- a/tests/integration/cli/config/editorconfig/max_line_length=unset.js
+++ b/tests/integration/cli/config/editorconfig/max_line_length=unset.js
@@ -1,0 +1,1 @@
+// This file intentionally left blank for EditorConfig resolution testing.

--- a/tests/unit/editorconfig-to-prettier.js
+++ b/tests/unit/editorconfig-to-prettier.js
@@ -130,6 +130,15 @@ test("editorconfigToPrettier", () => {
   ).toStrictEqual({
     useTabs: false,
     tabWidth: 2,
+    printWidth: Number.POSITIVE_INFINITY,
+  });
+
+  expect(
+    editorconfigToPrettier({
+      max_line_length: "unset",
+    }),
+  ).toStrictEqual({
+    printWidth: Number.POSITIVE_INFINITY,
   });
 
   expect(editorconfigToPrettier({})).toBeUndefined();

--- a/website/versioned_docs/version-stable/options.md
+++ b/website/versioned_docs/version-stable/options.md
@@ -57,6 +57,8 @@ In other words, don’t try to use printWidth as if it was ESLint’s [max-len](
 
 Setting `max_line_length` in an [`.editorconfig` file](https://editorconfig.org/) will configure Prettier’s print width, unless overridden.
 
+Valid values are a positive integer, `off`, or `unset`. A positive integer sets `printWidth` to that value; `unset` (per the EditorConfig spec) and `off` (for backward compatibility) both mean no line wrapping, mapping to `printWidth: Infinity`.
+
 (If you don’t want line wrapping when formatting Markdown, you can set the [Prose Wrap](#prose-wrap) option to disable it.)
 
 ## Tab Width


### PR DESCRIPTION
Closes #17514.

EditorConfig's `max_line_length` property accepts positive integers or `unset`, where `unset` means no line wrapping. Prettier already mapped `off` to `printWidth: Infinity`, but left `unset` unmapped, which is the spec-valid value. This change maps both `off` and `unset` to `Number.POSITIVE_INFINITY`.

Also updated the Print Width documentation to list valid values and their effects.