### PR TITLE
docs: update prettier-plugin-nginx repository owner

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -77,7 +77,7 @@ Strings provided to `plugins` are ultimately passed to [`import()` expression](h
 - [`prettier-plugin-marko`](https://github.com/marko-js/prettier) by [**@marko-js**](https://github.com/marko-js)
 - [`prettier-plugin-motoko`](https://github.com/dfinity/prettier-plugin-motoko) by [**@dfinity**](https://github.com/dfinity)
 - [`prettier-plugin-mustache`](https://github.com/Poliklot/prettier-plugin-mustache) by [**@Poliklot**](https://github.com/Poliklot)
-- [`prettier-plugin-nginx`](https://github.com/joedeandev/prettier-plugin-nginx) by [**@joedeandev**](https://github.com/joedeandev)
+- [`prettier-plugin-nginx`](https://github.com/jxddk/prettier-plugin-nginx) by [**@jxddk**](https://github.com/jxddk)
 - [`prettier-plugin-nunjucks`](https://github.com/Poliklot/prettier-plugin-nunjucks) by [**@Poliklot**](https://github.com/Poliklot)
 - [`prettier-plugin-prisma`](https://github.com/umidbekk/prettier-plugin-prisma) by [**@umidbekk**](https://github.com/umidbekk)
 - [`prettier-plugin-properties`](https://github.com/eemeli/prettier-plugin-properties) by [**@eemeli**](https://github.com/eemeli)

--- a/website/versioned_docs/version-stable/plugins.md
+++ b/website/versioned_docs/version-stable/plugins.md
@@ -77,7 +77,7 @@ Strings provided to `plugins` are ultimately passed to [`import()` expression](h
 - [`prettier-plugin-marko`](https://github.com/marko-js/prettier) by [**@marko-js**](https://github.com/marko-js)
 - [`prettier-plugin-motoko`](https://github.com/dfinity/prettier-plugin-motoko) by [**@dfinity**](https://github.com/dfinity)
 - [`prettier-plugin-mustache`](https://github.com/Poliklot/prettier-plugin-mustache) by [**@Poliklot**](https://github.com/Poliklot)
-- [`prettier-plugin-nginx`](https://github.com/joedeandev/prettier-plugin-nginx) by [**@joedeandev**](https://github.com/joedeandev)
+- [`prettier-plugin-nginx`](https://github.com/jxddk/prettier-plugin-nginx) by [**@jxddk**](https://github.com/jxddk)
 - [`prettier-plugin-nunjucks`](https://github.com/Poliklot/prettier-plugin-nunjucks) by [**@Poliklot**](https://github.com/Poliklot)
 - [`prettier-plugin-prisma`](https://github.com/umidbekk/prettier-plugin-prisma) by [**@umidbekk**](https://github.com/umidbekk)
 - [`prettier-plugin-properties`](https://github.com/eemeli/prettier-plugin-properties) by [**@eemeli**](https://github.com/eemeli)


### PR DESCRIPTION
## Description

Updates `prettier-plugin-nginx` URL from `https://github.com/joedeandev/prettier-plugin-nginx` to `https://github.com/jxddk/prettier-plugin-nginx`. (this is my plugin, and I changed my GitHub username some time ago; the old URL redirects to the new one)

Duplicate of #19871, re-submitted in appropriate format.

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
