### PR TITLE
Keep an own-line comment before a satisfies or as type on its own line

### DIFF
--- a/changelog_unreleased/typescript/19939-2.md
+++ b/changelog_unreleased/typescript/19939-2.md
@@ -1,16 +1,16 @@
-#### Fix misaligned block comment before a `satisfies` or `as` type (#19939 by @Kjubikstronk)
+#### Fix misaligned jsdoc comment before a `satisfies` or `as` type (#19939 by @Kjubikstronk)
 
 <!-- prettier-ignore -->
 ```tsx
 // Input
 const foo = {
-  bar: 1
+  bar: 1,
 } as
-/**
- * comment line 1
- * comment line 2
- */
-Foo;
+  /**
+   * comment line 1
+   * comment line 2
+   */
+  Foo;
 
 // Prettier stable
 const foo = {

--- a/changelog_unreleased/typescript/19939-2.md
+++ b/changelog_unreleased/typescript/19939-2.md
@@ -1,4 +1,4 @@
-#### Keep a block comment before a `satisfies` or `as` type on its own line (#19939 by @Kjubikstronk)
+#### Fix misaligned block comment before a `satisfies` or `as` type (#19939 by @Kjubikstronk)
 
 <!-- prettier-ignore -->
 ```tsx

--- a/changelog_unreleased/typescript/19939-2.md
+++ b/changelog_unreleased/typescript/19939-2.md
@@ -1,0 +1,24 @@
+#### Keep a block comment before a `satisfies` or `as` type on its own line (#19939 by @Kjubikstronk)
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+1 as
+/**
+ * jsdoc
+ */
+Foo;
+
+// Prettier stable
+1 as /**
+ * jsdoc
+ */
+Foo;
+
+// Prettier main
+1 as
+  /**
+   * jsdoc
+   */
+  Foo;
+```

--- a/changelog_unreleased/typescript/19939-2.md
+++ b/changelog_unreleased/typescript/19939-2.md
@@ -3,22 +3,31 @@
 <!-- prettier-ignore -->
 ```tsx
 // Input
-1 as
+const foo = {
+  bar: 1
+} as
 /**
- * jsdoc
+ * comment line 1
+ * comment line 2
  */
 Foo;
 
 // Prettier stable
-1 as /**
- * jsdoc
+const foo = {
+  bar: 1,
+} as /**
+ * comment line 1
+ * comment line 2
  */
 Foo;
 
 // Prettier main
-1 as
+const foo = {
+  bar: 1,
+} as
   /**
-   * jsdoc
+   * comment line 1
+   * comment line 2
    */
   Foo;
 ```

--- a/changelog_unreleased/typescript/19939.md
+++ b/changelog_unreleased/typescript/19939.md
@@ -6,8 +6,8 @@
 const foo = {
   bar: 1,
 } as
-// Comment
-Record<string, number>;
+  // Comment
+  Record<string, number>;
 
 // Prettier stable (first format)
 const foo = {

--- a/changelog_unreleased/typescript/19939.md
+++ b/changelog_unreleased/typescript/19939.md
@@ -3,27 +3,27 @@
 <!-- prettier-ignore -->
 ```tsx
 // Input
-const t1 = {
-  prop1: 1,
-} satisfies
+const foo = {
+  bar: 1,
+} as
 // Comment
 Record<string, number>;
 
 // Prettier stable (first format)
-const t1 = {
-  prop1: 1,
-} satisfies // Comment
+const foo = {
+  bar: 1,
+} as // Comment
 Record<string, number>;
 
 // Prettier stable (second format)
-const t1 = {
-  prop1: 1,
-} satisfies Record<string, number>; // Comment
+const foo = {
+  bar: 1,
+} as Record<string, number>; // Comment
 
 // Prettier main
