### PR TITLE
Bypass formatting cache for diagnostics and cursor results

### DIFF
--- a/changelog_unreleased/cli/19932.md
+++ b/changelog_unreleased/cli/19932.md
@@ -1,0 +1,9 @@
+#### Preserve diagnostic and cursor results with `--cache` (#19932 by @OskarEichler)
+
+Diagnostic and performance modes now bypass the formatting cache without
+deleting existing cache entries. A warm cache no longer makes `--debug-check`
+fail on valid code, replaces debug output with source text, or skips performance
+measurement.
+
+Cursor requests also recompute formatting, avoiding `undefined` cursor positions
+on cache hits. Normal formatting and check caching remain unchanged.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -233,6 +233,10 @@ prettier . --write --cache
 
 Running Prettier without `--cache` will delete the cache.
 
+Diagnostic and performance modes bypass the formatting cache. Requests with
+`--cursor-offset` also recompute formatting because cached entries do not contain
+cursor positions.
+
 Also, since the cache file is stored in `./node_modules/.cache/prettier/.prettier-cache`, so you can use `rm ./node_modules/.cache/prettier/.prettier-cache` to remove it manually.
 
 :::warning

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -279,6 +279,13 @@ async function formatFiles(context) {
   let numberOfUnformattedFilesFound = 0;
   let numberOfFilesWithError = 0;
   const { performanceTestFlag } = context;
+  const useCache =
+    context.argv.cache &&
+    !context.argv.debugCheck &&
+    !context.argv.debugPrintDoc &&
+    !context.argv.debugPrintAst &&
+    !context.argv.debugPrintComments &&
+    !performanceTestFlag;
 
   if (context.argv.check && !performanceTestFlag) {
     context.logger.log("Checking formatting...");
@@ -286,12 +293,12 @@ async function formatFiles(context) {
 
   let formatResultsCache;
   const cacheFilePath = await findCacheFile(context.argv.cacheLocation);
-  if (context.argv.cache) {
+  if (useCache) {
     formatResultsCache = new FormatResultsCache(
       cacheFilePath,
       context.argv.cacheStrategy || "content",
     );
-  } else if (!context.argv.cacheLocation) {
+  } else if (!context.argv.cache && !context.argv.cacheLocation) {
     const stat = await statSafe(cacheFilePath);
     if (stat) {
       await fs.unlink(cacheFilePath);
@@ -365,10 +372,10 @@ async function formatFiles(context) {
 
     const start = mockable.getTimestamp();
 
-    const isCacheExists = formatResultsCache?.existsAvailableFormatResultsCache(
-      filename,
-      options,
-    );
+    // Cache entries only establish that the text is formatted, not its cursor position.
+    const isCacheExists =
+      !(options.cursorOffset >= 0) &&
+      formatResultsCache?.existsAvailableFormatResultsCache(filename, options);
 
     let result;
     let output;


### PR DESCRIPTION
## Description

Preserve CLI results when --cache is combined with diagnostics, performance measurement, or cursor output. Cache entries establish only that source text is formatted; they do not contain a debug result or a relocated cursor.

**Observable fixes:** a second --debug-check no longer exits 2 on valid unchanged code; warmed --debug-print-doc/ast/comments emit their requested output instead of cached source text; warmed --debug-repeat actually measures formatting; --cursor-offset no longer prints undefined. These modes do more work deliberately to produce the requested result. Normal formatting/check caching remains unchanged. No public option, engine, or dependency-version change.

Diagnostic/performance modes bypass cache construction without deleting a caller's existing cache. Cursor requests bypass cache hits after per-file options have been resolved, so configuration-file cursor settings are covered too.

### Validation

- Twelve warm-cache controls reproduce all six incorrect results on unchanged main and verify all six fixes; diagnostic runs also preserve cache bytes. Repeated cold-cache runs cover the debug-check and cursor regressions.
- Isolated PR: 65 existing tests pass, including cache, parser inference, debug-check and debug-print-doc; 29 snapshots pass.
- Combined audit checkpoint: 35,268 existing tests pass. Four failures belong to the separate stdin exit-status change and are not part of this PR; five tests skip.
- Source lint, formatting, and repository typecheck pass (the repository typecheck excludes the CLI).
- No checked-in test/spec/snapshot changes and no app adoption. This does not duplicate #19086's invalid-file cache eviction or #17808's plugin invalidation work.

## Checklist

- [ ] I’ve added tests to confirm my change works. (Existing suites and external standalone controls were run; no checked-in tests added.)
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the docs/ directory).
- [x] (If the change is user-facing) I’ve added my changes to changelog_unreleased/*/XXXX.md.
- [x] I’ve read the contributing guidelines.
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

All four production packages build successfully from an isolated physical copy with matching source and dependency manifests. The original checkout inherited an unrelated ancestor Yarn PnP manifest; no user environment files were changed to work around it. An initial bundled test run omitted external parser builds; after building the companions, all 3,604 selected bundled-code tests and 2,011 snapshots passed. The final combined production full suite, including document follow-ups, reports 35,127 passing tests, the same four intentional stdin exit-code expectation failures, five skipped tests, and 13,366 passing snapshots. This is not a claim of a green full suite; that compatibility change remains draft and is absent from the other three focused PRs.

AI disclosure: generated and self-reviewed by Codex at the submitting GitHub account owner’s request. No independent human review is claimed. The focused diff, unchanged-baseline controls and limits above were reviewed before submission.
