### PR TITLE
Keep comments after in with TypeScript mapped type constraints

### DIFF
--- a/changelog_unreleased/typescript/20002.md
+++ b/changelog_unreleased/typescript/20002.md
@@ -1,0 +1,27 @@
+#### Keep comments after `in` with mapped type constraints (#20002 by @vzer200)
+
+Comments after a mapped type's `in` keyword now stay with its constraint, preventing repeated formatting from moving them across the type and changing the target of `prettier-ignore`.
+
+<!-- prettier-ignore -->
+```ts
+// Input
+type A = {
+  [K in // prettier-ignore
+    B]: C;
+};
+
+// Prettier stable
+type A = {
+  [
+    K in B // prettier-ignore
+  ]: C;
+};
+
+// Prettier main
+type A = {
+  [
+    K in // prettier-ignore
+    B
+  ]: C;
+};
+```

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -73,6 +73,7 @@ function handleOwnLineComment(context) {
   return [
     handleCommentInEmptyParens,
     handleIgnoreComments,
+    handleTSMappedTypeComments,
     handleClosureTypeCastComments,
     handleConditionalExpressionComments,
     handleLastFunctionParameterComments,
@@ -92,7 +93,6 @@ function handleOwnLineComment(context) {
     handleLabeledStatementComments,
     handleNestedConditionalExpressionComments,
     handleCommentsInDestructuringPattern,
-    handleTSMappedTypeComments,
     handleBinaryCastExpressionComment,
     handleUnionTypeLeadingComments,
     handleSequenceExpressionLeadingComment,
@@ -894,13 +894,27 @@ function isBeforeMappedTypeOpeningBracket(node, comment, options) {
   return locEnd(comment) < bracketIndex;
 }
 
-function handleTSMappedTypeComments({ comment, enclosingNode, options }) {
+function handleTSMappedTypeComments({
+  comment,
+  enclosingNode,
+  followingNode,
+  options,
+}) {
   if (enclosingNode?.type !== "TSMappedType") {
     return;
   }
 
   if (isBeforeMappedTypeOpeningBracket(enclosingNode, comment, options)) {
     addDanglingComment(enclosingNode, comment);
+    return true;
+  }
+
+  if (
+    followingNode === enclosingNode.constraint &&
+    locStart(comment) >
+      stripComments(options).indexOf("in", locEnd(enclosingNode.key))
+  ) {
+    addLeadingComment(followingNode, comment);
     return true;
   }
 }

--- a/src/language-js/print/mapped-type.js
+++ b/src/language-js/print/mapped-type.js
@@ -11,8 +11,15 @@ import hasNewline from "../../utilities/has-newline.js";
 import hasNewlineInRange from "../../utilities/has-newline-in-range.js";
 import { locEnd, locStart } from "../location/index.js";
 import { isLineComment } from "../utilities/comment-types.js";
-import { CommentCheckFlags, getComments } from "../utilities/comments.js";
+import {
+  CommentCheckFlags,
+  getComments,
+  hasComment,
+} from "../utilities/comments.js";
+import { hasNodeIgnoreComment } from "../utilities/has-node-ignore-comment.js";
+import { isUnionType } from "../utilities/node-types.js";
 import { stripComments } from "../utilities/strip-comments.js";
+import { shouldHugUnionType } from "../utilities/union-type-print.js";
 import { printClassMemberSemicolon } from "./class.js";
 
 /**
@@ -101,6 +108,23 @@ function printTypeScriptMappedType(path, options, print) {
     );
   }
 
+  // Unions normally print their own leading line break. Ignored or hugged
+  // unions need the same explicit break as other constraints.
+  const shouldBreakBeforeConstraint =
+    (!isUnionType(node.constraint) ||
+      shouldHugUnionType(node.constraint) ||
+      hasNodeIgnoreComment(node.constraint)) &&
+    hasComment(
+      node.constraint,
+      CommentCheckFlags.Leading |
+        CommentCheckFlags.Block |
+        CommentCheckFlags.First,
+      (comment) =>
+        hasNewline(options.originalText, locStart(comment), {
+          backwards: true,
+        }) && hasNewline(options.originalText, locEnd(comment)),
+    );
+
   return group(
     [
       "{",
@@ -119,7 +143,8 @@ function printTypeScriptMappedType(path, options, print) {
             indent([
               softline,
               print("key"),
-              " in ",
+              " in",
+              shouldBreakBeforeConstraint ? hardline : " ",
               print("constraint"),
               node.nameType ? [" as ", print("nameType")] : "",
             ]),

--- a/tests/config/format-test/failed-format-tests.js
+++ b/tests/config/format-test/failed-format-tests.js
@@ -13,7 +13,6 @@ const unstableTests = new Map(
     "flow/hook/declare-hook.js",
     "flow/hook/hook-type-annotation.js",
     "flow/comments/type_annotations.js",
-    "typescript/prettier-ignore/mapped-types.ts",
     "typescript/prettier-ignore/issue-14238.ts",
     "js/for-of/comments.js",
     "jsx/comments/in-attributes.js",

--- a/tests/format/typescript/mapped-type-comments-after-in/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/mapped-type-comments-after-in/__snapshots__/format.test.js.snap
@@ -1,0 +1,211 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`comments.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript", "babel-ts"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+type OwnLine = {
+  [Key in
+    // keys
+    keyof Source
+  ]: Value;
+};
+
+type EndOfLine = {
+  [Key in // keys
+    keyof Source]: Value;
+};
+
+type Block = { [Key in /* keys */ keyof Source]: Value };
+
+type Multiple = {
+  [Key in /* first */
+    // second
+    /* third */ keyof Source]: Value;
+};
+
+type Parenthesized = {
+  [Key in (
+    // keys
+    keyof Source
+  )]: Value;
+};
+
+type Union = {
+  [Key in
+    // keys
+    "a" | "b"]: Value;
+};
+
+type IgnoreUnion = {
+  [Key in // prettier-ignore
+    "a"  |  "b"]: Value;
+};
+
+type IgnoreReference = {
+  [Key in
+    /* prettier-ignore */
+    Keys<  Source  >]: Value;
+};
+
+type ModifiersAndRemapping = {
+  -readonly [Key in // keys
+    keyof Source as \`get\${Capitalize<Key>}\`]-?: Value;
+};
+
+type KeywordInComment = {
+  [Key /* in this comment */ in // keys
+    keyof Source]: Value;
+};
+
+type KeywordInName = {
+  [input in // keys
+    keyof Source]: Value;
+};
+
+type BeforeKeyword = {
+  [Key /* before in */ in keyof Source]: Value;
+};
+
+type MultipleBlocksBeforeUnion = {
+  [input /* in before keyword */ in /* first */
+    /* second */
+    "a" | "b"]: Value;
+};
+
+type OwnLineBlocksBeforeUnion = {
+  [Key in
+    /* first */
+    /* second */
+    "a" | "b"]: Value;
+};
+
+type IgnoredUnionWithBlocks = {
+  [Key in /* first */
+    /* prettier-ignore */
+    "a"  |  "b"]: Value;
+};
+
+type ObjectUnionWithBlock = {
+  [Key in
+    /* keys */
+    Source | null]: Value;
+};
+
+=====================================output=====================================
+type OwnLine = {
+  [
+    Key in // keys
+    keyof Source
+  ]: Value;
+};
+
+type EndOfLine = {
+  [
+    Key in // keys
+    keyof Source
+  ]: Value;
+};
+
+type Block = { [Key in /* keys */ keyof Source]: Value };
+
+type Multiple = {
+  [
+    Key in /* first */
+    // second
+    /* third */ keyof Source
+  ]: Value;
+};
+
+type Parenthesized = {
+  [
+    Key in // keys
+    keyof Source
+  ]: Value;
+};
+
+type Union = {
+  [
+    Key in
+      // keys
+      "a" | "b"
+  ]: Value;
+};
+
+type IgnoreUnion = {
+  [
+    Key in // prettier-ignore
+    "a"  |  "b"
+  ]: Value;
+};
+
+type IgnoreReference = {
+  [
+    Key in
+    /* prettier-ignore */
+    Keys<  Source  >
+  ]: Value;
+};
+
+type ModifiersAndRemapping = {
+  -readonly [
+    Key in // keys
+    keyof Source as \`get\${Capitalize<Key>}\`
+  ]-?: Value;
+};
+
+type KeywordInComment = {
+  [
+    Key /* in this comment */ in // keys
+    keyof Source
+  ]: Value;
+};
+
+type KeywordInName = {
+  [
+    input in // keys
+    keyof Source
+  ]: Value;
+};
+
+type BeforeKeyword = {
+  [Key /* before in */ in keyof Source]: Value;
+};
+
+type MultipleBlocksBeforeUnion = {
+  [
+    input /* in before keyword */ in
+      /* first */
+      /* second */
+      "a" | "b"
+  ]: Value;
+};
+
+type OwnLineBlocksBeforeUnion = {
+  [
+    Key in
+      /* first */
+      /* second */
+      "a" | "b"
+  ]: Value;
+};
+
+type IgnoredUnionWithBlocks = {
+  [
+    Key in /* first */
+    /* prettier-ignore */
+    "a"  |  "b"
+  ]: Value;
+};
+
+type ObjectUnionWithBlock = {
+  [
+    Key in
+    /* keys */
+    Source | null
+  ]: Value;
+};
+
+================================================================================
+`;

--- a/tests/format/typescript/mapped-type-comments-after-in/comments.ts
+++ b/tests/format/typescript/mapped-type-comments-after-in/comments.ts
@@ -1,0 +1,87 @@
+type OwnLine = {
+  [Key in
+    // keys
+    keyof Source
+  ]: Value;
+};
+
+type EndOfLine = {
+  [Key in // keys
+    keyof Source]: Value;
+};
+
+type Block = { [Key in /* keys */ keyof Source]: Value };
+
+type Multiple = {
+  [Key in /* first */
+    // second
+    /* third */ keyof Source]: Value;
+};
+
+type Parenthesized = {
+  [Key in (
+    // keys
+    keyof Source
+  )]: Value;
+};
+
+type Union = {
+  [Key in
+    // keys
+    "a" | "b"]: Value;
+};
+
+type IgnoreUnion = {
+  [Key in // prettier-ignore
+    "a"  |  "b"]: Value;
+};
+
+type IgnoreReference = {
+  [Key in
+    /* prettier-ignore */
+    Keys<  Source  >]: Value;
+};
+
+type ModifiersAndRemapping = {
+  -readonly [Key in // keys
+    keyof Source as `get${Capitalize<Key>}`]-?: Value;
+};
+
+type KeywordInComment = {
+  [Key /* in this comment */ in // keys
+    keyof Source]: Value;
+};
+
+type KeywordInName = {
+  [input in // keys
+    keyof Source]: Value;
+};
+
+type BeforeKeyword = {
+  [Key /* before in */ in keyof Source]: Value;
+};
+
+type MultipleBlocksBeforeUnion = {
+  [input /* in before keyword */ in /* first */
+    /* second */
+    "a" | "b"]: Value;
+};
+
+type OwnLineBlocksBeforeUnion = {
+  [Key in
+    /* first */
+    /* second */
+    "a" | "b"]: Value;
+};
+
+type IgnoredUnionWithBlocks = {
+  [Key in /* first */
+    /* prettier-ignore */
+    "a"  |  "b"]: Value;
+};
+
+type ObjectUnionWithBlock = {
+  [Key in
+    /* keys */
+    Source | null]: Value;
+};

--- a/tests/format/typescript/mapped-type-comments-after-in/format.test.js
+++ b/tests/format/typescript/mapped-type-comments-after-in/format.test.js
@@ -1,0 +1,30 @@
+import { outdent } from "outdent";
+
+runFormatTest(
+  {
+    importMeta: import.meta,
+    snippets: [
+      {
+        name: "ignore comment after in (issue 15550)",
+        code: outdent`
+          type A = {
+            [K in
+              // prettier-ignore
+              B  |  C
+            ]: D
+          }
+        `,
+        output:
+          outdent`
+            type A = {
+              [
+                K in // prettier-ignore
+                B  |  C
+              ]: D;
+            };
+          ` + "\n",
+      },
+    ],
+  },
+  ["typescript", "babel-ts"],
+);

--- a/tests/format/typescript/prettier-ignore/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/prettier-ignore/__snapshots__/format.test.js.snap
@@ -145,7 +145,8 @@ type e = {
 
 type f = {
   [
-    A in /* prettier-ignore */
+    A in
+    /* prettier-ignore */
     B
   ]: C | D;
 };


### PR DESCRIPTION
## Description

Fixes #15550.

Keep comments after a mapped type's `in` keyword attached to its constraint. These comments could drift past the constraint and closing bracket on repeated formatting, changing which node `prettier-ignore` applied to. Own-line block comments also retain their preceding newline so their layout remains stable.

Added line/block comment, union constraint, modifier and key-remapping regressions. Removed the expected-instability entry for the existing mapped-type prettier-ignore fixture, which now passes repeated formatting. With `FULL_TEST=1`, all 754 TypeScript/Flow suites, 22,988 tests and 3,841 snapshots pass. ESLint, formatting and format-test lint pass; 216 additional combinations remain identical across five formatting passes, and an independently prepared 2,016-case AST/stability matrix passes.

AI-assisted implementation, independently reviewed by other coding agents. Independent review re-ran the full suite and checked 6,048 additional combinations for AST equivalence and repeated formatting; 4,032 of those also verify comment content and order.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
