### PR TITLE
docs: add pnpm guidance for pre-commit / lint-staged setup

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -14,9 +14,44 @@ You can use Prettier with a pre-commit tool. This can re-format your files that 
 
 _Make sure Prettier is installed and is in your [`devDependencies`](https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file) before you proceed._
 
+<Tabs groupId="package-manager">
+<TabItem value="npm">
+
 ```bash
 npx mrm@2 lint-staged
 ```
+
+</TabItem>
+<TabItem value="yarn">
+
+```bash
+npx mrm@2 lint-staged
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add --save-dev husky lint-staged
+npx mrm@2 lint-staged
+```
+
+</TabItem>
+<TabItem value="bun">
+
+```bash
+npx mrm@2 lint-staged
+```
+
+</TabItem>
+<TabItem value="deno">
+
+```bash
+npx mrm@2 lint-staged
+```
+
+</TabItem>
+</Tabs>
 
 This will install [husky](https://github.com/typicode/husky) and [lint-staged](https://github.com/okonet/lint-staged), then add a configuration to the project’s `package.json` that will automatically format supported files in a pre-commit hook.
 

--- a/website/versioned_docs/version-stable/precommit.md
+++ b/website/versioned_docs/version-stable/precommit.md
@@ -14,9 +14,44 @@ You can use Prettier with a pre-commit tool. This can re-format your files that 
 
 _Make sure Prettier is installed and is in your [`devDependencies`](https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file) before you proceed._
 
+<Tabs groupId="package-manager">
+<TabItem value="npm">
+
 ```bash
 npx mrm@2 lint-staged
 ```
+
+</TabItem>
+<TabItem value="yarn">
+
+```bash
+npx mrm@2 lint-staged
+```
+
+</TabItem>
+<TabItem value="pnpm">
+
+```bash
+pnpm add --save-dev husky lint-staged
+npx mrm@2 lint-staged
+```
+
+</TabItem>
+<TabItem value="bun">
+
+```bash
+npx mrm@2 lint-staged
+```
+
+</TabItem>
+<TabItem value="deno">
+
+```bash
+npx mrm@2 lint-staged
+```
+
+</TabItem>
+</Tabs>
 
 This will install [husky](https://github.com/typicode/husky) and [lint-staged](https://github.com/okonet/lint-staged), then add a configuration to the project’s `package.json` that will automatically format supported files in a pre-commit hook.
 


### PR DESCRIPTION
Fixes #14405.

`npx mrm@2 lint-staged` does not detect pnpm, so running it in a pnpm project fails unless `husky` and `lint-staged` are already installed.

This adds package-manager tabs to the lint-staged section in the pre-commit docs. The pnpm tab installs both packages first, then runs `npx mrm@2 lint-staged`. The pnpm install command matches the existing guidance in `docs/install.md`.