-const t1 = {
-  prop1: 1,
-} satisfies
+const foo = {
+  bar: 1,
+} as
   // Comment
   Record<string, number>;
 ```

--- a/changelog_unreleased/typescript/19939.md
+++ b/changelog_unreleased/typescript/19939.md
@@ -1,0 +1,31 @@
+#### Keep an own-line comment before a `satisfies` or `as` type on its own line (#19939 by @Kjubikstronk)
+
+The comment was printed on the operator's line, which made it a trailing comment. The next format then moved it to the end of the statement.
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+const t1 = {
+  prop1: 1,
+} satisfies
+// Comment
+Record<string, number>;
+
+// Prettier stable (first format)
+const t1 = {
+  prop1: 1,
+} satisfies // Comment
+Record<string, number>;
+
+// Prettier stable (second format)
+const t1 = {
+  prop1: 1,
+} satisfies Record<string, number>; // Comment
+
+// Prettier main
+const t1 = {
+  prop1: 1,
+} satisfies
+  // Comment
+  Record<string, number>;
+```

--- a/changelog_unreleased/typescript/19939.md
+++ b/changelog_unreleased/typescript/19939.md
@@ -1,7 +1,5 @@
 #### Keep an own-line comment before a `satisfies` or `as` type on its own line (#19939 by @Kjubikstronk)
 
