### PR TITLE
Keep for-in and for-of comments with the right expression

### DIFF
--- a/changelog_unreleased/javascript/19999.md
+++ b/changelog_unreleased/javascript/19999.md
@@ -1,0 +1,19 @@
+#### Keep comments after `in` and `of` with the right-hand expression (#19999 by @vzer200)
+
+Comments after a loop's `in` or `of` keyword now stay with the expression that follows them. This also prevents repeated formatting from alternating between different layouts for parenthesized TypeScript assertions in `for...of` loops.
+
+<!-- prettier-ignore -->
+```js
+// Input
+for (const value of // iterable
+  values) {}
+
+// Prettier stable
+for (const value of values) { // iterable
+}
+
+// Prettier main
+for (const value of // iterable
+values) {
+}
+```

--- a/src/language-js/comments/attach/handle-for-x-statement-comments.js
+++ b/src/language-js/comments/attach/handle-for-x-statement-comments.js
@@ -1,5 +1,5 @@
 import { addLeadingComment } from "../../../main/comments/utilities.js";
-import { locStart } from "../../location/index.js";
+import { locEnd, locStart } from "../../location/index.js";
 import { stripComments } from "../../utilities/strip-comments.js";
 
 function handleForXStatementComments({
@@ -8,6 +8,20 @@ function handleForXStatementComments({
   followingNode,
   options,
 }) {
+  if (
+    (enclosingNode?.type === "ForInStatement" ||
+      enclosingNode?.type === "ForOfStatement") &&
+    followingNode === enclosingNode.right &&
+    locStart(comment) >
+      stripComments(options).indexOf(
+        enclosingNode.type === "ForOfStatement" ? "of" : "in",
+        locEnd(enclosingNode.left),
+      )
+  ) {
+    addLeadingComment(followingNode, comment);
+    return true;
+  }
+
   if (
     (enclosingNode?.type === "ForInStatement" ||
       enclosingNode?.type === "ForOfStatement" ||

--- a/tests/config/format-test/failed-format-tests.js
+++ b/tests/config/format-test/failed-format-tests.js
@@ -15,7 +15,6 @@ const unstableTests = new Map(
     "flow/comments/type_annotations.js",
     "typescript/prettier-ignore/mapped-types.ts",
     "typescript/prettier-ignore/issue-14238.ts",
-    "js/for-of/comments.js",
     "jsx/comments/in-attributes.js",
     "typescript/import-type/long-module-name/long-module-name4.ts",
     [

--- a/tests/format/js/for-of/__snapshots__/format.test.js.snap
+++ b/tests/format/js/for-of/__snapshots__/format.test.js.snap
@@ -75,11 +75,13 @@ for(x of
 y);
 
 =====================================output=====================================
-for (x in /*1a*/ //1b
+for (x in /*1a*/
+//1b
 y) //1c
 ;
 
-for (x /*2a*/ in y); //2b //2c
+for (x in /*2a*/ //2b
+y); //2c
 
 for (x /*3a*/ in y); //3b //3c
 
@@ -89,11 +91,13 @@ y);
 for (x in //5a
 y);
 
-for (x of /*6a*/ //6b
+for (x of /*6a*/
+//6b
 y) //6c
 ;
 
-for (x /*7a*/ of y); //7b //7c
+for (x of /*7a*/ //7b
+y); //7c
 
 for (x /*8a*/ of y); //8b //8c
 
@@ -102,6 +106,63 @@ y);
 
 for (x of //10a
 y);
+
+================================================================================
+`;
+
+exports[`comments-after-operator.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+for (const value of // iterable
+  values) {}
+
+for (const key in // object
+  object) {}
+
+for ((value) of // iterable
+  values) {}
+
+for (value /* left */ of // right
+  values) {}
+
+for (value // before of
+  of values);
+
+for (value of /* first */ // second
+  values) {}
+
+for (value of ( // sequence
+  first, second
+).entries()) {}
+
+=====================================output=====================================
+for (const value of // iterable
+values) {
+}
+
+for (const key in // object
+object) {
+}
+
+for (value of // iterable
+values) {
+}
+
+for (value /* left */ of // right
+values) {
+}
+
+for (value of values); // before of
+
+for (value of /* first */ // second
+values) {
+}
+
+for (value of // sequence
+(first, second).entries()) {
+}
 
 ================================================================================
 `;

--- a/tests/format/js/for-of/comments-after-operator.js
+++ b/tests/format/js/for-of/comments-after-operator.js
@@ -1,0 +1,21 @@
+for (const value of // iterable
+  values) {}
+
+for (const key in // object
+  object) {}
+
+for ((value) of // iterable
+  values) {}
+
+for (value /* left */ of // right
+  values) {}
+
+for (value // before of
+  of values);
+
+for (value of /* first */ // second
+  values) {}
+
+for (value of ( // sequence
+  first, second
+).entries()) {}

--- a/tests/format/typescript/for-of-comments/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/for-of-comments/__snapshots__/format.test.js.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`comments.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+for (const value of ( // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  column.getFacetedUniqueValues() as Map<TValue, number>
+).keys()) {
+}
+
+for (const value of ( // comment
+  collection as Map<string, number>
+).keys()) {}
+
+for (const key in ( // comment
+  collection as Record<string, number>
+).entries()) {}
+
+for await (const value of ( // comment
+  collection as Map<string, number>
+).keys()) {}
+
+=====================================output=====================================
+for (const value of // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+(column.getFacetedUniqueValues() as Map<TValue, number>).keys()) {
+}
+
+for (const value of // comment
+(collection as Map<string, number>).keys()) {
+}
+
+for (const key in // comment
+(collection as Record<string, number>).entries()) {
+}
+
+for await (const value of // comment
+(collection as Map<string, number>).keys()) {
+}
+
+================================================================================
+`;

--- a/tests/format/typescript/for-of-comments/comments.ts
+++ b/tests/format/typescript/for-of-comments/comments.ts
@@ -1,0 +1,16 @@
+for (const value of ( // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  column.getFacetedUniqueValues() as Map<TValue, number>
+).keys()) {
+}
+
+for (const value of ( // comment
+  collection as Map<string, number>
+).keys()) {}
+
+for (const key in ( // comment
+  collection as Record<string, number>
+).entries()) {}
+
+for await (const value of ( // comment
+  collection as Map<string, number>
+).keys()) {}

--- a/tests/format/typescript/for-of-comments/format.test.js
+++ b/tests/format/typescript/for-of-comments/format.test.js
@@ -1,0 +1,1 @@
+runFormatTest(import.meta, ["typescript"]);


### PR DESCRIPTION
## Description

Fixes #17213.

Keep comments after `in` and `of` attached to the loop's right-hand expression. They were being attached to the left declaration, which could move them towards the body or make a parenthesized TypeScript assertion alternate between two layouts on repeated formatting.

Added JavaScript and TypeScript regression cases and removed the expected-instability exemption for the existing for-of comment fixture, which is now stable. With `FULL_TEST=1`, the JS/TypeScript/Flow selection passes all 1,033 suites, 71,845 tests, and 8,272 snapshots. Targeted ESLint, formatting, and format-test lint also pass.

AI-assisted implementation, independently reviewed by a second coding agent.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
