### PR TITLE
Validate build output selections and relative destinations

### DIFF
--- a/scripts/build/README.md
+++ b/scripts/build/README.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- Node.js version `>= 16.16`.
+- Node.js version `>= 22` (see the repository's `package.json`).
 
 ## Usage
 
@@ -56,22 +56,25 @@ yarn build --compare-size
 
 ### `--file`
 
-To build specific file(s):
+To build specific file(s), use paths relative to `dist/`, including the package
+directory. Unknown output paths are rejected:
 
 ```sh
-yarn build --file=esm/parser-babel.mjs
+yarn build --file=prettier/plugins/babel.mjs
 ```
 
 ```sh
-yarn build --file=standalone.js --file=parser-meriyah.js
+yarn build --file=prettier/standalone.js --file=prettier/plugins/meriyah.js
 ```
 
 ### `--save-as`
 
-To save bundled file to a different location, this flag can only use together with ONE `--file` flag
+To save a JavaScript bundle to a different location, use this flag with exactly
+one `--file` flag. The destination must be a relative file path inside that
+package's output directory:
 
 ```sh
-yarn build --file=parser-babel.js --save-as=babel-for-test.js
+yarn build --file=prettier/plugins/babel.js --save-as=babel-for-test.js
 ```
 
 ### `--report`
@@ -91,18 +94,19 @@ yarn build --report=stdout --report=text --report=html
 
 ### `--minify` and `--no-minify`
 
-By default, the file minification is controlled by `config.mjs` and `bundler.mjs`, these flags are added to override that behavior.
+By default, file minification is controlled by the package build configuration.
+These flags override that behavior.
 
 These should only be used for debugging purposes, suggest to use them together with the `--file` flag.
 
 Force minify files:
 
 ```sh
-yarn build --file=index.js --minify
+yarn build --file=prettier/index.mjs --minify
 ```
 
 Disable minify files:
 
 ```sh
-yarn build --file=parser-babel.js --no-minify
+yarn build --file=prettier/plugins/babel.js --no-minify
 ```

--- a/scripts/build/README.md
+++ b/scripts/build/README.md
@@ -71,7 +71,8 @@ yarn build --file=prettier/standalone.js --file=prettier/plugins/meriyah.js
 
 To save a JavaScript bundle to a different location, use this flag with exactly
 one `--file` flag. The destination must be a relative file path inside that
-package's output directory:
+package's output directory. Relative imports to other bundled files are adjusted
+when moving a bundle into a nested directory:
 
 ```sh
 yarn build --file=prettier/plugins/babel.js --save-as=babel-for-test.js

--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -139,6 +139,23 @@ async function run() {
     packagesToBuild = packageConfigs;
   }
 
+  if (cliOptions.files) {
+    const availableFiles = new Set(
+      packagesToBuild.flatMap(({ distDirectory, modules }) =>
+        modules.flatMap(({ files }) =>
+          files.map(({ output }) => path.join(distDirectory, output)),
+        ),
+      ),
+    );
+    for (const file of cliOptions.files) {
+      if (!availableFiles.has(file)) {
+        throw new Error(
+          `Unknown output file '${path.relative(DIST_DIR, file)}'`,
+        );
+      }
+    }
+  }
+
   // TODO: Clear package dist directory instead
   if (cliOptions.clean) {
     let stat;

--- a/scripts/build/builders/javascript-module.js
+++ b/scripts/build/builders/javascript-module.js
@@ -157,7 +157,7 @@ function getEsbuildOptions({ packageConfig, file, cliOptions, buildOptions }) {
 
       return {
         module: path.join(sourceDirectory, bundle.input),
-        external: getRelativePath(file.output, output),
+        external: getRelativePath(cliOptions.saveAs ?? file.output, output),
       };
     });
     replaceModule.push(...replacements);

--- a/scripts/build/parse-arguments.js
+++ b/scripts/build/parse-arguments.js
@@ -42,17 +42,23 @@ function parseArguments() {
     throw new Error("'--package' should be unique.");
   }
 
-  if (result.saveAs) {
+  if (result.saveAs !== undefined) {
     if (result.files?.size !== 1) {
       throw new Error(
         "'--save-as' can only use together with one '--file' flag.",
       );
     }
 
-    // TODO: Support package name
-    const distDirectory = path.join(DIST_DIR, "prettier");
-    if (!path.join(distDirectory, result.saveAs).startsWith(distDirectory)) {
-      throw new Error("'--save-as' can only relative path.");
+    const normalized = path.normalize(result.saveAs);
+    if (
+      path.isAbsolute(normalized) ||
+      normalized === "." ||
+      normalized === ".." ||
+      normalized.startsWith(`..${path.sep}`)
+    ) {
+      throw new Error(
+        "'--save-as' must be a relative file path inside the package output directory.",
+      );
     }
   }
 


### PR DESCRIPTION
## Description

Validate build output selections and destinations before starting work, and update the contributor examples to match the package-based output layout.

- Reject unknown `--file` paths instead of reporting success after skipping every output. Validation also respects `--package` selection and runs before `--clean`.
- Reject empty/root/absolute/escaping `--save-as` destinations. The old string-prefix check accepted `../prettier-sibling/output.mjs`, absolute paths and `.`; the new lexical check does not depend on a hardcoded `prettier` package directory.
- Document `dist/`-relative package-qualified file selectors, JavaScript-bundle renaming and the repository's actual Node 22 requirement; remove references to obsolete build files.
- Recalculate relative imports from the actual renamed output path, so nested `--save-as` bundles can still load sibling artifacts.

**Contributor-visible behavior change:** mistyped output selectors and invalid destinations now fail explicitly. Valid builds, nested relative destinations and published runtime APIs/versions are unchanged. This is lexical destination validation, not a filesystem sandbox or a symlink-escape guarantee. Renaming non-JavaScript artifacts is not added by this PR.

### Validation

- 27 standalone argument/selection controls, including unchanged-upstream false-success and destination reproductions.
- Real renamed Babel and Yuku builds produce the requested files (309,862 and 476,352 bytes in this environment).
- Moving the main API to `audit/index.mjs` reproduces ERR_MODULE_NOT_FOUND before the relative-import fix; the rebuilt nested API imports and formats JavaScript successfully afterward.
- All four production packages build successfully with the changed driver and argument validation.
- Changed-source ESLint, formatting, documentation spelling and whitespace checks pass.
- No checked-in tests/specs/snapshots modified. No app adoption or dependency version changes. Windows execution and hosted CI are not claimed.
- Validation used a physical isolated copy to avoid an unrelated ancestor Yarn PnP manifest; no user environment files were edited.

## Checklist

- [ ] I’ve added tests to confirm my change works. External controls and actual builds were run; no checked-in tests added.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the docs/ directory). Internal build CLI only; documented in scripts/build/README.md.
- [ ] (If the change is user-facing) I’ve added my changes to changelog_unreleased/*/XXXX.md. Not applicable: internal contributor build tooling, not the published formatter CLI/API.
- [x] I’ve read the contributing guidelines.
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

AI disclosure: generated and self-reviewed by Codex at the submitting GitHub account owner’s request. No independent human review is claimed.