-The comment was printed on the operator's line, which made it a trailing comment. The next format then moved it to the end of the statement.
-
 <!-- prettier-ignore -->
 ```tsx
 // Input

--- a/src/language-js/print/binary-cast-expression.js
+++ b/src/language-js/print/binary-cast-expression.js
@@ -6,6 +6,7 @@ import {
   isCallOrNewExpression,
   isMemberExpression,
   isSatisfiesExpression,
+  isUnionType,
 } from "../utilities/node-types.js";
 
 function printBinaryCastExpression(path, options, print) {
@@ -15,18 +16,12 @@ function printBinaryCastExpression(path, options, print) {
     ? "const"
     : print("typeAnnotation");
 
-  // A union already prints its members on their own lines, so it does not need the
-  // break and would end up indented twice.
-  const isUnion =
-    node.typeAnnotation?.type === "TSUnionType" ||
-    node.typeAnnotation?.type === "UnionTypeAnnotation";
-
   // A line comment written on its own line before the type has to stay there.
   // Printing it after the operator makes it a trailing comment, and the next format
-  // then moves it to the end of the statement.
+  // then moves it to the end of the statement. A union already prints its members on
+  // their own lines, so it does not need the break and would be indented twice.
   const keepTypeOnOwnLine =
-    !isFlowAsConstExpression &&
-    !isUnion &&
+    !isUnionType(node.typeAnnotation) &&
     hasComment(
       node.typeAnnotation,
       CommentCheckFlags.Leading | CommentCheckFlags.Line,

--- a/src/language-js/print/binary-cast-expression.js
+++ b/src/language-js/print/binary-cast-expression.js
@@ -14,18 +14,21 @@ function printBinaryCastExpression(path, options, print) {
     ? "const"
     : print("typeAnnotation");
 
-  const keepTypeOnOwnLine =
-    !isUnionType(node.typeAnnotation) &&
-    hasLeadingOwnLineComment(options.originalText, node.typeAnnotation);
-
   const parts = [
     print("expression"),
     " ",
     isSatisfiesExpression(node) ? "satisfies" : "as",
-    keepTypeOnOwnLine
-      ? indent([hardline, typeAnnotationDoc])
-      : [" ", typeAnnotationDoc],
   ];
+
+  if (
+    // Union type already indented
+    !isUnionType(node.typeAnnotation) &&
+    hasLeadingOwnLineComment(options.originalText, node.typeAnnotation)
+  ) {
+    parts.push(indent([hardline, typeAnnotationDoc]));
+  } else {
+    parts.push(" ", typeAnnotationDoc);
+  }
 
   if (
     (key === "callee" && isCallOrNewExpression(parent)) ||

--- a/src/language-js/print/binary-cast-expression.js
+++ b/src/language-js/print/binary-cast-expression.js
@@ -1,5 +1,9 @@
 import { group, hardline, indent, softline } from "../../document/index.js";
-import { hasLeadingOwnLineComment } from "../utilities/has-leading-own-line-comment.js";
+import hasNewline from "../../utilities/has-newline.js";
+import { locEnd } from "../location/index.js";
+import { isLineComment } from "../utilities/comment-types.js";
+import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
+import { isIndentableBlockComment } from "../utilities/indentable-block-comment.js";
 import {
   isCallOrNewExpression,
   isMemberExpression,
@@ -16,7 +20,13 @@ function printBinaryCastExpression(path, options, print) {
 
   const keepTypeOnOwnLine =
     !isUnionType(node.typeAnnotation) &&
-    hasLeadingOwnLineComment(options.originalText, node.typeAnnotation);
+    hasComment(
+      node.typeAnnotation,
+      CommentCheckFlags.Leading,
+      (comment) =>
+        hasNewline(options.originalText, locEnd(comment)) &&
+        (isLineComment(comment) || isIndentableBlockComment(comment)),
+    );
 
   const parts = [
     print("expression"),

--- a/src/language-js/print/binary-cast-expression.js
+++ b/src/language-js/print/binary-cast-expression.js
@@ -1,7 +1,5 @@
 import { group, hardline, indent, softline } from "../../document/index.js";
-import hasNewline from "../../utilities/has-newline.js";
-import { locEnd } from "../location/index.js";
-import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
+import { hasLeadingOwnLineComment } from "../utilities/has-leading-own-line-comment.js";
 import {
   isCallOrNewExpression,
   isMemberExpression,
@@ -16,17 +14,13 @@ function printBinaryCastExpression(path, options, print) {
     ? "const"
     : print("typeAnnotation");
 
-  // A line comment written on its own line before the type has to stay there.
-  // Printing it after the operator makes it a trailing comment, and the next format
-  // then moves it to the end of the statement. A union already prints its members on
-  // their own lines, so it does not need the break and would be indented twice.
+  // A comment written on its own line before the type has to stay there. Printing it
+  // after the operator makes it a trailing comment, and the next format then moves it
+  // to the end of the statement. A union already prints its members on their own
+  // lines, so it does not need the break and would be indented twice.
   const keepTypeOnOwnLine =
     !isUnionType(node.typeAnnotation) &&
-    hasComment(
-      node.typeAnnotation,
-      CommentCheckFlags.Leading | CommentCheckFlags.Line,
-      (comment) => hasNewline(options.originalText, locEnd(comment)),
-    );
+    hasLeadingOwnLineComment(options.originalText, node.typeAnnotation);
 
   const parts = [
     print("expression"),

--- a/src/language-js/print/binary-cast-expression.js
+++ b/src/language-js/print/binary-cast-expression.js
@@ -1,4 +1,7 @@
-import { group, indent, softline } from "../../document/index.js";
+import { group, hardline, indent, softline } from "../../document/index.js";
+import hasNewline from "../../utilities/has-newline.js";
+import { locEnd } from "../location/index.js";
+import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
 import {
   isCallOrNewExpression,
   isMemberExpression,
@@ -12,12 +15,31 @@ function printBinaryCastExpression(path, options, print) {
     ? "const"
     : print("typeAnnotation");
 
+  // A union already prints its members on their own lines, so it does not need the
+  // break and would end up indented twice.
+  const isUnion =
+    node.typeAnnotation?.type === "TSUnionType" ||
+    node.typeAnnotation?.type === "UnionTypeAnnotation";
+
+  // A line comment written on its own line before the type has to stay there.
+  // Printing it after the operator makes it a trailing comment, and the next format
+  // then moves it to the end of the statement.
+  const keepTypeOnOwnLine =
+    !isFlowAsConstExpression &&
+    !isUnion &&
+    hasComment(
+      node.typeAnnotation,
+      CommentCheckFlags.Leading | CommentCheckFlags.Line,
+      (comment) => hasNewline(options.originalText, locEnd(comment)),
+    );
+
   const parts = [
     print("expression"),
     " ",
     isSatisfiesExpression(node) ? "satisfies" : "as",
-    " ",
-    typeAnnotationDoc,
+    keepTypeOnOwnLine
+      ? indent([hardline, typeAnnotationDoc])
+      : [" ", typeAnnotationDoc],
   ];
 
   if (

--- a/src/language-js/print/binary-cast-expression.js
+++ b/src/language-js/print/binary-cast-expression.js
@@ -1,9 +1,5 @@
 import { group, hardline, indent, softline } from "../../document/index.js";
-import hasNewline from "../../utilities/has-newline.js";
-import { locEnd } from "../location/index.js";
-import { isLineComment } from "../utilities/comment-types.js";
-import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
-import { isIndentableBlockComment } from "../utilities/indentable-block-comment.js";
+import { hasLeadingOwnLineComment } from "../utilities/has-leading-own-line-comment.js";
 import {
   isCallOrNewExpression,
   isMemberExpression,
@@ -20,13 +16,7 @@ function printBinaryCastExpression(path, options, print) {
 
   const keepTypeOnOwnLine =
     !isUnionType(node.typeAnnotation) &&
-    hasComment(
-      node.typeAnnotation,
-      CommentCheckFlags.Leading,
-      (comment) =>
-        hasNewline(options.originalText, locEnd(comment)) &&
-        (isLineComment(comment) || isIndentableBlockComment(comment)),
-    );
+    hasLeadingOwnLineComment(options.originalText, node.typeAnnotation);
 
   const parts = [
     print("expression"),

--- a/src/language-js/print/binary-cast-expression.js
+++ b/src/language-js/print/binary-cast-expression.js
@@ -14,10 +14,6 @@ function printBinaryCastExpression(path, options, print) {
     ? "const"
     : print("typeAnnotation");
 
-  // A comment written on its own line before the type has to stay there. Printing it
-  // after the operator makes it a trailing comment, and the next format then moves it
-  // to the end of the statement. A union already prints its members on their own
-  // lines, so it does not need the break and would be indented twice.
   const keepTypeOnOwnLine =
     !isUnionType(node.typeAnnotation) &&
     hasLeadingOwnLineComment(options.originalText, node.typeAnnotation);

--- a/tests/config/format-test/failed-format-tests.js
+++ b/tests/config/format-test/failed-format-tests.js
@@ -20,7 +20,6 @@ const unstableTests = new Map(
     "typescript/prettier-ignore/mapped-types.ts",
     "typescript/prettier-ignore/issue-14238.ts",
     "js/for-of/comments.js",
-    "typescript/satisfies-operators/comments-unstable.ts",
     "jsx/comments/in-attributes.js",
     "typescript/import-type/long-module-name/long-module-name4.ts",
     [

--- a/tests/format/typescript/as/comments/18160.ts
+++ b/tests/format/typescript/as/comments/18160.ts
@@ -61,8 +61,12 @@ Foo;
 /**
  * jsdoc
  */
+const;
+1 as
+/**
+ * jsdoc
+ */
 Foo;
-
 1 satisfies
 /**
  * jsdoc

--- a/tests/format/typescript/as/comments/18160.ts
+++ b/tests/format/typescript/as/comments/18160.ts
@@ -56,3 +56,15 @@ const;
 Foo;
 1 satisfies // comment
 Foo;
+
+1 as
+/**
+ * jsdoc
+ */
+Foo;
+
+1 satisfies
+/**
+ * jsdoc
+ */
+Foo;

--- a/tests/format/typescript/as/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/as/comments/__snapshots__/format.test.js.snap
@@ -116,27 +116,31 @@ comment
 1 as const /*
 comment
 */;
-1 as /*
+1 as
+  /*
 comment
 */
-Foo;
-1 satisfies /*
+  Foo;
+1 satisfies
+  /*
 comment
 */
-Foo;
+  Foo;
 
 1 as const;
 /*
 comment
 */
-1 as /*
+1 as
+  /*
 comment
 */
-Foo;
-1 satisfies /*
+  Foo;
+1 satisfies
+  /*
 comment
 */
-Foo;
+  Foo;
 
 1 as const; // comment
 1 as Foo; // comment

--- a/tests/format/typescript/as/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/as/comments/__snapshots__/format.test.js.snap
@@ -128,27 +128,31 @@ comment
 1 as const /*
 comment
 */;
-1 as /*
+1 as
+  /*
 comment
 */
-Foo;
-1 satisfies /*
+  Foo;
+1 satisfies
+  /*
 comment
 */
-Foo;
+  Foo;
 
 1 as const;
 /*
 comment
 */
-1 as /*
+1 as
+  /*
 comment
 */
-Foo;
-1 satisfies /*
+  Foo;
+1 satisfies
+  /*
 comment
 */
-Foo;
+  Foo;
 
 1 as const; // comment
 1 as Foo; // comment

--- a/tests/format/typescript/as/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/as/comments/__snapshots__/format.test.js.snap
@@ -128,31 +128,27 @@ comment
 1 as const /*
 comment
 */;
-1 as
-  /*
+1 as /*
 comment
 */
-  Foo;
-1 satisfies
-  /*
+Foo;
+1 satisfies /*
 comment
 */
-  Foo;
+Foo;
 
 1 as const;
 /*
 comment
 */
-1 as
-  /*
+1 as /*
 comment
 */
-  Foo;
-1 satisfies
-  /*
+Foo;
+1 satisfies /*
 comment
 */
-  Foo;
+Foo;
 
 1 as const; // comment
 1 as Foo; // comment

--- a/tests/format/typescript/as/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/as/comments/__snapshots__/format.test.js.snap
@@ -95,8 +95,12 @@ Foo;
 /**
  * jsdoc
  */
+const;
+1 as
+/**
+ * jsdoc
+ */
 Foo;
-
 1 satisfies
 /**
  * jsdoc
@@ -158,12 +162,15 @@ comment
 1 as Foo; // comment
 1 satisfies Foo; // comment
 
+1 as const;
+/**
+ * jsdoc
+ */
 1 as
   /**
    * jsdoc
    */
   Foo;
-
 1 satisfies
   /**
    * jsdoc

--- a/tests/format/typescript/as/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/as/comments/__snapshots__/format.test.js.snap
@@ -91,6 +91,18 @@ Foo;
 1 satisfies // comment
 Foo;
 
+1 as
+/**
+ * jsdoc
+ */
+Foo;
+
+1 satisfies
+/**
+ * jsdoc
+ */
+Foo;
+
 =====================================output=====================================
 1 as const /*
 comment
@@ -145,6 +157,18 @@ comment
 1 as const; // comment
 1 as Foo; // comment
 1 satisfies Foo; // comment
+
+1 as
+  /**
+   * jsdoc
+   */
+  Foo;
+
+1 satisfies
+  /**
+   * jsdoc
+   */
+  Foo;
 
 ================================================================================
 `;

