### PR TITLE
Fix ASI protection for breaking experimental ternaries

### DIFF
--- a/changelog_unreleased/javascript/20009.md
+++ b/changelog_unreleased/javascript/20009.md
@@ -1,0 +1,32 @@
+#### Preserve ASI protection for breaking experimental ternaries (#20009 by @jakezwang)
+
+With `experimentalTernaries` enabled and `semi: false`, parentheses added around a long condition could make the preceding expression into a function call. Prettier now adds the required leading semicolon.
+
+<!-- prettier-ignore -->
+```jsx
+// Options: --no-semi --experimental-ternaries --print-width 40
+
+// Input
+before();
+firstCondition && secondCondition && thirdCondition ? yes() : no();
+
+// Prettier stable
+before()
+(
+  firstCondition &&
+  secondCondition &&
+  thirdCondition
+) ?
+  yes()
+: no()
+
+// Prettier main
+before()
+;(
+  firstCondition &&
+  secondCondition &&
+  thirdCondition
+) ?
+  yes()
+: no()
+```

--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -12,6 +12,7 @@ import { printDanglingComments } from "../../main/comments/print.js";
 import hasNewlineInRange from "../../utilities/has-newline-in-range.js";
 import { locEnd, locStart } from "../location/index.js";
 import needsParentheses from "../parentheses/needs-parentheses.js";
