### PR TITLE
Fix indentation drift for indented code blocks in list items

### DIFF
--- a/changelog_unreleased/markdown/19647.md
+++ b/changelog_unreleased/markdown/19647.md
@@ -1,6 +1,6 @@
-#### Prevent indentation drift in task-list code blocks (#19647 by @Austin1serb)
+#### Prevent indentation drift in list-item code blocks (#19647, #19990 by @Austin1serb, @giaBaoJS)
 
-Indented code blocks inside task-list items no longer gain four spaces on each formatting pass.
+Indented code blocks inside list items no longer gain indentation on each formatting pass.
 
 <!-- prettier-ignore -->
 ```markdown

--- a/changelog_unreleased/markdown/19647.md
+++ b/changelog_unreleased/markdown/19647.md
@@ -1,7 +1,5 @@
 #### Prevent indentation drift in list-item code blocks (#19647, #19990 by @Austin1serb, @giaBaoJS)
 
-Indented code blocks inside list items no longer gain indentation on each formatting pass.
-
 <!-- prettier-ignore -->
 ```markdown
 <!-- Input -->

--- a/src/language-markdown/print/list.js
+++ b/src/language-markdown/print/list.js
@@ -103,6 +103,12 @@ function printListItem(path, options, print, listPrefix) {
           return align(" ".repeat(prefix.length), print());
         }
 
+        // An indented code block would swallow the alignment as part of its
+        // content, so it grows deeper on every format.
+        if (node.type === "code" && node.isIndented) {
+          return print();
+        }
+
         const alignment = " ".repeat(
           clamp(options.tabWidth - listPrefix.length, 0, 3), // 4+ will cause indented code block
         );
@@ -206,6 +212,12 @@ function printListItemLegacy(path, options, print, listPrefix) {
       processor({ node, isFirst }) {
         if (isFirst && node.type !== "list") {
           return align(" ".repeat(prefix.length), print());
+        }
+
+        // An indented code block would swallow the alignment as part of its
+        // content, so it grows deeper on every format.
+        if (node.type === "code" && node.isIndented) {
+          return print();
         }
 
         const alignment = " ".repeat(

--- a/src/language-markdown/print/list.js
+++ b/src/language-markdown/print/list.js
@@ -103,8 +103,6 @@ function printListItem(path, options, print, listPrefix) {
           return align(" ".repeat(prefix.length), print());
         }
 
-        // An indented code block would swallow the alignment as part of its
-        // content, so it grows deeper on every format.
         if (node.type === "code" && node.isIndented) {
           return print();
         }
@@ -214,8 +212,6 @@ function printListItemLegacy(path, options, print, listPrefix) {
           return align(" ".repeat(prefix.length), print());
         }
 
-        // An indented code block would swallow the alignment as part of its
-        // content, so it grows deeper on every format.
         if (node.type === "code" && node.isIndented) {
           return print();
         }

--- a/tests/format/markdown/list/tab-width/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/list/tab-width/__snapshots__/format.test.js.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`indented-code-block.md - {"tabWidth":4} format 1`] = `
+====================================options=====================================
+parsers: ["markdown", "mdx"]
+tabWidth: 4
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+- [x] task item
+
+      indented code
+
+- unordered item
+
+      indented code
+
+- outer item
+
+  - nested item
+
+        indented code
+
+- item with extra code indentation
+
+          indented code
+
+=====================================output=====================================
+- [x] task item
+
+      indented code
+
+- unordered item
+
+      indented code
+
+- outer item
+
+    - nested item
+
+          indented code
+
+- item with extra code indentation
+
+          indented code
+
+================================================================================
+`;

--- a/tests/format/markdown/list/tab-width/format.test.js
+++ b/tests/format/markdown/list/tab-width/format.test.js
@@ -1,0 +1,1 @@
+runFormatTest(import.meta, ["markdown", "mdx"], { tabWidth: 4 });

--- a/tests/format/markdown/list/tab-width/indented-code-block.md
+++ b/tests/format/markdown/list/tab-width/indented-code-block.md
@@ -1,0 +1,17 @@
+- [x] task item
+
+      indented code
+
+- unordered item
+
+      indented code
+
+- outer item
+
+  - nested item
+
+        indented code
+
+- item with extra code indentation
+
+          indented code


### PR DESCRIPTION
## Description

An indented code block that is not the first child of a list item is printed with the list item's tab-width alignment in front of it. Those extra columns are not layout. An indented code block is defined by four columns of indentation, so anything past that is parsed back as part of the block's content. The next format then adds the alignment on top of the content it just created, and the block moves right on every pass without ever settling.

With `--tab-width 4`:

```markdown
<!-- Input -->
- [x] task item

      indented code

<!-- Prettier main, first format -->
- [x] task item

        indented code

<!-- Prettier main, second format -->
- [x] task item

          indented code

<!-- This PR, stable at every pass -->
- [x] task item

      indented code
```

Two things are wrong with the current output:

1. `format(format(x)) !== format(x)`, and it never converges.
2. The document's text changes. Parsing the input gives a `code` node whose value is `"indented code"`; parsing the first output gives `"  indented code"`. The code block's content gains two leading spaces it never had.

This happens for task, unordered, ordered and nested list items, in both the markdown and the mdx printer, whenever `tabWidth` is not the default `2`.

## Root cause

`printListItem` used to skip its alignment for an indented code block. #19647 (unreleased) removed that branch, because the branch applied `align(prefix.length)`, which indented the continuation lines of a multi-line code block. Removing the branch outright also let the tab-width alignment reach indented code blocks.

This restores the guard without the `align`, so neither problem comes back. The example in `changelog_unreleased/markdown/19647.md` still formats exactly as documented there, at any tab width, so that entry is updated in place rather than a new one being added.

## Tests

New fixture `tests/format/markdown/list/tab-width/`, run with `markdown` and `mdx` at `tabWidth: 4`.

With only the change to `src/language-markdown/print/list.js` reverted, the fixture fails on `second format [markdown]` and on the snapshot. With the change in place all 8 tests pass.

Full `tests/format` run with `FULL_TEST=true`, before and after:

- passing tests 100970 -> 100978 (the 8 new ones)
- passing snapshots 13012 -> 13013 (the 1 new one)
- no existing snapshot changed
- the 8 pre-existing failures on `main` (all `yuku` / `yuku-ts`) are identical before and after

I also formatted every file under `tests/format/**` twice under several option sets and compared the two passes; this change removes three of the instabilities that scan found (`markdown/code/indent.md`, `markdown/list/issue-19644.md`, `markdown/list/followed-by-indented-things.md` at `tabWidth: 4`) and introduces none.

## Checklist

- [x] I've added tests to confirm my change works.
- [ ] (If changing the API or CLI) I've documented the changes I've made (in the `docs/` directory).
- [x] (If the change is user-facing) I've added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I've read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
