### PR TITLE
docs: fix an orphaned JSDoc block and a Hackly typo

### DIFF
--- a/src/language-js/print/angular.js
+++ b/src/language-js/print/angular.js
@@ -107,8 +107,8 @@ const hasSideEffect = createTypeCheckFunction([
   "OptionalCallExpression",
   "AssignmentExpression",
 ]);
-/** identify if an angular expression seems to have side effects */
 /**
+ * Identify if an angular expression seems to have side effects.
  * @param {AstPath} path
  * @returns {boolean}
  */

--- a/src/language-markdown/parse/micromark/mdast-util-gfm.js
+++ b/src/language-markdown/parse/micromark/mdast-util-gfm.js
@@ -1,5 +1,5 @@
 // There is no way to disable autolink
-// Hackly find and replace `gfm-autolink-literal`
+// Hacky find and replace `gfm-autolink-literal`
 // https://github.com/remarkjs/remark-gfm/issues/16#issuecomment-899046315
 
 import { gfmFromMarkdown as originalGfmFromMarkdown } from "mdast-util-gfm";


### PR DESCRIPTION
- `src/language-js/print/angular.js`: two stacked comment blocks above `hasNgSideEffect` — the one-line description was dead (the second block wins); merged into a single well-formed JSDoc
- `src/language-markdown/parse/micromark/mdast-util-gfm.js`: "**Hackly** find and replace" → "Hacky"

Comments only.