### PR TITLE
Fix explicit YAML scalar indentation when reindenting containers

### DIFF
--- a/changelog_unreleased/yaml/20000.md
+++ b/changelog_unreleased/yaml/20000.md
@@ -1,0 +1,24 @@
+#### Preserve explicit block scalar indentation when reindenting containers (#20000 by @vzer200)
+
+Explicitly indented block scalar content now moves with its containing mapping or sequence. Previously, reindenting an indentless sequence could turn scalar text into sibling mapping entries or produce invalid YAML.
+
+<!-- prettier-ignore -->
+```yaml
+# Input
+list:
+- with:
+    config-yml: |2
+      hello: world
+
+# Prettier stable
+list:
+  - with:
+      config-yml: |2
+      hello: world
+
+# Prettier main
+list:
+  - with:
+      config-yml: |2
+        hello: world
+```

--- a/src/language-yaml/print/block.js
+++ b/src/language-yaml/print/block.js
@@ -20,9 +20,12 @@ import { alignWithSpaces } from "./misc.js";
 
 function printBlock(path, options, print) {
   const { node } = path;
-  const parentIndent = path.ancestors.filter(
-    (node) => node.type === "sequence" || node.type === "mapping",
-  ).length;
+  const parent = path.findAncestor(
+    (node) => node.type === "sequenceItem" || node.type === "mappingItem",
+  );
+  // Read the scalar relative to its original parent indentation. The parent
+  // may move when we normalize indentation, for example an indentless sequence.
+  const parentIndent = parent ? parent.position.start.column - 1 : 0;
   const isLastDescendant = isLastDescendantNode(path);
   /** @type {Doc[]} */
   const parts = [node.type === "blockFolded" ? ">" : "|"];
@@ -68,11 +71,7 @@ function printBlock(path, options, print) {
   if (node.indent === null) {
     parts.push(dedent(alignWithSpaces(options.tabWidth, contentsParts)));
   } else {
-    parts.push(
-      dedentToRoot(
-        alignWithSpaces(node.indent - 1 + parentIndent, contentsParts),
-      ),
-    );
+    parts.push(dedent(alignWithSpaces(node.indent, contentsParts)));
   }
 
   return parts;

--- a/src/language-yaml/utilities.js
+++ b/src/language-yaml/utilities.js
@@ -221,7 +221,7 @@ function getBlockValueLineContents(
       ? matches.groups.leadingSpace.length
       : Number.POSITIVE_INFINITY;
   } else {
-    leadingSpaceCount = node.indent - 1 + parentIndent;
+    leadingSpaceCount = node.indent + parentIndent;
   }
 
   const rawLineContents = content

--- a/tests/format/yaml/block-value/explicit-indent/__snapshots__/format.test.js.snap
+++ b/tests/format/yaml/block-value/explicit-indent/__snapshots__/format.test.js.snap
@@ -1,0 +1,868 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`scalars.yml - {"tabWidth":1,"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["yaml"]
+proseWrap: "always"
+tabWidth: 1
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+---
+list:
+- with:
+    config-yml: |2
+      hello: world
+    next: value
+---
+list:
+- >1-
+ hello
+ world
+- next
+---
+list:
+- - |2
+    nested sequence
+  - next
+---
+mapping:
+      value: |2 # indentation indicator
+        first line
+          leading spaces
+
+        last line
+      next: value
+---
+mapping:
+      value: >2-
+        first line
+        second line
+
+          indented line
+        last line
+---
+list:
+- &anchor |2+
+
+  first line
+    leading spaces
+
+- *anchor
+---
+list:
+- ? |2
+    multiline
+    key
+  : |1-
+   multiline
+   value
+---
+   root: |2-
+     indented root
+---
+|2-
+  root scalar
+    leading spaces
+
+=====================================output=====================================
+---
+list:
+ - with:
+    config-yml: |2
+      hello: world
+    next: value
+---
+list:
+ - >1-
+  hello world
+ - next
+---
+list:
+ - - |2
+     nested sequence
+   - next
+---
+mapping:
+ value: |2 # indentation indicator
+   first line
+     leading spaces
+
+   last line
+ next: value
+---
+mapping:
+ value: >2-
+   first line second line
+
+     indented line
+   last line
+---
+list:
+ - &anchor |2+
+
+   first line
+     leading spaces
+
+ - *anchor
+---
+list:
+ - ? |2
+     multiline
+     key
+   : |1-
+    multiline
+    value
+---
+root: |2-
+  indented root
+---
+|2-
+  root scalar
+    leading spaces
+
+================================================================================
+`;
+
+exports[`scalars.yml - {"tabWidth":1,"proseWrap":"preserve"} format 1`] = `
+====================================options=====================================
+parsers: ["yaml"]
+proseWrap: "preserve"
+tabWidth: 1
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+---
+list:
+- with:
+    config-yml: |2
+      hello: world
+    next: value
+---
+list:
+- >1-
+ hello
+ world
+- next
+---
+list:
+- - |2
+    nested sequence
+  - next
+---
+mapping:
+      value: |2 # indentation indicator
+        first line
+          leading spaces
+
+        last line
+      next: value
+---
+mapping:
+      value: >2-
+        first line
+        second line
+
+          indented line
+        last line
+---
+list:
+- &anchor |2+
+
+  first line
+    leading spaces
+
+- *anchor
+---
+list:
+- ? |2
+    multiline
+    key
+  : |1-
+   multiline
+   value
+---
+   root: |2-
+     indented root
+---
+|2-
+  root scalar
+    leading spaces
+
+=====================================output=====================================
+---
+list:
+ - with:
+    config-yml: |2
+      hello: world
+    next: value
+---
+list:
+ - >1-
+  hello
+  world
+ - next
+---
+list:
+ - - |2
+     nested sequence
+   - next
+---
+mapping:
+ value: |2 # indentation indicator
+   first line
+     leading spaces
+
+   last line
+ next: value
+---
+mapping:
+ value: >2-
+   first line
+   second line
+
+     indented line
+   last line
+---
+list:
+ - &anchor |2+
+
+   first line
+     leading spaces
+
+ - *anchor
+---
+list:
+ - ? |2
+     multiline
+     key
+   : |1-
+    multiline
+    value
+---
+root: |2-
+  indented root
+---
+|2-
+  root scalar
+    leading spaces
+
+================================================================================
+`;
+
+exports[`scalars.yml - {"tabWidth":4,"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["yaml"]
+proseWrap: "always"
+tabWidth: 4
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+---
+list:
+- with:
+    config-yml: |2
+      hello: world
+    next: value
+---
+list:
+- >1-
+ hello
+ world
+- next
+---
+list:
+- - |2
+    nested sequence
+  - next
+---
+mapping:
+      value: |2 # indentation indicator
+        first line
+          leading spaces
+
+        last line
+      next: value
+---
+mapping:
+      value: >2-
+        first line
+        second line
+
+          indented line
+        last line
+---
+list:
+- &anchor |2+
+
+  first line
+    leading spaces
+
+- *anchor
+---
+list:
+- ? |2
+    multiline
+    key
+  : |1-
+   multiline
+   value
+---
+   root: |2-
+     indented root
+---
+|2-
+  root scalar
+    leading spaces
+
+=====================================output=====================================
+---
+list:
+    - with:
+          config-yml: |2
+            hello: world
+          next: value
+---
+list:
+    - >1-
+     hello world
+    - next
+---
+list:
+    - - |2
+        nested sequence
+      - next
+---
+mapping:
+    value: |2 # indentation indicator
+      first line
+        leading spaces
+
+      last line
+    next: value
+---
+mapping:
+    value: >2-
+      first line second line
+
+        indented line
+      last line
+---
+list:
+    - &anchor |2+
+
+      first line
+        leading spaces
+
+    - *anchor
+---
+list:
+    - ? |2
+        multiline
+        key
+      : |1-
+       multiline
+       value
+---
+root: |2-
+  indented root
+---
+|2-
+  root scalar
+    leading spaces
+
+================================================================================
+`;
+
+exports[`scalars.yml - {"tabWidth":4,"proseWrap":"preserve"} format 1`] = `
+====================================options=====================================
+parsers: ["yaml"]
+proseWrap: "preserve"
+tabWidth: 4
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+---
+list:
+- with:
+    config-yml: |2
+      hello: world
+    next: value
+---
+list:
+- >1-
+ hello
+ world
+- next
+---
+list:
+- - |2
+    nested sequence
+  - next
+---
+mapping:
+      value: |2 # indentation indicator
+        first line
+          leading spaces
+
+        last line
+      next: value
+---
+mapping:
+      value: >2-
+        first line
+        second line
+
+          indented line
+        last line
+---
+list:
+- &anchor |2+
+
+  first line
+    leading spaces
+
+- *anchor
+---
+list:
+- ? |2
+    multiline
+    key
+  : |1-
+   multiline
+   value
+---
+   root: |2-
+     indented root
+---
+|2-
+  root scalar
+    leading spaces
+
+=====================================output=====================================
+---
+list:
+    - with:
+          config-yml: |2
+            hello: world
+          next: value
+---
+list:
+    - >1-
+     hello
+     world
+    - next
+---
+list:
+    - - |2
+        nested sequence
+      - next
+---
+mapping:
+    value: |2 # indentation indicator
+      first line
+        leading spaces
+
+      last line
+    next: value
+---
+mapping:
+    value: >2-
+      first line
+      second line
+
+        indented line
+      last line
+---
+list:
+    - &anchor |2+
+
+      first line
+        leading spaces
+
+    - *anchor
+---
+list:
+    - ? |2
+        multiline
+        key
+      : |1-
+       multiline
+       value
+---
+root: |2-
+  indented root
+---
+|2-
+  root scalar
+    leading spaces
+
+================================================================================
+`;
+
+exports[`scalars.yml - {"tabWidth":8,"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["yaml"]
+proseWrap: "always"
+tabWidth: 8
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+---
+list:
+- with:
+    config-yml: |2
+      hello: world
+    next: value
+---
+list:
+- >1-
+ hello
+ world
+- next
+---
+list:
+- - |2
+    nested sequence
+  - next
+---
+mapping:
+      value: |2 # indentation indicator
+        first line
+          leading spaces
+
+        last line
+      next: value
+---
+mapping:
+      value: >2-
+        first line
+        second line
+
+          indented line
+        last line
+---
+list:
+- &anchor |2+
+
+  first line
+    leading spaces
+
+- *anchor
+---
+list:
+- ? |2
+    multiline
+    key
+  : |1-
+   multiline
+   value
+---
+   root: |2-
+     indented root
+---
+|2-
+  root scalar
+    leading spaces
+
+=====================================output=====================================
+---
+list:
+        - with:
+                  config-yml: |2
+                    hello: world
+                  next: value
+---
+list:
+        - >1-
+         hello world
+        - next
+---
+list:
+        - - |2
+            nested sequence
+          - next
+---
+mapping:
+        value: |2 # indentation indicator
+          first line
+            leading spaces
+
+          last line
+        next: value
+---
+mapping:
+        value: >2-
+          first line second line
+
+            indented line
+          last line
+---
+list:
+        - &anchor |2+
+
+          first line
+            leading spaces
+
+        - *anchor
+---
+list:
+        - ? |2
+            multiline
+            key
+          : |1-
+           multiline
+           value
+---
+root: |2-
+  indented root
+---
+|2-
+  root scalar
+    leading spaces
+
+================================================================================
+`;
+
+exports[`scalars.yml - {"tabWidth":8,"proseWrap":"preserve"} format 1`] = `
+====================================options=====================================
+parsers: ["yaml"]
+proseWrap: "preserve"
+tabWidth: 8
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+---
+list:
+- with:
+    config-yml: |2
+      hello: world
+    next: value
+---
+list:
+- >1-
+ hello
+ world
+- next
+---
+list:
+- - |2
+    nested sequence
+  - next
+---
+mapping:
+      value: |2 # indentation indicator
+        first line
+          leading spaces
+
+        last line
+      next: value
+---
+mapping:
+      value: >2-
+        first line
+        second line
+
+          indented line
+        last line
+---
+list:
+- &anchor |2+
+
+  first line
+    leading spaces
+
+- *anchor
+---
+list:
+- ? |2
+    multiline
+    key
+  : |1-
+   multiline
+   value
+---
+   root: |2-
+     indented root
+---
+|2-
+  root scalar
+    leading spaces
+
+=====================================output=====================================
+---
+list:
+        - with:
+                  config-yml: |2
+                    hello: world
+                  next: value
+---
+list:
+        - >1-
+         hello
+         world
+        - next
+---
+list:
+        - - |2
+            nested sequence
+          - next
+---
+mapping:
+        value: |2 # indentation indicator
+          first line
+            leading spaces
+
+          last line
+        next: value
+---
+mapping:
+        value: >2-
+          first line
+          second line
+
+            indented line
+          last line
+---
+list:
+        - &anchor |2+
+
+          first line
+            leading spaces
+
+        - *anchor
+---
+list:
+        - ? |2
+            multiline
+            key
+          : |1-
+           multiline
+           value
+---
+root: |2-
+  indented root
+---
+|2-
+  root scalar
+    leading spaces
+
+================================================================================
+`;
+
+exports[`scalars.yml format 1`] = `
+====================================options=====================================
+parsers: ["yaml"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+---
+list:
+- with:
+    config-yml: |2
+      hello: world
+    next: value
+---
+list:
+- >1-
+ hello
+ world
+- next
+---
+list:
+- - |2
+    nested sequence
+  - next
+---
+mapping:
+      value: |2 # indentation indicator
+        first line
+          leading spaces
+
+        last line
+      next: value
+---
+mapping:
+      value: >2-
+        first line
+        second line
+
+          indented line
+        last line
+---
+list:
+- &anchor |2+
+
+  first line
+    leading spaces
+
+- *anchor
+---
+list:
+- ? |2
+    multiline
+    key
+  : |1-
+   multiline
+   value
+---
+   root: |2-
+     indented root
+---
+|2-
+  root scalar
+    leading spaces
+
+=====================================output=====================================
+---
+list:
+  - with:
+      config-yml: |2
+        hello: world
+      next: value
+---
+list:
+  - >1-
+   hello
+   world
+  - next
+---
+list:
+  - - |2
+      nested sequence
+    - next
+---
+mapping:
+  value: |2 # indentation indicator
+    first line
+      leading spaces
+
+    last line
+  next: value
+---
+mapping:
+  value: >2-
+    first line
+    second line
+
+      indented line
+    last line
+---
+list:
+  - &anchor |2+
+
+    first line
+      leading spaces
+
+  - *anchor
+---
+list:
+  - ? |2
+      multiline
+      key
+    : |1-
+     multiline
+     value
+---
+root: |2-
+  indented root
+---
+|2-
+  root scalar
+    leading spaces
+
+================================================================================
+`;

--- a/tests/format/yaml/block-value/explicit-indent/format.test.js
+++ b/tests/format/yaml/block-value/explicit-indent/format.test.js
@@ -1,0 +1,44 @@
+import { outdent } from "outdent";
+
+const snippets = [
+  {
+    name: "indentless sequence with a literal scalar (issue 16183)",
+    code: outdent`
+      list:
+      - with:
+          config-yml: |2
+            hello: world
+    `,
+    output: outdent`
+      list:
+        - with:
+            config-yml: |2
+              hello: world
+    `,
+  },
+  {
+    name: "indentless sequence with a folded scalar",
+    code: outdent`
+      list:
+      - with:
+          value: >2-
+            hello
+            world
+    `,
+    output: outdent`
+      list:
+        - with:
+            value: >2-
+              hello
+              world
+    `,
+  },
+].map((test) => ({ ...test, output: test.output + "\n" }));
+
+runFormatTest({ importMeta: import.meta, snippets }, ["yaml"]);
+
+for (const tabWidth of [1, 4, 8]) {
+  for (const proseWrap of ["preserve", "always"]) {
+    runFormatTest(import.meta, ["yaml"], { tabWidth, proseWrap });
+  }
+}

--- a/tests/format/yaml/block-value/explicit-indent/scalars.yml
+++ b/tests/format/yaml/block-value/explicit-indent/scalars.yml
@@ -1,0 +1,56 @@
+---
+list:
+- with:
+    config-yml: |2
+      hello: world
+    next: value
+---
+list:
+- >1-
+ hello
+ world
+- next
+---
+list:
+- - |2
+    nested sequence
+  - next
+---
+mapping:
+      value: |2 # indentation indicator
+        first line
+          leading spaces
+
+        last line
+      next: value
+---
+mapping:
+      value: >2-
+        first line
+        second line
+
+          indented line
+        last line
+---
+list:
+- &anchor |2+
+
+  first line
+    leading spaces
+
+- *anchor
+---
+list:
+- ? |2
+    multiline
+    key
+  : |1-
+   multiline
+   value
+---
+   root: |2-
+     indented root
+---
+|2-
+  root scalar
+    leading spaces


### PR DESCRIPTION
## Description

Fixes #16183.

Keep explicitly indented YAML block scalars relative to their containing mapping or sequence. When an indentless sequence was reindented, its scalar content stayed at the original absolute column and could become a sibling mapping or lose characters. Read the content using its original parent indentation, then print it relative to the formatted parent.

Added literal and folded scalar regressions covering nested sequences, overindented mappings, anchors, explicit keys, root scalars, content whitespace and different indentation widths. With `FULL_TEST=1`, all 31 YAML suites, 9,767 tests and 1,631 snapshots pass. Targeted ESLint, formatting and format-test lint pass.

An additional 4,608-case YAML value comparison found 2,479 cases fixed and no newly failing cases. It also encounters 403 pre-existing folded-scalar failures involving `proseWrap: never` with keep chomping or narrow-width wrapping of more-indented text; those folding behaviors are outside this indentation change.

AI-assisted implementation, independently reviewed by two other coding agents. The independent review additionally checked 5,940 parser/idempotency cases: 3,132 passed and 2,808 failed on both the baseline and fix, with no new regression. Existing empty/leading-blank scalar instability is outside this indentation change. No human review is claimed.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.


