### PR TITLE
chore: fix typos in comments

### DIFF
--- a/scripts/build/packages/prettier-package-json.js
+++ b/scripts/build/packages/prettier-package-json.js
@@ -36,7 +36,7 @@ function generatePackageJson(packageJson, { packageConfig }) {
           }),
       ),
       // Legacy entries
-      // TODO: Remove bellow in v4
+      // TODO: Remove below in v4
       "./esm/standalone.mjs": "./standalone.mjs",
       ...Object.fromEntries(
         files

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -103,7 +103,7 @@ function genericPrint(path, options, print) {
       const printed = getTextValueParts(node);
 
       const suffix = printClosingTagSuffix(node, options);
-      // We cant use `fill([prefix, printed, suffix])` because it violates rule of fill: elements with odd indices must be line break
+      // We can't use `fill([prefix, printed, suffix])` because it violates rule of fill: elements with odd indices must be line break
       printed[0] = [prefix, printed[0]];
       // @ts-expect-error -- Need investigate how `replaceEndOfLine` works
       printed.push([printed.pop(), suffix]);


### PR DESCRIPTION
## Description

Fix two typos in code comments (no behavior change):

- `src/language-html/printer-html.js`: `cant` -> `can't`
- `scripts/build/packages/prettier-package-json.js`: `bellow` -> `below` (in a TODO comment)

Typo candidates were found with spell-check tooling; changes were assisted by Codex (AI) and reviewed by a human before submitting.

## Checklist

- [ ] I've added tests to confirm my change works. (comment-only changes, N/A)
- [ ] (If changing the API or CLI) I've documented the changes I've made (in the `docs/` directory). (N/A)
- [ ] (If the change is user-facing) I've added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`. (N/A)
- [x] I've read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
