### PR TITLE
use native `import.meta.dirname` and `import.meta.filename`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,8 @@
 import path from "node:path";
-import createEsmUtils from "esm-utils";
 import installBrowser from "./tests/config/install-browser.js";
 import installPrettier from "./tests/config/install-prettier.js";
 
-const { dirname: PROJECT_ROOT } = createEsmUtils(import.meta);
+const PROJECT_ROOT = import.meta.dirname;
 const isProduction = process.env.NODE_ENV === "production";
 const ENABLE_CODE_COVERAGE = Boolean(process.env.ENABLE_CODE_COVERAGE);
 const TEST_STANDALONE = Boolean(process.env.TEST_STANDALONE);

--- a/tests/config/format-test/constants.js
+++ b/tests/config/format-test/constants.js
@@ -1,8 +1,7 @@
 import path from "node:path";
-import createEsmUtils from "esm-utils";
 import { normalizeDirectory } from "./utilities.js";
 
-const { __dirname } = createEsmUtils(import.meta);
+const __dirname = import.meta.dirname;
 
 export const FORMAT_TEST_SCRIPT_FILENAME = "format.test.js";
 

--- a/tests/config/format-test/verify-fixtures.js
+++ b/tests/config/format-test/verify-fixtures.js
@@ -1,9 +1,8 @@
 import path from "node:path";
-import createEsmUtils from "esm-utils";
 import { outdent } from "outdent";
 import { FORMAT_TEST_DIRECTORY, FULL_TEST } from "./constants.js";
 
-const { __filename } = createEsmUtils(import.meta);
+const __filename = import.meta.filename;
 
 const getCategory = (dirname) =>
   path.relative(FORMAT_TEST_DIRECTORY, dirname).split(path.sep).shift();

--- a/tests/integration/__tests__/file-info.js
+++ b/tests/integration/__tests__/file-info.js
@@ -1,11 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import url from "node:url";
-import createEsmUtils from "esm-utils";
 import { temporaryDirectory as getTemporaryDirectory } from "tempy";
 import prettier from "../../config/prettier-entry.js";
 
-const { __dirname } = createEsmUtils(import.meta);
+const __dirname = import.meta.dirname;
 
 describe("extracts file-info for a js file", () => {
   runCli("cli/", ["--file-info", "something.js"]).test({

--- a/tests/integration/__tests__/ignore-absolute-path.js
+++ b/tests/integration/__tests__/ignore-absolute-path.js
@@ -1,6 +1,6 @@
 import path from "node:path";
-import createEsmUtils from "esm-utils";
-const { __dirname } = createEsmUtils(import.meta);
+
+const __dirname = import.meta.dirname;
 
 describe("support absolute filename", () => {
   runCli("cli/ignore-absolute-path", [

--- a/tests/integration/__tests__/invalid-ignore.js
+++ b/tests/integration/__tests__/invalid-ignore.js
@@ -1,8 +1,7 @@
 import path from "node:path";
-import createEsmUtils from "esm-utils";
 import prettier from "../../config/prettier-entry.js";
 
-const { __dirname } = createEsmUtils(import.meta);
+const __dirname = import.meta.dirname;
 
 describe("throw error with invalid ignore", () => {
   runCli("cli/invalid-ignore", ["something.js"]).test({

--- a/tests/integration/__tests__/patterns-dirs.js
+++ b/tests/integration/__tests__/patterns-dirs.js
@@ -1,10 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
-import createEsmUtils from "esm-utils";
 import { projectRoot } from "../env.js";
 import jestPathSerializer from "../path-serializer.js";
 
-const { __dirname } = createEsmUtils(import.meta);
+const __dirname = import.meta.dirname;
 
 expect.addSnapshotSerializer(jestPathSerializer);
 

--- a/tests/integration/env.js
+++ b/tests/integration/env.js
@@ -1,7 +1,8 @@
 import path from "node:path";
 import createEsmUtils from "esm-utils";
 
-const { __dirname, require } = createEsmUtils(import.meta);
+const __dirname = import.meta.dirname;
+const { require } = createEsmUtils(import.meta);
 
 const isProduction = process.env.NODE_ENV === "production";
 const { PRETTIER_DIR } = process.env;


### PR DESCRIPTION
<!--
⚠️ Pull requests that do not follow the template may be closed without review.
-->

## Description

`node: >=22` has a native access to the current `dirname` and `filename`, this will save some unnecessary imports during testing.

If the CI tests on older versions of `node`, I'll close this PR 
<!-- Please provide a brief summary of your changes -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [X] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.
