### PR TITLE
Avoid argument-count limits in document cleanup, debug output and suffixes

### DIFF
--- a/changelog_unreleased/api/19933.md
+++ b/changelog_unreleased/api/19933.md
@@ -1,0 +1,9 @@
+#### Avoid argument-count limits during document cleanup (#19933 by @OskarEichler)
+
+Cleaning large flat nested documents no longer spreads all elements into an
+`Array.push` call, which could throw a `RangeError` when the engine's argument
+limit was exceeded. This also avoids temporary arrays while preserving document
+order and string coalescing.
+
+This improves embedded-language formatting and document utilities that perform
+cleanup. It does not remove recursive-depth limits elsewhere in the formatter.

--- a/changelog_unreleased/api/19933.md
+++ b/changelog_unreleased/api/19933.md
@@ -1,9 +1,12 @@
-#### Avoid argument-count limits during document cleanup (#19933 by @OskarEichler)
+#### Avoid argument-count limits while processing documents (#19933 by @OskarEichler)
 
 Cleaning large flat nested documents no longer spreads all elements into an
 `Array.push` call, which could throw a `RangeError` when the engine's argument
 limit was exceeded. This also avoids temporary arrays while preserving document
 order and string coalescing.
+
+Debug-document flattening and line-suffix flushing also append incrementally,
+avoiding the same argument-count limit for large documents and pending suffixes.
 
 This improves embedded-language formatting and document utilities that perform
 cleanup. It does not remove recursive-depth limits elsewhere in the formatter.

--- a/src/document/debug.js
+++ b/src/document/debug.js
@@ -23,7 +23,9 @@ function flattenDoc(doc) {
     const res = [];
     for (const part of doc) {
       if (Array.isArray(part)) {
-        res.push(...flattenDoc(part));
+        for (const flattened of flattenDoc(part)) {
+          res.push(flattened);
+        }
       } else {
         const flattened = flattenDoc(part);
         if (flattened !== "") {

--- a/src/document/printer/printer.js
+++ b/src/document/printer/printer.js
@@ -194,6 +194,12 @@ function printDocToString(doc, options) {
 
   const result = new PrintResult();
 
+  function flushLineSuffix() {
+    while (lineSuffix.length > 0) {
+      commands.push(lineSuffix.pop());
+    }
+  }
+
   propagateBreaks(doc);
 
   while (commands.length > 0) {
@@ -493,8 +499,8 @@ function printDocToString(doc, options) {
 
           case MODE_BREAK:
             if (lineSuffix.length > 0) {
-              commands.push({ indent, mode, doc }, ...lineSuffix.reverse());
-              lineSuffix.length = 0;
+              commands.push({ indent, mode, doc });
+              flushLineSuffix();
               break;
             }
 
@@ -531,8 +537,7 @@ function printDocToString(doc, options) {
     // Flush remaining line-suffix contents at the end of the document, in case
     // there is no new line after the line-suffix.
     if (commands.length === 0 && lineSuffix.length > 0) {
-      commands.push(...lineSuffix.reverse());
-      lineSuffix.length = 0;
+      flushLineSuffix();
     }
   }
 

--- a/src/document/utilities/index.js
+++ b/src/document/utilities/index.js
@@ -308,7 +308,8 @@ function cleanDocFn(doc) {
         if (!part) {
           continue;
         }
-        const [currentPart, ...restParts] = Array.isArray(part) ? part : [part];
+        const isArray = Array.isArray(part);
+        const currentPart = isArray ? part[0] : part;
         if (
           typeof currentPart === "string" &&
           typeof parts.at(-1) === "string"
@@ -317,7 +318,11 @@ function cleanDocFn(doc) {
         } else {
           parts.push(currentPart);
         }
-        parts.push(...restParts);
+        if (isArray) {
+          for (let index = 1; index < part.length; index++) {
+            parts.push(part[index]);
+          }
+        }
       }
 
       if (parts.length === 0) {


### PR DESCRIPTION
## Description

Remove argument-count limits from document cleanup, debug-document flattening and line-suffix flushing. A nested flat document with 160,000 alternating text/line elements currently throws RangeError when its remaining elements are spread into Array.push. Indexed append handles the same document without converting the elements into function arguments. Debug flattening and queued line comments have the same demonstrated limit; incremental appends preserve their original order at newline, suffix-boundary and end-of-document flushes.

The change also avoids allocating [part] and rest arrays for each ordinary part. Existing first/last string coalescing and document order are preserved.

**Compatibility:** no intended formatting or API change; large flat nested documents that previously crashed now complete. This is not a claim to remove recursive-depth limits elsewhere in the formatter.

### Validation

- Unchanged-main crash reproduced; fixed cleanup preserves all 160,000 elements.
- Representative group/fill/conditional trees and 1,000 seeded bounded random trees produce exactly the same cleaned documents as unchanged main.
- Isolated final PR: 186 existing unit/document/debug tests and 84 snapshots pass. Five additional controls reproduce the suffix/debug crashes and compare 1,000 seeded document trees, including tabs and spaces, against unchanged upstream.
- Combined full-suite checkpoint: 35,268 tests and 13,406 snapshots pass. Four failures belong to a separate CLI exit-status change; five skip.
- A local Node 22 microbenchmark over 10,000 small nested arrays measured median ten-run times of 23.13 ms before and 15.80 ms after. This is an isolated measurement, not a whole-project speedup guarantee.
- Source lint, formatting and repository typecheck pass. No checked-in tests/specs/snapshots or application dependencies changed.

## Checklist

- [ ] I’ve added tests to confirm my change works. (Existing suites and external standalone controls were run; no checked-in tests added.)
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the docs/ directory). Not applicable: no public API change.
- [x] (If the change is user-facing) I’ve added my changes to changelog_unreleased/*/XXXX.md.
- [x] I’ve read the contributing guidelines.
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

All four production packages build successfully from an isolated physical copy with matching source and dependency manifests. The original checkout inherited an unrelated ancestor Yarn PnP manifest; no user environment files were changed to work around it. An initial bundled test run omitted external parser builds; after building the companions, all 3,604 selected bundled-code tests and 2,011 snapshots passed. The final combined production full suite, including document follow-ups, reports 35,127 passing tests, the same four intentional stdin exit-code expectation failures, five skipped tests, and 13,366 passing snapshots. This is not a claim of a green full suite; that compatibility change remains draft and is absent from the other three focused PRs.

AI disclosure: generated and self-reviewed by Codex at the submitting GitHub account owner’s request. No independent human review is claimed. The focused diff, unchanged-baseline controls and limits above were reviewed before submission.
