### PR TITLE
Fix fitting of pending line spaces and trim

### DIFF
--- a/changelog_unreleased/api/19935.md
+++ b/changelog_unreleased/api/19935.md
@@ -1,0 +1,8 @@
+#### Measure pending line spaces and trimming consistently (#19935 by @OskarEichler)
+
+Document fitting now counts every pending space produced by consecutive `line`
+commands and discards those pending spaces when it encounters `trim`.
+
+This prevents unnecessary wrapping when the spaces would be trimmed and avoids
+underestimating the width of consecutive spaces. Documents containing these
+combinations may wrap differently; no public API or formatting option is added.

--- a/src/document/printer/printer.js
+++ b/src/document/printer/printer.js
@@ -63,7 +63,7 @@ function fits(
   }
 
   let restCommandsIndex = restCommands.length;
-  let hasPendingSpace = false;
+  let pendingSpaces = 0;
   /** @type {Array<Omit<Command, 'indent'>>} */
   const commands = [next];
   // `output` is only used for width counting because `trim` requires to look
@@ -84,10 +84,10 @@ function fits(
     switch (docType) {
       case DOC_TYPE_STRING:
         if (doc) {
-          if (hasPendingSpace) {
-            output += " ";
-            remainingWidth -= 1;
-            hasPendingSpace = false;
+          if (pendingSpaces > 0) {
+            output += " ".repeat(pendingSpaces);
+            remainingWidth -= pendingSpaces;
+            pendingSpaces = 0;
           }
 
           output += doc;
@@ -113,6 +113,7 @@ function fits(
         break;
 
       case DOC_TYPE_TRIM: {
+        pendingSpaces = 0;
         const { text, count } = trimIndentation(output);
         output = text;
         remainingWidth += count;
@@ -150,7 +151,7 @@ function fits(
           return true;
         }
         if (!doc.soft) {
-          hasPendingSpace = true;
+          pendingSpaces++;
         }
         break;
 


### PR DESCRIPTION
## Description

Fix predictive width calculations for flattened `line` documents and `trim`:

- Count every pending line-generated space, not just whether any space is pending.
- Clear pending spaces on `trim`, matching what the actual printer removes.

**Formatting change:** affected documents may wrap differently. A group equivalent to `group(["aa", line, trim, "bb"])` now prints `aabb` at width 4 instead of unnecessarily breaking. `group(["a", line, line, "b"])` no longer prints four columns on a width-3 line. No new option or public API is introduced. This change does not address arbitrary raw strings with trailing whitespace or every other fitting heuristic.

### Validation

- Both incorrect results reproduce on unchanged main at `0283c8848ecb541c7ea0601ff274799bce1b39e5`.
- 571 standalone cases pass against the isolated PR: the reproductions, all 81 four-command combinations of line/softline/trim at seven widths, and nested indentation with LF/CRLF output.
- Isolated existing suites: 3,729 tests and 2,040 snapshots pass.
- Full source suite with the other audit fixes: 35,268 tests pass, four fail only on the separate draft CLI exit-code change, five skip; 13,406 snapshots pass. This PR does not include that CLI change.
- Changed-source ESLint, formatting, repository typecheck and whitespace checks pass.
- Rebuilt production package: all 3,560 selected document/Markdown/HTML/JSX tests and 2,044 snapshots pass after this change.
- No checked-in tests/specs/snapshots changed. No application dependency adoption. Hosted CI and platform matrices are not claimed.

## Checklist

- [ ] I’ve added tests to confirm my change works. Existing suites and external controls were run; no checked-in tests added.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the docs/ directory). Not applicable: no public API/CLI option changes.
- [x] (If the change is user-facing) I’ve added my changes to changelog_unreleased/api/19935.md.
- [x] I’ve read the contributing guidelines.
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

AI disclosure: generated and self-reviewed by Codex at the submitting GitHub account owner’s request. No independent human review is claimed.
