### PR TITLE
Fix unstable formatting of method chains with multiline objects

### DIFF
--- a/changelog_unreleased/javascript/19973.md
+++ b/changelog_unreleased/javascript/19973.md
@@ -1,0 +1,29 @@
+#### Fix unstable formatting of method chains with multiline objects (#19973 by @wangxpych)
+
+Method chains could change layout on the second formatting pass after an object
+literal expanded. The chain now stays expanded once the object becomes multiline.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+const value = object.method().anotherMethod(null, { message: "something something something something something" });
+
+// Prettier stable (First format)
+const value = object
+  .method()
+  .anotherMethod(null, {
+    message: "something something something something something",
+  });
+
+// Prettier stable (Second format)
+const value = object.method().anotherMethod(null, {
+  message: "something something something something something",
+});
+
+// Prettier main
+const value = object
+  .method()
+  .anotherMethod(null, {
+    message: "something something something something something",
+  });
+```

--- a/src/language-js/print/member-chain.js
+++ b/src/language-js/print/member-chain.js
@@ -9,10 +9,13 @@ import {
   willBreak,
 } from "../../document/index.js";
 import { printComments } from "../../main/comments/print.js";
+import { hasDescendant } from "../../utilities/ast.js";
 import getNextNonSpaceNonCommentCharacterIndex from "../../utilities/get-next-non-space-non-comment-character-index.js";
+import hasNewlineInRange from "../../utilities/has-newline-in-range.js";
 import isNextLineEmptyAfterIndex from "../../utilities/is-next-line-empty.js";
-import { locEnd } from "../location/index.js";
+import { locEnd, locStart } from "../location/index.js";
 import needsParentheses from "../parentheses/needs-parentheses.js";
+import getVisitorKeys from "../traverse/get-visitor-keys.js";
 import { CommentCheckFlags, hasComment } from "../utilities/comments.js";
 import { isLongCurriedCallExpression } from "../utilities/is-long-curried-call-expression.js";
 import { isMemberish } from "../utilities/is-memberish.js";
@@ -23,6 +26,7 @@ import {
   isFunctionOrArrowExpression,
   isMemberExpression,
   isNumericLiteral,
+  isObjectExpression,
 } from "../utilities/node-types.js";
 import { printBindExpressionCallee } from "./bind-expression.js";
 import printCallArguments from "./call-arguments.js";
@@ -372,7 +376,29 @@ function printMemberChain(path, options, print) {
   const callExpressions = printedNodes
     .map(({ node }) => node)
     .filter(isCallExpression);
-
+  const isMultilineObject = (node) =>
+    isObjectExpression(node) &&
+    node.properties.length > 0 &&
+    hasNewlineInRange(
+      options.originalText,
+      locStart(node),
+      locStart(node.properties[0]),
+    );
+  const hasMultilineObjectArgument =
+    !isExpressionStatement &&
+    callExpressions.some((callExpression) =>
+      callExpression.arguments.some(
+        (argument) =>
+          isMultilineObject(argument) ||
+          hasDescendant(argument, {
+            getVisitorKeys: (node) =>
+              isCallExpression(node) || isMemberish(node)
+                ? []
+                : getVisitorKeys(node),
+            predicate: isMultilineObject,
+          }),
+      ),
+    );
   function lastGroupWillBreakAndOtherCallsHaveFunctionArguments() {
     const lastGroupNode = groups.at(-1).at(-1).node;
     const lastGroupDoc = printedGroups.at(-1);
@@ -399,6 +425,7 @@ function printMemberChain(path, options, print) {
       callExpressions.some((expr) =>
         expr.arguments.some((arg) => !isSimpleCallArgument(arg)),
       )) ||
+    hasMultilineObjectArgument ||
     printedGroups.slice(0, -1).some(willBreak) ||
     lastGroupWillBreakAndOtherCallsHaveFunctionArguments()
   ) {

--- a/tests/format/js/method-chain/__snapshots__/format.test.js.snap
+++ b/tests/format/js/method-chain/__snapshots__/format.test.js.snap
@@ -1266,6 +1266,42 @@ foo1(/叱叱叱/)
 ================================================================================
 `;
 
+exports[`issue-16132.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+const value = object.method().anotherMethod(null, { message: "something something something something something" });
+
+const thoughts = updates
+  .slice(0, 10)
+  .map(thought =>
+    thought ? { id: thought.id, value: thought.value, rank: thought.rank, lastUpdated: thought.lastUpdated } : null,
+  )
+
+=====================================output=====================================
+const value = object
+  .method()
+  .anotherMethod(null, {
+    message: "something something something something something",
+  });
+
+const thoughts = updates
+  .slice(0, 10)
+  .map((thought) =>
+    thought
+      ? {
+          id: thought.id,
+          value: thought.value,
+          rank: thought.rank,
+          lastUpdated: thought.lastUpdated,
+        }
+      : null,
+  );
+
+================================================================================
+`;
+
 exports[`issue-17457.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]

--- a/tests/format/js/method-chain/issue-16132.js
+++ b/tests/format/js/method-chain/issue-16132.js
@@ -1,0 +1,7 @@
+const value = object.method().anotherMethod(null, { message: "something something something something something" });
+
+const thoughts = updates
+  .slice(0, 10)
+  .map(thought =>
+    thought ? { id: thought.id, value: thought.value, rank: thought.rank, lastUpdated: thought.lastUpdated } : null,
+  )


### PR DESCRIPTION
## Description

Method chains could change layout across consecutive formatting passes when an object literal expanded during the first pass. On the next pass, the preserved multiline object allowed the surrounding chain to collapse.

Keep the surrounding chain expanded when its argument directly contains a preserved multiline object. Traversal stops at nested call/member chains so an independent nested chain does not affect its parent.

Fixes #16132.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the contributing guidelines.
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

Tests: full test suite (35,277 passed, 5 skipped), full lint suite, and focused deep format tests (1,080 passed).