### PR TITLE
Keep parentheses when a comment would break a postfix update expression

### DIFF
--- a/changelog_unreleased/javascript/19967.md
+++ b/changelog_unreleased/javascript/19967.md
@@ -1,0 +1,18 @@
+#### Keep parentheses when a comment would break a postfix update expression (#19967 by @giaBaoJS)
+
+A postfix `++`/`--` is a restricted production: no line terminator is allowed between the argument and the operator. A comment spanning lines counts as one, so the parentheses have to be kept.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+(a/*
+*/)++;
+
+// Prettier stable
+a /*
+ */++;
+
+// Prettier main
+(a /*
+ */)++;
+```

--- a/src/language-js/print/estree.js
+++ b/src/language-js/print/estree.js
@@ -1,14 +1,13 @@
 import {
   group,
   hardline,
+  ifBreak,
   indent,
   replaceEndOfLine,
   softline,
 } from "../../document/index.js";
 import { printDanglingComments } from "../../main/comments/print.js";
-import hasNewlineInRange from "../../utilities/has-newline-in-range.js";
 import UnexpectedNodeError from "../../utilities/unexpected-node-error.js";
-import { locEnd, locStart } from "../location/index.js";
 import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
 import { isMeaningfulEmptyStatement } from "../utilities/is-meaningful-empty-statement.js";
 import { isMethod } from "../utilities/is-method.js";
@@ -243,24 +242,25 @@ function printEstree(path, options, print, args) {
 
       return parts;
     }
-    case "UpdateExpression":
-      /*
-      A postfix update expression is a restricted production, a line terminator
-      is not allowed between the argument and the operator. A trailing comment
-      spanning lines would introduce one, so parentheses have to be restored.
-      */
-      if (
-        !node.prefix &&
-        hasNewlineSpanningTrailingComment(node.argument, options)
-      ) {
-        return ["(", print("argument"), ")", node.operator];
+    case "UpdateExpression": {
+      if (node.prefix) {
+        return [node.operator, print("argument")];
       }
 
+      const argumentDoc = print("argument");
+
+      // A postfix operator is a restricted production, no line terminator is
+      // allowed before it, so keep the parentheses when the argument breaks.
       return [
-        node.prefix ? node.operator : "",
-        print("argument"),
-        node.prefix ? "" : node.operator,
+        hasComment(
+          node.argument,
+          CommentCheckFlags.Trailing | CommentCheckFlags.Block,
+        )
+          ? group([ifBreak("("), argumentDoc, ifBreak(")")])
+          : argumentDoc,
+        node.operator,
       ];
+    }
     case "ConditionalExpression":
       return printTernary(path, options, print, args);
     case "VariableDeclaration":
@@ -352,12 +352,6 @@ function printEstree(path, options, print, args) {
       /* c8 ignore next */
       throw new UnexpectedNodeError(node, "ESTree");
   }
-}
-
-function hasNewlineSpanningTrailingComment(node, options) {
-  return hasComment(node, CommentCheckFlags.Trailing, (comment) =>
-    hasNewlineInRange(options.originalText, locStart(comment), locEnd(comment)),
-  );
 }
 
 export { printEstree };

--- a/src/language-js/print/estree.js
+++ b/src/language-js/print/estree.js
@@ -6,7 +6,9 @@ import {
   softline,
 } from "../../document/index.js";
 import { printDanglingComments } from "../../main/comments/print.js";
+import hasNewlineInRange from "../../utilities/has-newline-in-range.js";
 import UnexpectedNodeError from "../../utilities/unexpected-node-error.js";
+import { locEnd, locStart } from "../location/index.js";
 import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
 import { isMeaningfulEmptyStatement } from "../utilities/is-meaningful-empty-statement.js";
 import { isMethod } from "../utilities/is-method.js";
@@ -242,6 +244,18 @@ function printEstree(path, options, print, args) {
       return parts;
     }
     case "UpdateExpression":
+      /*
+      A postfix update expression is a restricted production, a line terminator
+      is not allowed between the argument and the operator. A trailing comment
+      spanning lines would introduce one, so parentheses have to be restored.
+      */
+      if (
+        !node.prefix &&
+        hasNewlineSpanningTrailingComment(node.argument, options)
+      ) {
+        return ["(", print("argument"), ")", node.operator];
+      }
+
       return [
         node.prefix ? node.operator : "",
         print("argument"),
@@ -338,6 +352,12 @@ function printEstree(path, options, print, args) {
       /* c8 ignore next */
       throw new UnexpectedNodeError(node, "ESTree");
   }
+}
+
+function hasNewlineSpanningTrailingComment(node, options) {
+  return hasComment(node, CommentCheckFlags.Trailing, (comment) =>
+    hasNewlineInRange(options.originalText, locStart(comment), locEnd(comment)),
+  );
 }
 
 export { printEstree };

--- a/tests/format/js/update-expression/__snapshots__/format.test.js.snap
+++ b/tests/format/js/update-expression/__snapshots__/format.test.js.snap
@@ -1,5 +1,60 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`comments.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+// Line terminators are not allowed between the argument and a postfix operator,
+// so the parentheses must be kept.
+(a/*
+*/)++;
+
+(a/*
+*/)--;
+
+(a.b/*
+*/)++;
+
+f((a/*
+*/)++);
+
+// Safe, the operator comes first.
+f(++(a/*
+*/));
+
+// Safe, the comment doesn't span lines.
+(a /* comment */)++;
+
+=====================================output=====================================
+// Line terminators are not allowed between the argument and a postfix operator,
+// so the parentheses must be kept.
+(a /*
+ */)++;
+
+(a /*
+ */)--;
+
+(a.b /*
+ */)++;
+
+f(
+  (a /*
+   */)++,
+);
+
+// Safe, the operator comes first.
+f(
+  ++a /*
+   */,
+);
+
+// Safe, the comment doesn't span lines.
+a /* comment */++;
+
+================================================================================
+`;
+
 exports[`update_expression.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]