+import { shouldConditionalExpressionPrintLeadingSemicolon } from "../semicolon/semicolon.js";
 import { isBlockComment } from "../utilities/comment-types.js";
 import {
   CommentCheckFlags,
@@ -134,8 +135,8 @@ function shouldExtraIndentForConditionalExpression(path) {
   return parent[ancestorNameMap.get(parent.type)] === child;
 }
 
-const wrapInParens = (doc) => [
-  ifBreak("("),
+const wrapInParens = (doc, shouldPrintLeadingSemicolon = false) => [
+  ifBreak(shouldPrintLeadingSemicolon ? ";(" : "("),
   indent([softline, doc]),
   softline,
   ifBreak(")"),
@@ -297,7 +298,10 @@ function printTernary(path, options, print, args) {
 
   const printedTest = isConditionalExpression
     ? [
-        wrapInParens(print("test")),
+        wrapInParens(
+          print("test"),
+          shouldConditionalExpressionPrintLeadingSemicolon(path, options),
+        ),
         node.test.type === "ConditionalExpression" ? breakParent : "",
       ]
     : [

--- a/src/language-js/semicolon/semicolon.js
+++ b/src/language-js/semicolon/semicolon.js
@@ -7,11 +7,15 @@ import {
 import { isJsxElement } from "../utilities/node-types.js";
 
 function shouldExpressionStatementPrintLeadingSemicolon(path, options) {
-  if (options.semi) {
-    return false;
-  }
+  return (
+    !options.semi &&
+    isExpressionStatementInStatementList(path, options) &&
+    path.call(() => expressionNeedsAsiProtection(path, options), "expression")
+  );
+}
 
-  const { node } = path;
+function isExpressionStatementInStatementList(path, options) {
+  const { node, key, parent } = path;
 
   if (
     node.type !== "ExpressionStatement" ||
@@ -22,21 +26,27 @@ function shouldExpressionStatementPrintLeadingSemicolon(path, options) {
     return false;
   }
 
-  const { key, parent } = path;
-  if (
+  return (
     // `Program.directives` don't need leading semicolon
-    ((key === "body" &&
+    (key === "body" &&
       (parent.type === "Program" ||
         parent.type === "BlockStatement" ||
         parent.type === "StaticBlock" ||
         parent.type === "TSModuleBlock")) ||
-      (key === "consequent" && parent.type === "SwitchCase")) &&
-    path.call(() => expressionNeedsAsiProtection(path, options), "expression")
-  ) {
-    return true;
-  }
+    (key === "consequent" && parent.type === "SwitchCase")
+  );
+}
 
-  return false;
+function shouldConditionalExpressionPrintLeadingSemicolon(path, options) {
+  return (
+    !options.semi &&
+    path.parent.type === "ExpressionStatement" &&
+    path.callParent(
+      () =>
+        isExpressionStatementInStatementList(path, options) &&
+        !shouldExpressionStatementPrintLeadingSemicolon(path, options),
+    )
+  );
 }
 
 function expressionNeedsAsiProtection(path, options) {
@@ -131,5 +141,6 @@ export {
   isSingleHtmlEventHandlerExpressionStatement,
   isSingleJsxExpressionStatementInMarkdown,
   isSingleVueEventBindingExpressionStatement,
+  shouldConditionalExpressionPrintLeadingSemicolon,
   shouldExpressionStatementPrintLeadingSemicolon,
 };

--- a/tests/format/js/conditional-expression/asi-protection/__snapshots__/format.test.js.snap
+++ b/tests/format/js/conditional-expression/asi-protection/__snapshots__/format.test.js.snap
@@ -1,0 +1,497 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`conditional.js - {"experimentalTernaries":true,"printWidth":40,"semi":false} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 40
+semi: false
+                        printWidth: 40 |
+=====================================input======================================
+before();
+firstCondition && secondCondition && thirdCondition ? yes() : no();
+
+before();
+condition ? yes() : no();
+
+before();
+condition ? veryLongConsequent() : veryLongAlternate();
+
+before();
+(firstCondition, secondCondition, thirdCondition) ? yes() : no();
+
+before();
+[firstCondition, secondCondition, thirdCondition] ? yes() : no();
+
+before();
+(firstCondition && secondCondition && thirdCondition ? yes() : no()), after();
+
+before();
+first(), (firstCondition && secondCondition && thirdCondition ? yes() : no());
+
+before();
+(firstCondition && secondCondition && thirdCondition ? yes() : no()) ? yes() : no();
+
+before();
+condition ? yes() : firstCondition && secondCondition && thirdCondition ? yes() : no();
+
+before();
+// Leading comment
+firstCondition && secondCondition && thirdCondition ? yes() : no();
+
+=====================================output=====================================
+before()
+;(
+  firstCondition &&
+  secondCondition &&
+  thirdCondition
+) ?
+  yes()
+: no()
+
+before()
+condition ? yes() : no()
+
+before()
+condition ?
+  veryLongConsequent()
+: veryLongAlternate()
+
+before()
+;(
+  (firstCondition,
+  secondCondition,
+  thirdCondition)
+) ?
+  yes()
+: no()
+
+before()
+;(
+  [
+    firstCondition,
+    secondCondition,
+    thirdCondition,
+  ]
+) ?
+  yes()
+: no()
+
+before()
+;((
+  firstCondition &&
+  secondCondition &&
+  thirdCondition
+) ?
+  yes()
+: no(),
+  after())
+
+before()
+;(first(),
+  (
+    firstCondition &&
+    secondCondition &&
+    thirdCondition
+  ) ?
+    yes()
+  : no())
+
+before()
+;(
+  (
+    firstCondition &&
+    secondCondition &&
+    thirdCondition
+  ) ?
+    yes()
+  : no()
+) ?
+  yes()
+: no()
+
+before()
+condition ? yes()
+: (
+  firstCondition &&
+  secondCondition &&
+  thirdCondition
+) ?
+  yes()
+: no()
+
+before()
+// Leading comment
+;(
+  firstCondition &&
+  secondCondition &&
+  thirdCondition
+) ?
+  yes()
+: no()
+
+================================================================================
+`;
+
+exports[`conditional.js - {"experimentalTernaries":true,"printWidth":40,"semi":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 40
+semi: true
+                        printWidth: 40 |
+=====================================input======================================
+before();
+firstCondition && secondCondition && thirdCondition ? yes() : no();
+
+before();
+condition ? yes() : no();
+
+before();
+condition ? veryLongConsequent() : veryLongAlternate();
+
+before();
+(firstCondition, secondCondition, thirdCondition) ? yes() : no();
+
+before();
+[firstCondition, secondCondition, thirdCondition] ? yes() : no();
+
+before();
+(firstCondition && secondCondition && thirdCondition ? yes() : no()), after();
+
+before();
+first(), (firstCondition && secondCondition && thirdCondition ? yes() : no());
+
+before();
+(firstCondition && secondCondition && thirdCondition ? yes() : no()) ? yes() : no();
+
+before();
+condition ? yes() : firstCondition && secondCondition && thirdCondition ? yes() : no();
+
+before();
+// Leading comment
+firstCondition && secondCondition && thirdCondition ? yes() : no();
+
+=====================================output=====================================
+before();
+(
+  firstCondition &&
+  secondCondition &&
+  thirdCondition
+) ?
+  yes()
+: no();
+
+before();
+condition ? yes() : no();
+
+before();
+condition ?
+  veryLongConsequent()
+: veryLongAlternate();
+
+before();
+(
+  (firstCondition,
+  secondCondition,
+  thirdCondition)
+) ?
+  yes()
+: no();
+
+before();
+(
+  [
+    firstCondition,
+    secondCondition,
+    thirdCondition,
+  ]
+) ?
+  yes()
+: no();
+
+before();
+((
+  firstCondition &&
+  secondCondition &&
+  thirdCondition
+) ?
+  yes()
+: no(),
+  after());
+
+before();
+(first(),
+  (
+    firstCondition &&
+    secondCondition &&
+    thirdCondition
+  ) ?
+    yes()
+  : no());
+
+before();
+(
+  (
+    firstCondition &&
+    secondCondition &&
+    thirdCondition
+  ) ?
+    yes()
+  : no()
+) ?
+  yes()
+: no();
+
+before();
+condition ? yes()
+: (
+  firstCondition &&
+  secondCondition &&
+  thirdCondition
+) ?
+  yes()
+: no();
+
+before();
+// Leading comment
+(
+  firstCondition &&
+  secondCondition &&
+  thirdCondition
+) ?
+  yes()
+: no();
+
+================================================================================
+`;
+
+exports[`statements.js - {"experimentalTernaries":true,"printWidth":40,"semi":false} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 40
+semi: false
+                        printWidth: 40 |
+=====================================input======================================
+function foo() {
+  before();
+  firstCondition && secondCondition && thirdCondition ? yes() : no();
+}
+
+switch (condition) {
+  case 1:
+    before();
+    firstCondition && secondCondition && thirdCondition ? yes() : no();
+}
+
+class Foo {
+  static {
+    before();
+    firstCondition && secondCondition && thirdCondition ? yes() : no();
+  }
+}
+
+if (condition)
+  firstCondition && secondCondition && thirdCondition ? yes() : no();
+
+while (condition)
+  firstCondition && secondCondition && thirdCondition ? yes() : no();
+
+do
+  firstCondition && secondCondition && thirdCondition ? yes() : no();
+while (condition);
+
+label:
+  firstCondition && secondCondition && thirdCondition ? yes() : no();
+
+=====================================output=====================================
+function foo() {
+  before()
+  ;(
+    firstCondition &&
+    secondCondition &&
+    thirdCondition
+  ) ?
+    yes()
+  : no()
+}
+
+switch (condition) {
+  case 1:
+    before()
+    ;(
+      firstCondition &&
+      secondCondition &&
+      thirdCondition
+    ) ?
+      yes()
+    : no()
+}
+
+class Foo {
+  static {
+    before()
+    ;(
+      firstCondition &&
+      secondCondition &&
+      thirdCondition
+    ) ?
+      yes()
+    : no()
+  }
+}
+
+if (condition)
+  (
+    firstCondition &&
+    secondCondition &&
+    thirdCondition
+  ) ?
+    yes()
+  : no()
+
+while (condition)
+  (
+    firstCondition &&
+    secondCondition &&
+    thirdCondition
+  ) ?
+    yes()
+  : no()
+
+do
+  (
+    firstCondition &&
+    secondCondition &&
+    thirdCondition
+  ) ?
+    yes()
+  : no()
+while (condition)
+
+label: (
+  firstCondition &&
+  secondCondition &&
+  thirdCondition
+) ?
+  yes()
+: no()
+
+================================================================================
+`;
+
+exports[`statements.js - {"experimentalTernaries":true,"printWidth":40,"semi":true} format 1`] = `
+====================================options=====================================
+experimentalTernaries: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 40
+semi: true
+                        printWidth: 40 |
+=====================================input======================================
+function foo() {
+  before();
+  firstCondition && secondCondition && thirdCondition ? yes() : no();
+}
+
+switch (condition) {
+  case 1:
+    before();
+    firstCondition && secondCondition && thirdCondition ? yes() : no();
+}
+
+class Foo {
+  static {
+    before();
+    firstCondition && secondCondition && thirdCondition ? yes() : no();
+  }
+}
+
+if (condition)
+  firstCondition && secondCondition && thirdCondition ? yes() : no();
+
+while (condition)
+  firstCondition && secondCondition && thirdCondition ? yes() : no();
+
+do
+  firstCondition && secondCondition && thirdCondition ? yes() : no();
+while (condition);
+
+label:
+  firstCondition && secondCondition && thirdCondition ? yes() : no();
+
+=====================================output=====================================
+function foo() {
+  before();
+  (
+    firstCondition &&
+    secondCondition &&
+    thirdCondition
+  ) ?
+    yes()
+  : no();
+}
+
+switch (condition) {
+  case 1:
+    before();
+    (
+      firstCondition &&
+      secondCondition &&
+      thirdCondition
+    ) ?
+      yes()
+    : no();
+}
+
+class Foo {
+  static {
+    before();
+    (
+      firstCondition &&
+      secondCondition &&
+      thirdCondition
+    ) ?
+      yes()
+    : no();
+  }
+}
+
+if (condition)
+  (
+    firstCondition &&
+    secondCondition &&
+    thirdCondition
+  ) ?
+    yes()
+  : no();
+
+while (condition)
+  (
+    firstCondition &&
+    secondCondition &&
+    thirdCondition
+  ) ?
+    yes()
+  : no();
+
+do
+  (
+    firstCondition &&
+    secondCondition &&
+    thirdCondition
+  ) ?
+    yes()
+  : no();
+while (condition);
+
+label: (
+  firstCondition &&
+  secondCondition &&
+  thirdCondition
+) ?
+  yes()
+: no();
+
+================================================================================
+`;

--- a/tests/format/js/conditional-expression/asi-protection/conditional.js
+++ b/tests/format/js/conditional-expression/asi-protection/conditional.js
@@ -1,0 +1,30 @@
+before();
+firstCondition && secondCondition && thirdCondition ? yes() : no();
+
+before();
+condition ? yes() : no();
+
+before();
+condition ? veryLongConsequent() : veryLongAlternate();
+
+before();
+(firstCondition, secondCondition, thirdCondition) ? yes() : no();
+
+before();
+[firstCondition, secondCondition, thirdCondition] ? yes() : no();
+
+before();
+(firstCondition && secondCondition && thirdCondition ? yes() : no()), after();
+
+before();
+first(), (firstCondition && secondCondition && thirdCondition ? yes() : no());
+
+before();
+(firstCondition && secondCondition && thirdCondition ? yes() : no()) ? yes() : no();
+
+before();
+condition ? yes() : firstCondition && secondCondition && thirdCondition ? yes() : no();
+
+before();
+// Leading comment
+firstCondition && secondCondition && thirdCondition ? yes() : no();

--- a/tests/format/js/conditional-expression/asi-protection/format.test.js
+++ b/tests/format/js/conditional-expression/asi-protection/format.test.js
@@ -1,0 +1,7 @@
+for (const semi of [false, true]) {
+  runFormatTest(import.meta, ["babel", "flow", "typescript"], {
+    experimentalTernaries: true,
+    printWidth: 40,
+    semi,
+  });
+}

--- a/tests/format/js/conditional-expression/asi-protection/statements.js
+++ b/tests/format/js/conditional-expression/asi-protection/statements.js
@@ -1,0 +1,30 @@
+function foo() {
+  before();
+  firstCondition && secondCondition && thirdCondition ? yes() : no();
+}
+
+switch (condition) {
+  case 1:
+    before();
+    firstCondition && secondCondition && thirdCondition ? yes() : no();
+}
+
+class Foo {
+  static {
+    before();
+    firstCondition && secondCondition && thirdCondition ? yes() : no();
+  }
+}
+
+if (condition)
+  firstCondition && secondCondition && thirdCondition ? yes() : no();
+
+while (condition)
+  firstCondition && secondCondition && thirdCondition ? yes() : no();
+
+do
+  firstCondition && secondCondition && thirdCondition ? yes() : no();
+while (condition);
+
+label:
+  firstCondition && secondCondition && thirdCondition ? yes() : no();


### PR DESCRIPTION
## Description

Fixes #18965.

Print the leading semicolon with the parentheses added around a breaking ternary condition when `semi: false`. Reuse the existing statement and ASI checks so short conditions, already-protected expressions, and unbraced control-flow bodies keep their current output.

Validation: the full suite passed (35,703 tests, 13,509 snapshots), along with typecheck and lint. Targeted `FULL_TEST=1` suites passed 2,047 tests, including AST equivalence and idempotence. The new fixture fails 30 checks without the fix.

Codex implemented and independently reviewed the change; the results above are from local automated checks.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
