### PR TITLE
Preserve comment order in test calls

### DIFF
--- a/changelog_unreleased/javascript/20043.md
+++ b/changelog_unreleased/javascript/20043.md
@@ -1,7 +1,5 @@
 #### Preserve comments in test calls (#20043 by @lllleolin-max)
 
-Comments between test-call arguments keep their original order, and formatting the output again no longer changes it. This also applies to TypeScript and Flow.
-
 <!-- prettier-ignore -->
 ```jsx
 // Input

--- a/changelog_unreleased/javascript/20043.md
+++ b/changelog_unreleased/javascript/20043.md
@@ -1,4 +1,4 @@
-#### Preserve comments in test calls (#20043 by @lllleolin-max)
+#### Preserve comment order in test calls (#20043 by @lllleolin-max)
 
 <!-- prettier-ignore -->
 ```jsx

--- a/changelog_unreleased/javascript/20043.md
+++ b/changelog_unreleased/javascript/20043.md
@@ -1,0 +1,32 @@
+#### Preserve comments in test calls (#20043 by @lllleolin-max)
+
+Comments between test-call arguments keep their original order, and formatting the output again no longer changes it. This also applies to TypeScript and Flow.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+test("x", () => {
+  run();
+}, // first
+// second
+// third
+60000);
+
+// Prettier stable
+test("x", () => {
+  run();
+}, // second // first
+// third
+60000);
+
+// Prettier main
+test(
+  "x",
+  () => {
+    run();
+  }, // first
+  // second
+  // third
+  60000,
+);
+```

--- a/src/language-js/print/call-expression.js
+++ b/src/language-js/print/call-expression.js
@@ -48,7 +48,7 @@ function printCallExpression(path, options, print) {
     isCommonsJsOrAmdModuleDefinition(path) ||
     // Keep test declarations on a single line
     // e.g. `it('long name', () => {`
-    isTestCall(node, path.parent)
+    (isTestCall(node, path.parent) && args.every((arg) => !hasComment(arg)))
   ) {
     const printed = [];
     iterateCallArgumentsPath(path, () => {

--- a/src/language-js/print/call-expression.js
+++ b/src/language-js/print/call-expression.js
@@ -48,7 +48,7 @@ function printCallExpression(path, options, print) {
     isCommonsJsOrAmdModuleDefinition(path) ||
     // Keep test declarations on a single line
     // e.g. `it('long name', () => {`
-    (isTestCall(node, path.parent) && args.every((arg) => !hasComment(arg)))
+    isTestCall(node, path.parent)
   ) {
     const printed = [];
     iterateCallArgumentsPath(path, () => {

--- a/src/language-js/utilities/test-libraries.js
+++ b/src/language-js/utilities/test-libraries.js
@@ -1,4 +1,5 @@
 import { getCallArguments } from "./call-arguments.js";
+import { hasComment } from "./comments.js";
 import { getFunctionParameters } from "./function-parameters.js";
 import { isNodeMatches } from "./is-node-matches.js";
 import {
@@ -103,6 +104,10 @@ function isTestCall(node, parent) {
   }
 
   const args = getCallArguments(node);
+
+  if (args.some((arg) => hasComment(arg))) {
+    return false;
+  }
 
   if (args.length === 1) {
     if (isAngularTestWrapper(node) && isTestCall(parent)) {

--- a/tests/format/js/test-declarations/__snapshots__/format.test.js.snap
+++ b/tests/format/js/test-declarations/__snapshots__/format.test.js.snap
@@ -534,6 +534,151 @@ function x() {
 ================================================================================
 `;
 
+exports[`comments.js - {"arrowParens":"avoid"} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+test("comments after callback", () => {
+  run();
+}, // first
+// second
+// third
+60000);
+
+it("comments before timeout", function (done) {
+  done();
+},
+// first
+// second
+60000);
+
+describe.only("comments after callback", () => {
+  run();
+}, // first
+// second
+60000);
+
+test("comments before callback", // first
+// second
+() => {
+  run();
+});
+
+=====================================output=====================================
+test(
+  "comments after callback",
+  () => {
+    run();
+  }, // first
+  // second
+  // third
+  60000,
+);
+
+it(
+  "comments before timeout",
+  function (done) {
+    done();
+  },
+  // first
+  // second
+  60000,
+);
+
+describe.only(
+  "comments after callback",
+  () => {
+    run();
+  }, // first
+  // second
+  60000,
+);
+
+test(
+  "comments before callback", // first
+  // second
+  () => {
+    run();
+  },
+);
+
+================================================================================
+`;
+
+exports[`comments.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+test("comments after callback", () => {
+  run();
+}, // first
+// second
+// third
+60000);
+
+it("comments before timeout", function (done) {
+  done();
+},
+// first
+// second
+60000);
+
+describe.only("comments after callback", () => {
+  run();
+}, // first
+// second
+60000);
+
+test("comments before callback", // first
+// second
+() => {
+  run();
+});
+
+=====================================output=====================================
+test(
+  "comments after callback",
+  () => {
+    run();
+  }, // first
+  // second
+  // third
+  60000,
+);
+
+it(
+  "comments before timeout",
+  function (done) {
+    done();
+  },
+  // first
+  // second
+  60000,
+);
+
+describe.only(
+  "comments after callback",
+  () => {
+    run();
+  }, // first
+  // second
+  60000,
+);
+
+test(
+  "comments before callback", // first
+  // second
+  () => {
+    run();
+  },
+);
+
+================================================================================
+`;
+
 exports[`jest-each.js - {"arrowParens":"avoid"} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"

--- a/tests/format/js/test-declarations/comments.js
+++ b/tests/format/js/test-declarations/comments.js
@@ -1,0 +1,25 @@
+test("comments after callback", () => {
+  run();
+}, // first
+// second
+// third
+60000);
+
+it("comments before timeout", function (done) {
+  done();
+},
+// first
+// second
+60000);
+
+describe.only("comments after callback", () => {
+  run();
+}, // first
+// second
+60000);
+
+test("comments before callback", // first
+// second
+() => {
+  run();
+});


### PR DESCRIPTION
## Description

Fixes #20029.

Use the normal argument printer for test calls whose arguments have attached comments. The compact test-call path joins argument documents with literal spaces, which can move a pending trailing line comment after the next argument's leading comments. This reverses and merges comments and makes repeated formatting change the output again.

Calls without argument comments retain their existing compact layout. Regression fixtures cover comments after callbacks and before timeout arguments in `test`, `it`, and `describe.only`, plus comments between a test title and its callback.

Validation:

- Reproduced the reordered comments and non-idempotent output on the unchanged source.
- Confirmed preserved comment order and idempotent output with Babel, TypeScript, and Flow after the fix.
- `FULL_TEST=1` test-declarations suite: 540 tests passed; all 16 existing snapshots unchanged and 2 new snapshots added.
- `FULL_TEST=1` comments and function-comments suites: 4,366 tests and 156 existing snapshots passed across 14 suites.
- ESLint, Prettier, and `git diff --check` passed for the source change.

These checks cover 4,906 passing tests. The source change and generated snapshots were reviewed by Codex agents, and the reproduction and tests were run locally. Automated/agent review is complete; no independent human review is claimed.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory). — Not applicable: no API or CLI changes.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.