--- a/tests/format/typescript/satisfies-operators/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/satisfies-operators/__snapshots__/format.test.js.snap
@@ -381,11 +381,25 @@ parsers: ["typescript"]
 semi: false
                                                       printWidth: 80 (default) |
 =====================================input======================================
+const t1 = {
+    prop1: 1,
+    prop2: 2,
+    prop3: 3
+} satisfies
+// Comment
+Record<string, number>;
 const t2 = {} /* comment */ satisfies {};
 const t3 = {} satisfies /* comment */ {};
 const t4 = {} /* comment1 */ satisfies /* comment2 */ {};
 
 =====================================output=====================================
+const t1 = {
+  prop1: 1,
+  prop2: 2,
+  prop3: 3,
+} satisfies
+  // Comment
+  Record<string, number>
 const t2 = {} /* comment */ satisfies {}
 const t3 = {} satisfies /* comment */ {}
 const t4 = {} /* comment1 */ satisfies /* comment2 */ {}
@@ -398,24 +412,6 @@ exports[`comments.ts format 1`] = `
 parsers: ["typescript"]
                                                       printWidth: 80 (default) |
 =====================================input======================================
-const t2 = {} /* comment */ satisfies {};
-const t3 = {} satisfies /* comment */ {};
-const t4 = {} /* comment1 */ satisfies /* comment2 */ {};
-
-=====================================output=====================================
-const t2 = {} /* comment */ satisfies {};
-const t3 = {} satisfies /* comment */ {};
-const t4 = {} /* comment1 */ satisfies /* comment2 */ {};
-
-================================================================================
-`;
-
-exports[`comments-unstable.ts - {"semi":false} format 1`] = `
-====================================options=====================================
-parsers: ["typescript"]
-semi: false
-                                                      printWidth: 80 (default) |
-=====================================input======================================
 const t1 = {
     prop1: 1,
     prop2: 2,
@@ -423,31 +419,9 @@ const t1 = {
 } satisfies
 // Comment
 Record<string, number>;
-
-=====================================output=====================================
-const t1 = {
-  prop1: 1,
-  prop2: 2,
-  prop3: 3,
-} satisfies
-  // Comment
-  Record<string, number>
-
-================================================================================
-`;
-
-exports[`comments-unstable.ts format 1`] = `
-====================================options=====================================
-parsers: ["typescript"]
-                                                      printWidth: 80 (default) |
-=====================================input======================================
-const t1 = {
-    prop1: 1,
-    prop2: 2,
-    prop3: 3
-} satisfies
-// Comment
-Record<string, number>;
+const t2 = {} /* comment */ satisfies {};
+const t3 = {} satisfies /* comment */ {};
+const t4 = {} /* comment1 */ satisfies /* comment2 */ {};
 
 =====================================output=====================================
 const t1 = {
@@ -457,6 +431,9 @@ const t1 = {
 } satisfies
   // Comment
   Record<string, number>;
+const t2 = {} /* comment */ satisfies {};
+const t3 = {} satisfies /* comment */ {};
+const t4 = {} /* comment1 */ satisfies /* comment2 */ {};
 
 ================================================================================
 `;

