### PR TITLE
Fix property casing in commented LESS detached rulesets

### DIFF
--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -21,6 +21,7 @@ import isScssNestedPropertyNode from "./utilities/is-scss-nested-property-node.j
 
 const DEFAULT_SCSS_DIRECTIVE = /(\s*)(!default).*$/;
 const GLOBAL_SCSS_DIRECTIVE = /(\s*)(!global).*$/;
+const LESS_VARIABLE_PARAMS = /^(?:\/\/[^\r\n]*|\/\*.*?\*\/|\s)*:/s;
 
 function parseNestedCSS(node, options) {
   if (isObject(node)) {
@@ -275,20 +276,25 @@ function parseNestedCSS(node, options) {
         }
 
         // `@color :blue;`
+        const lessVariableParams = node.params?.match(LESS_VARIABLE_PARAMS);
         if (
           !["page", "nest", "keyframes"].includes(node.name) &&
-          node.params?.[0] === ":"
+          lessVariableParams
         ) {
           node.variable = true;
-          const text = node.params.slice(1);
-          if (text) {
-            node.value = parseValue(text, options);
+          if (lessVariableParams[0].includes("/")) {
+            node.raws.lessVariableParams = true;
+          } else {
+            const text = node.params.slice(lessVariableParams[0].length);
+            if (text) {
+              node.value = parseValue(text, options);
+            }
+            node.raws.afterName += ":";
           }
-          node.raws.afterName += ":";
         }
 
         // Less variable
-        if (node.variable) {
+        if (node.variable && !node.raws.lessVariableParams) {
           delete node.params;
 
           if (!node.value) {

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -127,7 +127,7 @@ function genericPrint(path, options, print) {
           ];
         }
 
-        if (node.variable) {
+        if (node.variable && !node.raws.lessVariableParams) {
           return [
             "@",
             node.name,

--- a/tests/format/less/case/__snapshots__/format.test.js.snap
+++ b/tests/format/less/case/__snapshots__/format.test.js.snap
@@ -400,7 +400,6 @@ parsers: ["less"]
 @var // comment
 : // comment
 {
-  /* FIXME: should not change case */
   preserveCase: 5;
 };
 
@@ -411,8 +410,13 @@ parsers: ["less"]
 
 @var // comment
 :{
-  /* FIXME: should not change case */
   preserveCase: 5;
+};
+
+@var // a
+: // b
+{
+  camelCase: 1;
 };
 
 // Known css properties
@@ -473,8 +477,7 @@ parsers: ["less"]
 @var // comment
 : // comment
 {
-  /* FIXME: should not change case */
-  preservecase: 5;
+  preserveCase: 5;
 }
 
 @var: // comment
@@ -484,8 +487,13 @@ parsers: ["less"]
 
 @var // comment
 : {
-  /* FIXME: should not change case */
-  preservecase: 5;
+  preserveCase: 5;
+}
+
+@var // a
+: // b
+{
+  camelCase: 1;
 }
 
 // Known css properties

--- a/tests/format/less/case/variable.less
+++ b/tests/format/less/case/variable.less
@@ -35,7 +35,6 @@
 @var // comment
 : // comment
 {
-  /* FIXME: should not change case */
   preserveCase: 5;
 };
 
@@ -46,8 +45,13 @@
 
 @var // comment
 :{
-  /* FIXME: should not change case */
   preserveCase: 5;
+};
+
+@var // a
+: // b
+{
+  camelCase: 1;
 };
 
 // Known css properties


### PR DESCRIPTION
<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

<!-- Please provide a brief summary of your changes -->


Fixes incorrect lowercasing of property names inside Less detached rulesets when comments appear before the colon in the variable declaration.

For example:

```less
@var // comment
: // comment
{
  preserveCase: 5;
};
```

was formatted as:

```
@var // comment
: // comment
{
  preservecase: 5;
}
```


This changes the property name inside the detached ruleset and can break Less property lookups that depend on case.

The parser now recognizes Less variable declarations whose colon is separated from the variable name by whitespace or comments, while preserving the original comment placement during printing.





## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
