### PR TITLE
Keep the CLI error snapshots stable on Node.js 26

### DIFF
--- a/tests/integration/run-cli.js
+++ b/tests/integration/run-cli.js
@@ -188,6 +188,13 @@ function runCli(dir, args = [], options = {}) {
             /\r/g,
             options.ignoreLineEndings ? "" : "/*CR*/",
           );
+
+          // Node.js 26 appends the path to the `read` error raised when reading a
+          // directory; earlier versions stop at the syscall name.
+          value = value.replace(
+            /(?<=EISDIR: illegal operation on a directory, read) '[^'\n]*'/g,
+            "",
+          );
         }
 
         if (name in testOptions) {


### PR DESCRIPTION
## Description

`config-invalid` and `invalid-ignore` fail on Node.js 26 and pass on 14 through 22:

```
- [error] Unable to read '.prettierignore': EISDIR: illegal operation on a directory, read",
+ [error] Unable to read '.prettierignore': EISDIR: illegal operation on a directory, read '.prettierignore'",
```

Node.js 26 appends the offending path to the `read` error raised when reading a directory. Earlier versions stop at the syscall name, which is what the snapshots record.

This is not specific to any branch — every PR whose CI has run on the current Node 26 image hits it, including #19916 and #19908, with the same two suites and the same diff.

`runCli` already normalises `\r` before snapshotting, so the appended path is stripped in the same place. That keeps the existing snapshots valid on every supported version, rather than updating them to Node 26 and breaking 14 through 22.

The pattern is deliberately narrow. Node has always included the path for errors like `ENOENT ... open '/foo'`; what changed in 26 is that `read` includes it too. Matching every errno message would strip paths that snapshots legitimately record, so this only touches the `EISDIR ... read` case. No snapshot files change.

Verified by transforming the exact strings from the failing CI logs and confirming they equal the committed snapshots, and that Node ≤ 25 output passes through unchanged. Locally (Node 24) the full `tests/integration` suite is unaffected: 507 passed, 334 snapshots passed.

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

This is test-only and not user-facing, so no changelog entry or docs change. It adds no new test — the two existing suites are the coverage, and they are what currently fails on Node 26. I used AI assistance and reviewed everything before submitting.
