### PR TITLE
Preserve empty lines in folded YAML with proseWrap never

### DIFF
--- a/changelog_unreleased/yaml/20004.md
+++ b/changelog_unreleased/yaml/20004.md
@@ -1,0 +1,20 @@
+#### Preserve empty lines in folded YAML with `proseWrap: "never"` (#20004 by @vzer200)
+
+Folded YAML scalars no longer gain extra blank lines when `proseWrap` is `"never"`. This also preserves the value of scalars using keep chomping (`>+`) and applies to YAML front matter in Markdown.
+
+<!-- prettier-ignore -->
+```yaml
+# Input (--prose-wrap never)
+>+
+  first
+  second
+
+# Prettier stable
+>+
+  first second
+  
+
+# Prettier main
+>+
+  first second
+```

--- a/src/language-yaml/utilities.js
+++ b/src/language-yaml/utilities.js
@@ -215,7 +215,7 @@ function getBlockValueLineContents(
 
   /** @type {number} */
   let leadingSpaceCount;
-  if (node.indent === null) {
+  if (node.indent === null || node.value === "") {
     const matches = content.match(/^(?<leadingSpace> *)[^\n\r ]/m);
     leadingSpaceCount = matches
       ? matches.groups.leadingSpace.length
@@ -269,7 +269,7 @@ function getBlockValueLineContents(
   });
 
   if (options.proseWrap === "never") {
-    lines = lines.map((words) => [words.join(" ")]);
+    lines = lines.map((words) => (words.length > 0 ? [words.join(" ")] : []));
   }
 
   return removeUnnecessaryTrailingNewlines(lines);

--- a/tests/format/markdown/yaml/prose-wrap-never/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/yaml/prose-wrap-never/__snapshots__/format.test.js.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`folded.md - {"proseWrap":"never"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown", "mdx"]
+proseWrap: "never"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+---
+description: >
+  first
+  second
+
+  another paragraph
+teaser: >-
+  first
+  second
+kept: >+
+  first
+  second
+
+title: Example
+---
+
+# Heading
+
+=====================================output=====================================
+---
+description: >
+  first second
+
+  another paragraph
+teaser: >-
+  first second
+kept: >+
+  first second
+
+title: Example
+---
+
+# Heading
+
+================================================================================
+`;

--- a/tests/format/markdown/yaml/prose-wrap-never/folded.md
+++ b/tests/format/markdown/yaml/prose-wrap-never/folded.md
@@ -1,0 +1,17 @@
+---
+description: >
+  first
+  second
+
+  another paragraph
+teaser: >-
+  first
+  second
+kept: >+
+  first
+  second
+
+title: Example
+---
+
+# Heading

--- a/tests/format/markdown/yaml/prose-wrap-never/format.test.js
+++ b/tests/format/markdown/yaml/prose-wrap-never/format.test.js
@@ -1,0 +1,1 @@
+runFormatTest(import.meta, ["markdown", "mdx"], { proseWrap: "never" });

--- a/tests/format/yaml/block-folded/prose-wrap-never/__snapshots__/format.test.js.snap
+++ b/tests/format/yaml/block-folded/prose-wrap-never/__snapshots__/format.test.js.snap
@@ -1,0 +1,117 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`folded.yml - {"proseWrap":"never"} format 1`] = `
+====================================options=====================================
+parsers: ["yaml"]
+proseWrap: "never"
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+clip: >
+  first
+  second
+
+  another paragraph
+next: value
+
+strip: >-
+  first
+  second
+next-strip: value
+
+keep: >+
+  first
+  second
+
+
+next-keep: value
+
+nested:
+  - value: >-
+      first
+      second
+    next: value
+  - >+
+    first
+
+    another paragraph
+
+  - last
+
+empty: >+
+
+
+next-empty: value
+
+literal: |-
+  first
+  second
+next-literal: value
+---
+>1
+ 
+ 
+---
+>2-
+     
+---
+|1
+ 
+ 
+---
+>+
+  last document
+
+
+=====================================output=====================================
+clip: >
+  first second
+
+  another paragraph
+next: value
+
+strip: >-
+  first second
+next-strip: value
+
+keep: >+
+  first second
+
+
+next-keep: value
+
+nested:
+  - value: >-
+      first second
+    next: value
+  - >+
+    first
+
+    another paragraph
+
+  - last
+
+empty: >+
+
+
+next-empty: value
+
+literal: |-
+  first
+  second
+next-literal: value
+---
+>1
+
+---
+>2-
+
+---
+|1
+
+---
+>+
+  last document
+
+
+================================================================================
+`;

--- a/tests/format/yaml/block-folded/prose-wrap-never/folded.yml
+++ b/tests/format/yaml/block-folded/prose-wrap-never/folded.yml
@@ -1,0 +1,55 @@
+clip: >
+  first
+  second
+
+  another paragraph
+next: value
+
+strip: >-
+  first
+  second
+next-strip: value
+
+keep: >+
+  first
+  second
+
+
+next-keep: value
+
+nested:
+  - value: >-
+      first
+      second
+    next: value
+  - >+
+    first
+
+    another paragraph
+
+  - last
+
+empty: >+
+
+
+next-empty: value
+
+literal: |-
+  first
+  second
+next-literal: value
+---
+>1
+ 
+ 
+---
+>2-
+     
+---
+|1
+ 
+ 
+---
+>+
+  last document
+

--- a/tests/format/yaml/block-folded/prose-wrap-never/format.test.js
+++ b/tests/format/yaml/block-folded/prose-wrap-never/format.test.js
@@ -1,0 +1,41 @@
+const snippets = [
+  {
+    name: "paragraphs before another mapping item (issue 10776)",
+    code: "key: >\n  first paragraph\n\n  second paragraph\nnext: value\n",
+    output: "key: >\n  first paragraph\n\n  second paragraph\nnext: value\n",
+  },
+  {
+    name: "strip chomping before another sequence item",
+    code: "- >-\n  first\n  second\n- next\n",
+    output: "- >-\n  first second\n- next\n",
+  },
+  {
+    name: "keep chomping at end of document",
+    code: ">+\n  first\n  second\n",
+    output: ">+\n  first second\n",
+  },
+  {
+    name: "empty scalar with keep chomping",
+    code: ">+\n\n",
+    output: ">+\n\n",
+  },
+  {
+    name: "trailing content spaces before another mapping item",
+    code: "key: >-\n  value  \nnext: value\n",
+    output: "key: >-\n  value  \nnext: value\n",
+  },
+  {
+    name: "empty scalar with explicit indentation",
+    code: ">1\n \n \n",
+    output: ">1\n",
+  },
+  {
+    name: "empty scalar with explicit indentation and strip chomping",
+    code: ">2-\n     \n",
+    output: ">2-\n",
+  },
+];
+
+runFormatTest({ importMeta: import.meta, snippets }, ["yaml"], {
+  proseWrap: "never",
+});


### PR DESCRIPTION
## Description

Fixes #10776. Related to #6031.

Preserve empty-line entries when joining folded YAML scalar words with `proseWrap: "never"`. Previously, these entries became nonempty arrays, so trailing-newline handling retained extra blank lines and could change the value of a scalar using keep chomping. The change also normalizes indentation-only content when the parsed scalar value is empty.

Added YAML and Markdown/MDX front matter regressions for paragraphs, mapping and sequence boundaries, empty scalars, explicit indentation and all chomping modes. With `FULL_TEST=1`, all 99 YAML/Markdown/MDX suites, 18,776 tests and 3,127 snapshots pass. ESLint, formatting and format-test lint pass; an additional 2,880-case matrix preserves YAML values and produces stable repeated output. No existing snapshots change.

AI-assisted implementation, independently reviewed by other coding agents. Review also verified compatibility with #20000 (18,822 combined tests pass). Existing comment, anchor, explicit-key and indentation edge defects remain outside this patch; the full #6031 report is not resolved.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
