### PR TITLE
docs(plugins): fix duplicated startIndex in hasNewlineInRange signature

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -638,7 +638,7 @@ function hasNewline(
 function hasNewlineInRange(
   text: string,
   startIndex: number,
-  startIndex: number,
+  endIndex: number,
 ): boolean;
 
 function hasSpaces(


### PR DESCRIPTION
The plugins doc's `hasNewlineInRange` type listed `startIndex` twice; the real function is `(text, startIndex, endIndex)`. Docs-only, one line. (Submitted per the AI usage policy — happy to explain every line.)