### PR TITLE
Preserve carriage returns in GraphQL strings and reuse argument printing

### DIFF
--- a/changelog_unreleased/graphql/19937.md
+++ b/changelog_unreleased/graphql/19937.md
@@ -1,0 +1,19 @@
+#### Preserve escaped carriage returns in strings (#19937 by @OskarEichler)
+
+Carriage returns in ordinary GraphQL strings now remain escaped. Previously,
+formatting emitted a literal carriage return and the output could not be parsed
+again. String descriptions and default values receive the same correction.
+
+<!-- prettier-ignore -->
+```graphql
+# Input
+{ f(a: "a\rb") }
+
+# Prettier stable
+# Emits a literal carriage return inside the string, making the output invalid.
+
+# Prettier main
+{
+  f(a: "a\rb")
+}
+```

--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -74,20 +74,7 @@ function genericPrint(path, options, print) {
       return group([
         node.alias ? [print("alias"), ": "] : "",
         print("name"),
-        isNonEmptyArray(node.arguments)
-          ? group([
-              "(",
-              indent([
-                softline,
-                join(
-                  [ifBreak("", ", "), softline],
-                  printSequence(path, options, print, "arguments"),
-                ),
-              ]),
-              softline,
-              ")",
-            ])
-          : "",
+        printArguments(path, options, print),
         printDirectives(path, print),
         node.selectionSet ? " " : "",
         print("selectionSet"),
@@ -115,6 +102,7 @@ function genericPrint(path, options, print) {
         '"',
         node.value
           .replaceAll(/["\\]/g, String.raw`\$&`)
+          .replaceAll("\r", String.raw`\r`)
           .replaceAll("\n", String.raw`\n`),
         '"',
       ];
@@ -246,20 +234,7 @@ function genericPrint(path, options, print) {
       return [
         printDescription(path, options, print),
         print("name"),
-        isNonEmptyArray(node.arguments)
-          ? group([
-              "(",
-              indent([
-                softline,
-                join(
-                  [ifBreak("", ", "), softline],
-                  printSequence(path, options, print, "arguments"),
-                ),
-              ]),
-              softline,
-              ")",
-            ])
-          : "",
+        printArguments(path, options, print),
         ": ",
         print("type"),
         printDirectives(path, print),
@@ -271,20 +246,7 @@ function genericPrint(path, options, print) {
         "directive ",
         "@",
         print("name"),
-        isNonEmptyArray(node.arguments)
-          ? group([
-              "(",
-              indent([
-                softline,
-                join(
-                  [ifBreak("", ", "), softline],
-                  printSequence(path, options, print, "arguments"),
-                ),
-              ]),
-              softline,
-              ")",
-            ])
-          : "",
+        printArguments(path, options, print),
         printDirectives(path, print),
         node.repeatable ? " repeatable" : "",
         " on ",


### PR DESCRIPTION
## Description

**Formatting correction:** an escaped carriage return in a GraphQL string must remain escaped. Previously formatting `{ f(a: "a\rb") }` emitted a literal carriage return, producing an unterminated string when parsed again. This also affects escaped Unicode U+000D and string descriptions/defaults. Preserve the string value by emitting `\r`; keep all other existing escape and block-string behavior unchanged.

Also reuse the existing `printArguments` helper for fields, field definitions and directive definitions, removing three equivalent formatting implementations. This refactor does not intentionally change formatting.

No public API, option, dependency or supported runtime changes. GraphQL's [String Value grammar](https://spec.graphql.org/September2025/#sec-String-Value) excludes literal line terminators from ordinary quoted strings.

### Validation

- Reproduced invalid output on unchanged main `0283c8848ecb541c7ea0601ff274799bce1b39e5`.
- 2,520 standalone string cases preserve parsed values and remain stable on a second format, across LF/CRLF/CR output, arguments, descriptions, defaults, Unicode and escaped backslashes. Another 88 argument-layout cases exactly match baseline output.
- Isolated PR: all 643 existing GraphQL checks and 109 snapshots pass with `FULL_TEST=1`.
- Rebuilt GraphQL/YAML bundles: all 10,364 combined existing checks and 1,733 snapshots pass with `FULL_TEST=1`. The separate YAML optimization is not included in this PR.
- Changed-source ESLint, formatting, repository typecheck and whitespace checks pass.
- No checked-in tests/specs/snapshots added or edited; standalone diagnostic scripts are external to the repository. No hosted CI/platform-matrix claim or application dependency adoption.

## Checklist

- [ ] I’ve added tests to confirm my change works. Existing suites and external controls were run; no checked-in tests added.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the docs/ directory). Not applicable.
- [x] (If the change is user-facing) I’ve added my changes to changelog_unreleased/graphql/19937.md.
- [x] I’ve read the contributing guidelines.
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

AI disclosure: generated and self-reviewed by Codex at the submitting GitHub account owner’s request. No independent human review is claimed.