--- a/tests/format/typescript/satisfies-operators/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/satisfies-operators/__snapshots__/format.test.js.snap
@@ -429,8 +429,9 @@ const t1 = {
   prop1: 1,
   prop2: 2,
   prop3: 3,
-} satisfies // Comment
-Record<string, number>
+} satisfies
+  // Comment
+  Record<string, number>
 
 ================================================================================
 `;
@@ -453,8 +454,9 @@ const t1 = {
   prop1: 1,
   prop2: 2,
   prop3: 3,
-} satisfies // Comment
-Record<string, number>;
+} satisfies
+  // Comment
+  Record<string, number>;
 
 ================================================================================
 `;

--- a/tests/format/typescript/satisfies-operators/comments-unstable.ts
+++ b/tests/format/typescript/satisfies-operators/comments-unstable.ts
@@ -1,7 +1,0 @@
-const t1 = {
-    prop1: 1,
-    prop2: 2,
-    prop3: 3
-} satisfies
-// Comment
-Record<string, number>;

--- a/tests/format/typescript/satisfies-operators/comments.ts
+++ b/tests/format/typescript/satisfies-operators/comments.ts
@@ -1,3 +1,10 @@
+const t1 = {
+    prop1: 1,
+    prop2: 2,
+    prop3: 3
+} satisfies
+// Comment
+Record<string, number>;
 const t2 = {} /* comment */ satisfies {};
 const t3 = {} satisfies /* comment */ {};
 const t4 = {} /* comment1 */ satisfies /* comment2 */ {};