--- a/tests/format/js/update-expression/__snapshots__/format.test.js.snap
+++ b/tests/format/js/update-expression/__snapshots__/format.test.js.snap
@@ -26,6 +26,10 @@ f(++(a/*
 // Safe, the comment doesn't span lines.
 (a /* comment */)++;
 
+// Safe, a line comment moves to the end of the line.
+(a//
+)++;
+
 =====================================output=====================================
 // Line terminators are not allowed between the argument and a postfix operator,
 // so the parentheses must be kept.
@@ -51,6 +55,9 @@ f(
 
 // Safe, the comment doesn't span lines.
 a /* comment */++;
+
+// Safe, a line comment moves to the end of the line.
+a++; //
 
 ================================================================================
 `;

--- a/tests/format/js/update-expression/comments.js
+++ b/tests/format/js/update-expression/comments.js
@@ -1,0 +1,20 @@
+// Line terminators are not allowed between the argument and a postfix operator,
+// so the parentheses must be kept.
+(a/*
+*/)++;
+
+(a/*
+*/)--;
+
+(a.b/*
+*/)++;
+
+f((a/*
+*/)++);
+
+// Safe, the operator comes first.
+f(++(a/*
+*/));
+
+// Safe, the comment doesn't span lines.
+(a /* comment */)++;

--- a/tests/format/js/update-expression/comments.js
+++ b/tests/format/js/update-expression/comments.js
@@ -18,3 +18,7 @@ f(++(a/*
 
 // Safe, the comment doesn't span lines.
 (a /* comment */)++;
+
+// Safe, a line comment moves to the end of the line.
+(a//
+)++;


### PR DESCRIPTION
<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

Second half of the split requested in #19913, which now covers only `yield`.

Part of #11358.

A postfix `++` / `--` is a restricted production: no line terminator is allowed between the argument and the operator. A block comment that spans lines counts as a line terminator, so dropping the parentheses that kept such a comment out of that position changes the program.

<!-- prettier-ignore -->
```jsx
// Input
(a/*
*/)++;

// Prettier stable (SyntaxError when re-parsed)
a /*
 */++;

// Prettier main
(a /*
 */)++;
```

`ReturnStatement` and `ThrowStatement` already restore the parentheses in the same situation (`printReturnOrThrowArgument`); `UpdateExpression` never did.

Per review, this now uses the `ifBreak` trick from #19913 rather than measuring the comment range: when the argument carries a trailing block comment, it is printed inside a group with `ifBreak` parentheses, so the parentheses appear exactly when the comment forces a break. Prefix operators are untouched, the operator comes before the comment there.

The fixture includes cases that must *not* change (`f(++(a/*\n*/))`, `(a /* comment */)++`), so the test would catch a fix that simply parenthesized everything.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

