### PR TITLE
fix(no-semi): correct identification of in/instanceof identifiers

### DIFF
--- a/changelog_unreleased/javascript/20019.md
+++ b/changelog_unreleased/javascript/20019.md
@@ -1,0 +1,30 @@
+#### Avoid unnecessary semicolons before private members named `#in` or `#instanceof` (#20019 by @cellison-figma)
+
+With `semi: false`, Prettier incorrectly added a semicolon before private fields and methods named `#in` or `#instanceof` when using parsers such as `oxc`, `typescript`, and `flow`. These private names were mistaken for the `in` and `instanceof` operators. The fix preserves necessary semicolons before public members with those names.
+
+<!-- prettier-ignore -->
+```js
+// Input
+class Graph {
+  #nodes = {};
+  #in = {};
+  value = {};
+  #instanceof() {}
+}
+
+// Prettier stable (--parser oxc --no-semi)
+class Graph {
+  #nodes = {};
+  #in = {}
+  value = {};
+  #instanceof() {}
+}
+
+// Prettier main (--parser oxc --no-semi)
+class Graph {
+  #nodes = {}
+  #in = {}
+  value = {}
+  #instanceof() {}
+}
+```

--- a/changelog_unreleased/javascript/20019.md
+++ b/changelog_unreleased/javascript/20019.md
@@ -1,30 +1,22 @@
 #### Avoid unnecessary semicolons before private members named `#in` or `#instanceof` (#20019 by @cellison-figma)
 
-With `semi: false`, Prettier incorrectly added a semicolon before private fields and methods named `#in` or `#instanceof` when using parsers such as `oxc`, `typescript`, and `flow`. These private names were mistaken for the `in` and `instanceof` operators. The fix preserves necessary semicolons before public members with those names.
-
 <!-- prettier-ignore -->
 ```js
 // Input
 class Graph {
   #nodes = {};
   #in = {};
-  value = {};
-  #instanceof() {}
 }
 
 // Prettier stable (--parser oxc --no-semi)
 class Graph {
   #nodes = {};
   #in = {}
-  value = {};
-  #instanceof() {}
 }
 
 // Prettier main (--parser oxc --no-semi)
 class Graph {
   #nodes = {}
   #in = {}
-  value = {}
-  #instanceof() {}
 }
 ```

--- a/src/language-js/print/class-body.js
+++ b/src/language-js/print/class-body.js
@@ -256,8 +256,8 @@ function shouldPrintSemicolonAfterClassProperty(
     return false;
   }
 