### PR DESCRIPTION
## Description

`typescript/satisfies-operators/comments-unstable.ts` is listed in `failed-format-tests.js` as unstable. This fixes it and removes the entry.

```tsx
// Input
const t1 = {
    prop1: 1,
    prop2: 2,
    prop3: 3
} satisfies
// Comment
Record<string, number>;

// Prettier stable (first format)
} satisfies // Comment
Record<string, number>;

// Prettier stable (second format)
} satisfies Record<string, number>; // Comment

// Prettier main
} satisfies
  // Comment
  Record<string, number>;
```

The operator was followed by a hard `" "`, so a comment written on its own line before the type was pulled up onto the `satisfies` line. That turns it into a trailing comment, and the next format moves it to the end of the statement, so the file needed three passes to settle.

Keeping the comment on the line it was written on fixes the instability and leaves it where it was written, rather than at the end of the statement.

Unions are excluded: they already print their members on separate lines, so they do not need the break and would otherwise be indented twice. `typescript/union/consistent-with-flow/single-type.ts` is unaffected by this change; it is unstable for a different reason (comments on union members) and stays in the list.

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

No new test is added because the fixture already exists; it was listed as unstable rather than passing, and that entry is now removed. Verified with the full `tests/format/js`, `typescript`, `jsx` and `flow` suites: the set of failing tests is identical to `main` on my machine. I used AI assistance and reviewed everything before submitting.
