### PR TITLE
docs: document how override patterns are resolved

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,6 +172,8 @@ overrides:
 
 `files` is required for each override, and may be a string or array of strings. `excludeFiles` may be optionally provided to exclude files for a given rule, and may also be a string or array of strings.
 
+Patterns are matched against the path of each file relative to the directory that contains the configuration file, so `legacy/**/*.js` only covers files below that directory. A pattern without a `/`, such as `*.test.js`, is matched against the file name alone and therefore applies at any depth.
+
 ## Setting the [parser](options.md#parser) option
 
 By default, Prettier automatically infers which parser to use based on the input file extension. Combined with `overrides` you can teach Prettier how to parse files it does not recognize.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -172,7 +172,7 @@ overrides:
 
 `files` is required for each override, and may be a string or array of strings. `excludeFiles` may be optionally provided to exclude files for a given rule, and may also be a string or array of strings.
 
-Patterns are matched against the path of each file relative to the directory that contains the configuration file, so `legacy/**/*.js` only covers files below that directory. A pattern without a `/`, such as `*.test.js`, is matched against the file name alone and therefore applies at any depth.
+`files` patterns are matched against the file path relative to the directory containing the configuration file, not the current working directory, so `legacy/**/*.js` only matches files inside the `legacy` directory next to that configuration file. A pattern without a `/`, such as `*.test.js`, is matched against the file name alone, so it applies at any depth.
 
 ## Setting the [parser](options.md#parser) option
 

--- a/website/versioned_docs/version-stable/configuration.md
+++ b/website/versioned_docs/version-stable/configuration.md
@@ -171,6 +171,8 @@ overrides:
 
 `files` is required for each override, and may be a string or array of strings. `excludeFiles` may be optionally provided to exclude files for a given rule, and may also be a string or array of strings.
 
+Patterns are matched against the path of each file relative to the directory that contains the configuration file, so `legacy/**/*.js` only covers files below that directory. A pattern without a `/`, such as `*.test.js`, is matched against the file name alone and therefore applies at any depth.
+
 ## Setting the [parser](options.md#parser) option
 
 By default, Prettier automatically infers which parser to use based on the input file extension. Combined with `overrides` you can teach Prettier how to parse files it does not recognize.

--- a/website/versioned_docs/version-stable/configuration.md
+++ b/website/versioned_docs/version-stable/configuration.md
@@ -171,7 +171,7 @@ overrides:
 
 `files` is required for each override, and may be a string or array of strings. `excludeFiles` may be optionally provided to exclude files for a given rule, and may also be a string or array of strings.
 
-Patterns are matched against the path of each file relative to the directory that contains the configuration file, so `legacy/**/*.js` only covers files below that directory. A pattern without a `/`, such as `*.test.js`, is matched against the file name alone and therefore applies at any depth.
+`files` patterns are matched against the file path relative to the directory containing the configuration file, not the current working directory, so `legacy/**/*.js` only matches files inside the `legacy` directory next to that configuration file. A pattern without a `/`, such as `*.test.js`, is matched against the file name alone, so it applies at any depth.
 
 ## Setting the [parser](options.md#parser) option
 


### PR DESCRIPTION
## Description

Override patterns are matched against the file path relative to the directory holding the configuration file, and a pattern with no `/` is matched against the file name only. Neither of those is written down anywhere, so moving a config file into a subdirectory silently changes which files an override like `dir/*.md` covers, while `*.md` keeps matching. This adds a sentence about both to the `overrides` section.

Fixes #19994

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.
