### PR TITLE
Avoid quadratic YAML scalar word accumulation

### DIFF
--- a/changelog_unreleased/yaml/19938.md
+++ b/changelog_unreleased/yaml/19938.md
@@ -1,0 +1,9 @@
+#### Avoid repeated scalar word accumulation (#19938 by @OskarEichler)
+
+Formatting long multiline flow and folded YAML scalars no longer copies all
+previously collected words for each additional line. Folded scalars also check
+word boundaries without repeatedly converting the accumulated array to a string.
+
+Formatting and scalar values are unchanged. The improvement applies to scalar
+word accumulation when prose wrapping combines multiple input lines, not every
+stage of YAML parsing or printing.

--- a/src/language-yaml/utilities.js
+++ b/src/language-yaml/utilities.js
@@ -185,7 +185,10 @@ function getFlowScalarLineContents(nodeType, content, options) {
         nodeType === "quoteDouble" && lines.at(-1).at(-1).endsWith("\\")
       )
     ) {
-      lines[lines.length - 1] = [...lines.at(-1), ...words];
+      const previousWords = lines.at(-1);
+      for (const word of words) {
+        previousWords.push(word);
+      }
     } else {
       lines.push(words);
     }
@@ -244,12 +247,13 @@ function getBlockValueLineContents(
       words.length > 0 &&
       rawLineContents[index - 1].length > 0 &&
       !/^\s/.test(words[0]) &&
-      // This test against a `string[]`, should be a mistake
-      // originally introduced in https://github.com/prettier/prettier/pull/4742/files#diff-a4dc2e1922e1d8d5ac20818480f777c9a2d5af739eaa3a0409b08bf29a9d0f74R282
-      // @ts-expect-error -- see comment above
-      !/^\s|\s$/.test(lines.at(-1))
+      !/^\s/.test(lines.at(-1)[0]) &&
+      !/\s$/.test(lines.at(-1).at(-1))
     ) {
-      lines[lines.length - 1] = [...lines.at(-1), ...words];
+      const previousWords = lines.at(-1);
+      for (const word of words) {
+        previousWords.push(word);
+      }
     } else {
       lines.push(words);
     }


### PR DESCRIPTION
## Description

Avoid repeated copying and stringification of the accumulated words in multiline YAML scalars:

- Append newly parsed words to the owned output array instead of copying every preceding word again for each line. An indexed-size-independent loop also avoids the function argument-count limit of spreading into `push`.
- Check the first and last words for whitespace instead of coercing the entire previous word array to a comma-joined string on every folded line. This preserves the existing boundary check and removes its TypeScript suppression.

**Compatibility:** no intentional formatting, scalar-value, API, option or dependency change. Blank lines, indentation, chomping, literal blocks, escaped continuations and all three prose-wrap modes retain their existing behavior. This improves scalar-word accumulation, not every stage of YAML parsing/printing.

### Validation

- Isolated PR: all 9,721 existing YAML checks and 1,624 snapshots pass with `FULL_TEST=1`.
- 15,000 seeded utility comparisons and 1,800 whole-document formatting comparisons exactly match unchanged main `0283c8848ecb541c7ea0601ff274799bce1b39e5`.
- Synthetic 8,000-line, 16,000-word helper benchmark (six measured runs after warmup, local Node 22): median flow-scalar accumulation 105.70 ms before / 0.58 ms after; folded-block accumulation 646.83 ms before / 1.81 ms after. These are helper microbenchmarks, not application-wide speedups or general throughput guarantees.
- Rebuilt GraphQL/YAML bundles: all 10,364 combined existing checks and 1,733 snapshots pass with `FULL_TEST=1`. The separate GraphQL fix is not included in this PR.
- Changed-source ESLint, formatting, repository typecheck and whitespace checks pass.
- No checked-in tests/specs/snapshots added or edited; standalone diagnostic scripts are external to the repository. No hosted CI/platform-matrix claim or application dependency adoption.

## Checklist

- [ ] I’ve added tests to confirm my change works. Existing suites and external controls were run; no checked-in tests added.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the docs/ directory). Not applicable.
- [x] (If the change is user-facing) I’ve added my changes to changelog_unreleased/yaml/19938.md.
- [x] I’ve read the contributing guidelines.
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

AI disclosure: generated and self-reviewed by Codex at the submitting GitHub account owner’s request. No independent human review is claimed.
