### PR TITLE
Fix CLI check error statuses and summaries

### DIFF
--- a/changelog_unreleased/cli/19931.md
+++ b/changelog_unreleased/cli/19931.md
@@ -1,0 +1,8 @@
+#### [BREAKING] Report failed CLI checks consistently (#19931 by @OskarEichler)
+
+When checking stdin with `--check` or `--list-different`, syntax errors and
+failures to infer a parser now return exit code `2` instead of logging an error
+and returning `0`. `--ignore-unknown` still skips unsupported inputs.
+
+Checks that encounter failed pattern expansion or file reads/writes now report
+an error summary instead of claiming that formatting succeeded.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -101,6 +101,12 @@ If you need to pipe the list of unformatted files to another command, you can u
 | `1`  | Something wasn’t formatted properly |
 | `2`  | Something’s wrong with Prettier     |
 
+When checking stdin, syntax errors and failures to infer a parser also return
+exit code `2`. Unsupported files are skipped when `--ignore-unknown` is set.
+
+If a file cannot be read or written, or a file pattern cannot be expanded,
+`--check` reports an error summary instead of claiming that formatting succeeded.
+
 ## `--debug-check`
 
 If you're worried that Prettier will change the correctness of your code, add `--debug-check` to the command. This will cause Prettier to print an error message if it detects that code correctness might have changed. Note that `--write` cannot be used with `--debug-check`.

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -93,7 +93,7 @@ async function listDifferent(context, input, options, filename) {
       process.exitCode = 1;
     }
   } catch (error) {
-    context.logger.error(error.message);
+    handleError(context, filename, error);
   }
 
   return true;
@@ -278,6 +278,7 @@ async function formatFiles(context) {
 
   let numberOfUnformattedFilesFound = 0;
   let numberOfFilesWithError = 0;
+  let hasPatternError = false;
   const { performanceTestFlag } = context;
 
   if (context.argv.check && !performanceTestFlag) {
@@ -308,6 +309,7 @@ async function formatFiles(context) {
   )) {
     if (error) {
       context.logger.error(error);
+      hasPatternError = true;
       // Don't exit, but set the exit code to 2
       process.exitCode = 2;
       continue;
@@ -352,6 +354,8 @@ async function formatFiles(context) {
 
       // Don't exit the process if one file failed
       process.exitCode = 2;
+
+      numberOfFilesWithError += 1;
 
       continue;
       /* c8 ignore stop */
@@ -430,6 +434,7 @@ async function formatFiles(context) {
 
           // Don't exit the process if one file failed
           process.exitCode = 2;
+          numberOfFilesWithError += 1;
         }
       } else if (!context.argv.check && !context.argv.listDifferent) {
         const message = `${picocolors.gray(fileNameToDisplay)} ${timeToDisplay} (unchanged)`;
@@ -470,7 +475,9 @@ async function formatFiles(context) {
 
   // Print check summary based on expected exit code
   if (context.argv.check) {
-    if (numberOfFilesWithError > 0) {
+    if (hasPatternError) {
+      context.logger.log("Error occurred when checking code style.");
+    } else if (numberOfFilesWithError > 0) {
       const files =
         numberOfFilesWithError === 1
           ? "the above file"


### PR DESCRIPTION
## Description

Fix false success reports in CLI checks: stdin formatting errors now use the same error handler as file formatting, and failed pattern expansion, reads, or writes cannot produce a successful formatting summary.

**Behavior change / draft merge gate:** stdin --check and --list-different return 2 instead of 0 for syntax errors and missing parsers. --ignore-unknown still skips unsupported inputs. Four existing tests explicitly assert the old exit code; this PR is draft until maintainers update those expectations and snapshots. No test assertions have been weakened or silently changed.

### Reproduction

Pipe invalid JavaScript (for example, `const =`) into `prettier --check --parser babel`: current main prints an error but exits 0; this change exits 2. The same applies to --list-different and --write combinations. Checking a nonexistent file currently prints both an error and “All matched files use Prettier code style!”; this change reports a failed check instead.

### Validation

- Sixteen standalone stdin/pattern scenarios and controlled read/write failures pass, with unchanged-upstream reproductions.
- Isolated PR: 30 existing tests pass, four fail exclusively on the intentional old-code-0 expectations.
- Combined audit checkpoint: 35,268 existing tests pass, four fail on those same expectations, five skip; 13,406 snapshots pass and four become obsolete. This is not a green full suite.
- Source lint, formatting, and repository typecheck pass (the repository typecheck excludes the CLI).
- No checked-in test/spec/snapshot files added or modified. Regression coverage and snapshot updates remain a merge requirement. No application dependency changes.

## Checklist

- [ ] I’ve added tests to confirm my change works. (Existing suites and external standalone controls were run; no checked-in tests added.)
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the docs/ directory).
- [x] (If the change is user-facing) I’ve added my changes to changelog_unreleased/*/XXXX.md.
- [x] I’ve read the contributing guidelines.
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

All four production packages build successfully from an isolated physical copy with matching source and dependency manifests. The original checkout inherited an unrelated ancestor Yarn PnP manifest; no user environment files were changed to work around it. An initial bundled test run omitted external parser builds; after building the companions, all 3,604 selected bundled-code tests and 2,011 snapshots passed. The final combined production full suite, including document follow-ups, reports 35,127 passing tests, the same four intentional stdin exit-code expectation failures, five skipped tests, and 13,366 passing snapshots. This is not a claim of a green full suite; that compatibility change remains draft and is absent from the other three focused PRs.

AI disclosure: generated and self-reviewed by Codex at the submitting GitHub account owner’s request. No independent human review is claimed. The focused diff, unchanged-baseline controls and limits above were reviewed before submission.
