### PR TITLE
Preserve trailing commas in CSS custom properties

### DIFF
--- a/changelog_unreleased/css/19998.md
+++ b/changelog_unreleased/css/19998.md
@@ -1,0 +1,19 @@
+#### Preserve trailing commas in custom properties (#19998 by @vzer200)
+
+Trailing commas are part of a custom property's value and can be required when the value is substituted into another declaration. They are now preserved with the CSS, SCSS, and Less parsers.
+
+<!-- prettier-ignore -->
+```css
+/* Input */
+.foo { --interpolation-method: in oklab,; }
+
+/* Prettier stable */
+.foo {
+  --interpolation-method: in oklab;
+}
+
+/* Prettier main */
+.foo {
+  --interpolation-method: in oklab,;
+}
+```

--- a/src/language-css/print/css-declaration.js
+++ b/src/language-css/print/css-declaration.js
@@ -81,6 +81,16 @@ function printCssDeclaration(path, options, print) {
 
   parts.push(value);
 
+  // The value parser drops the final empty comma group, but its comma is
+  // significant in a custom property.
+  if (
+    node.prop.startsWith("--") &&
+    node.value.type === "value-root" &&
+    node.value.text.trimEnd().endsWith(",")
+  ) {
+    parts.push(",");
+  }
+
   if (node.raws.important) {
     parts.push(node.raws.important.replace(/\s*!\s*important/i, " !important"));
   } else if (node.important) {

--- a/tests/format/css/custom-property-trailing-comma/__snapshots__/format.test.js.snap
+++ b/tests/format/css/custom-property-trailing-comma/__snapshots__/format.test.js.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`trailing-comma.css format 1`] = `
+====================================options=====================================
+parsers: ["css", "scss", "less"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+.foo {
+  --single: red,;
+  --multiple: red, blue,;
+  --empty: ,;
+  --empty-items: ,,;
+  --function: var(--fallback,),;
+  --before-comment: red, /* comment */;
+  --after-comment: red /* comment */,;
+  --important: in oklab, !important;
+  --no-semicolon: red,
+}
+
+.unchanged {
+  --no-comma: red;
+  --string: ",";
+  --function: var(--fallback,);
+  font-family: Arial, sans-serif,;
+  background-image: url("image.png"),;
+}
+
+=====================================output=====================================
+.foo {
+  --single: red,;
+  --multiple: red, blue,;
+  --empty: ,;
+  --empty-items: , ,;
+  --function: var(--fallback,),;
+  --before-comment: red, /* comment */;
+  --after-comment: red /* comment */,;
+  --important: in oklab, !important;
+  --no-semicolon: red,;
+}
+
+.unchanged {
+  --no-comma: red;
+  --string: ",";
+  --function: var(--fallback,);
+  font-family: Arial, sans-serif;
+  background-image: url("image.png");
+}
+
+================================================================================
+`;

--- a/tests/format/css/custom-property-trailing-comma/format.test.js
+++ b/tests/format/css/custom-property-trailing-comma/format.test.js
@@ -1,0 +1,12 @@
+runFormatTest(
+  {
+    importMeta: import.meta,
+    snippets: [
+      {
+        code: ".foo { --my-var: in oklab,; }",
+        output: ".foo {\n  --my-var: in oklab,;\n}\n",
+      },
+    ],
+  },
+  ["css", "scss", "less"],
+);

--- a/tests/format/css/custom-property-trailing-comma/trailing-comma.css
+++ b/tests/format/css/custom-property-trailing-comma/trailing-comma.css
@@ -1,0 +1,19 @@
+.foo {
+  --single: red,;
+  --multiple: red, blue,;
+  --empty: ,;
+  --empty-items: ,,;
+  --function: var(--fallback,),;
+  --before-comment: red, /* comment */;
+  --after-comment: red /* comment */,;
+  --important: in oklab, !important;
+  --no-semicolon: red,
+}
+
+.unchanged {
+  --no-comma: red;
+  --string: ",";
+  --function: var(--fallback,);
+  font-family: Arial, sans-serif,;
+  background-image: url("image.png"),;
+}


### PR DESCRIPTION
## Description

Fixes #17058.

Preserve the trailing comma in custom-property values such as `--interpolation-method: in oklab,;`. Removing it changes the value substituted by `var()` and can invalidate a gradient. The declaration printer now preserves the comma dropped by value parsing, while ordinary property cleanup and function-argument formatting stay the same.

Added regression coverage for CSS, SCSS, and Less, including empty values, lists, comments, `!important`, and ordinary-property controls. With `FULL_TEST=1`, all 131 CSS/SCSS/Less suites pass (3,320 tests and 553 snapshots). ESLint, formatting, and format-test lint pass. A Chromium check confirms that the formatted gradient matches the original rendering.

AI-assisted implementation, independently reviewed by a second coding agent.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