-  if (!nextNode.computed) {
-    const name = nextNode.key?.name;
+  if (!nextNode.computed && nextNode.key?.type === "Identifier") {
+    const name = nextNode.key.name;
     if (name === "in" || name === "instanceof") {
       return true;
     }

--- a/src/language-js/print/class-body.js
+++ b/src/language-js/print/class-body.js
@@ -257,7 +257,7 @@ function shouldPrintSemicolonAfterClassProperty(
   }
 
   if (!nextNode.computed && nextNode.key?.type === "Identifier") {
-    const name = nextNode.key.name;
+    const { name } = nextNode.key;
     if (name === "in" || name === "instanceof") {
       return true;
     }

--- a/tests/format/js/no-semi/__snapshots__/format.test.js.snap
+++ b/tests/format/js/no-semi/__snapshots__/format.test.js.snap
@@ -2104,10 +2104,38 @@ class C {
   ["method"]() {}
 }
 
+class PrivateKeywordFields {
+  a = {};
+  #in = {};
+  b = {};
+  #instanceof = {};
+}
+
+class PrivateKeywordMethods {
+  a = {};
+  #in() {}
+  b = {};
+  #instanceof() {}
+}
+
 =====================================output=====================================
 class C {
   #field = "value";
   ["method"]() {}
+}
+
+class PrivateKeywordFields {
+  a = {}
+  #in = {}
+  b = {}
+  #instanceof = {}
+}
+
+class PrivateKeywordMethods {
+  a = {}
+  #in() {}
+  b = {}
+  #instanceof() {}
 }
 
 ================================================================================
@@ -2123,10 +2151,38 @@ class C {
   ["method"]() {}
 }
 
+class PrivateKeywordFields {
+  a = {};
+  #in = {};
+  b = {};
+  #instanceof = {};
+}
+
+class PrivateKeywordMethods {
+  a = {};
+  #in() {}
+  b = {};
+  #instanceof() {}
+}
+
 =====================================output=====================================
 class C {
   #field = "value";
   ["method"]() {}
+}
+
+class PrivateKeywordFields {
+  a = {};
+  #in = {};
+  b = {};
+  #instanceof = {};
+}
+
+class PrivateKeywordMethods {
+  a = {};
+  #in() {}
+  b = {};
+  #instanceof() {}
 }
 
 ================================================================================

--- a/tests/format/js/no-semi/__snapshots__/format.test.js.snap
+++ b/tests/format/js/no-semi/__snapshots__/format.test.js.snap
@@ -2111,13 +2111,6 @@ class PrivateKeywordFields {
   #instanceof = {};
 }
 
-class PrivateKeywordMethods {
-  a = {};
-  #in() {}
-  b = {};
-  #instanceof() {}
-}
-
 =====================================output=====================================
 class C {
   #field = "value";
@@ -2129,13 +2122,6 @@ class PrivateKeywordFields {
   #in = {}
   b = {}
   #instanceof = {}
-}
-
-class PrivateKeywordMethods {
-  a = {}
-  #in() {}
-  b = {}
-  #instanceof() {}
 }
 
 ================================================================================
@@ -2158,13 +2144,6 @@ class PrivateKeywordFields {
   #instanceof = {};
 }
 
-class PrivateKeywordMethods {
-  a = {};
-  #in() {}
-  b = {};
-  #instanceof() {}
-}
-
 =====================================output=====================================
 class C {
   #field = "value";
@@ -2176,13 +2155,6 @@ class PrivateKeywordFields {
   #in = {};
   b = {};
   #instanceof = {};
-}
-
-class PrivateKeywordMethods {
-  a = {};
-  #in() {}
-  b = {};
-  #instanceof() {}
 }
 
 ================================================================================

--- a/tests/format/js/no-semi/private-field.js
+++ b/tests/format/js/no-semi/private-field.js
@@ -2,3 +2,17 @@ class C {
   #field = 'value';
   ["method"]() {}
 }
+
+class PrivateKeywordFields {
+  a = {};
+  #in = {};
+  b = {};
+  #instanceof = {};
+}
+
+class PrivateKeywordMethods {
+  a = {};
+  #in() {}
+  b = {};
+  #instanceof() {}
+}

--- a/tests/format/js/no-semi/private-field.js
+++ b/tests/format/js/no-semi/private-field.js
@@ -9,10 +9,3 @@ class PrivateKeywordFields {
   b = {};
   #instanceof = {};
 }
-
-class PrivateKeywordMethods {
-  a = {};
-  #in() {}
-  b = {};
-  #instanceof() {}
-}


### PR DESCRIPTION
## Description

Fixes unnecessary semicolons before private class fields and methods named `#in` or `#instanceof` when `semi: false`.

The default Bazel parser and the OXC parser represent private class fields differently, which changes the outcome of the logic used in that semicolon determination. Prettier checks `nextNode.key?.name`, which, in the case below, resolved to `undefined` with the Bazel parser and `'in'` with the OXC parser. This causes the semi determination to be based (for OXC) on the private identifier. 

```
class MyClass {
  #nodes = {}
  #in = {}
}

// Babel: #in
key: {
  type: "PrivateName",
  id: { type: "Identifier", name: "in" }
}

// Oxc: #in
key: {
  type: "PrivateIdentifier",
  name: "in"
}
```

Adding an additional guard to check that the type of the node is `Identifier` excludes private names & preserved necessary semicolons.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [-] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [-] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
