### PR TITLE
Exclude DEL from the printable ASCII width fast path

### DIFF
--- a/changelog_unreleased/misc/19934.md
+++ b/changelog_unreleased/misc/19934.md
@@ -1,0 +1,6 @@
+#### Measure DEL consistently as a zero-width control character (#19934 by @OskarEichler)
+
+The printable-ASCII fast path now excludes U+007F (DEL), matching the existing
+Unicode path. DEL therefore contributes zero columns regardless of surrounding
+text. Lines containing this control character may fit or wrap differently;
+other width rules are unchanged.

--- a/src/utilities/get-string-width.js
+++ b/src/utilities/get-string-width.js
@@ -7,7 +7,7 @@ import {
 } from "get-east-asian-width";
 import { isNarrowEmojiCharacter } from "narrow-emojis";
 
-const notAsciiRegex = /[^\x20-\x7F]/;
+const notAsciiRegex = /[^\x20-\x7E]/;
 // Exclude [`Spacing Mark`](https://www.compart.com/en/unicode/category/Mc) because spacing marks contribute horizontal width.
 const zeroWidthMarkRegex = /[\p{Nonspacing_Mark}\p{Enclosing_Mark}]/u;
 


### PR DESCRIPTION
## Description

Exclude U+007F (DEL) from the printable-ASCII fast path used to measure text width. The existing slow path already assigns DEL zero width, but the fast path currently counts it as one column. As a result, the same control character changes width depending on whether surrounding text contains non-ASCII characters.

**Formatting change:** lines containing literal DEL may now fit or wrap differently because the character is consistently zero width. Other ASCII/Unicode width rules and public APIs remain unchanged.

### Validation

- Unchanged-main reproduction: width of a\u007Fb is 3; corrected width is 2.
- Standalone controls cover DEL alone and in ASCII/Unicode text, other C0/C1 controls, combining marks, CJK and emoji.
- Isolated PR: 3,729 existing unit/Markdown/HTML/JSX tests and 2,040 snapshots pass.
- Combined full-suite checkpoint: 35,268 tests and 13,406 snapshots pass; four failures belong to a separate CLI exit-status change, and five skip.
- Source lint, formatting and repository typecheck pass. No checked-in tests/specs/snapshots or application dependency changes.

## Checklist

- [ ] I’ve added tests to confirm my change works. (Existing suites and external standalone controls were run; no checked-in tests added.)
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the docs/ directory). Not applicable: no public API change.
- [x] (If the change is user-facing) I’ve added my changes to changelog_unreleased/*/XXXX.md.
- [x] I’ve read the contributing guidelines.
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

All four production packages build successfully from an isolated physical copy with matching source and dependency manifests. The original checkout inherited an unrelated ancestor Yarn PnP manifest; no user environment files were changed to work around it. An initial bundled test run omitted external parser builds; after building the companions, all 3,604 selected bundled-code tests and 2,011 snapshots passed. The final combined production full suite, including document follow-ups, reports 35,127 passing tests, the same four intentional stdin exit-code expectation failures, five skipped tests, and 13,366 passing snapshots. This is not a claim of a green full suite; that compatibility change remains draft and is absent from the other three focused PRs.

AI disclosure: generated and self-reviewed by Codex at the submitting GitHub account owner’s request. No independent human review is claimed. The focused diff, unchanged-baseline controls and limits above were reviewed before submission.
