### PR TITLE
Fix Angular `ngIf` microsyntax colon formatting

### DIFF
--- a/changelog_unreleased/angular/20051.md
+++ b/changelog_unreleased/angular/20051.md
@@ -1,0 +1,13 @@
+#### Preserve Angular `ngIf` microsyntax keywords after `let` declarations (#20051 by @splincode)
+
+<!-- prettier-ignore -->
+```html
+<!-- Input -->
+<div *ngIf="item$ | async; let item; else loadingTemplate"></div>
+
+<!-- Prettier stable -->
+<div *ngIf="item$ | async; let item; else: loadingTemplate"></div>
+
+<!-- Prettier main -->
+<div *ngIf="item$ | async; let item; else loadingTemplate"></div>
+```

--- a/src/language-js/print/angular.js
+++ b/src/language-js/print/angular.js
@@ -54,16 +54,11 @@ function printAngular(path, options, print) {
       const shouldNotPrintColon =
         isNgForOf(path) ||
         isNgForOfTrack(path) ||
-        (((index === 1 &&
+        (parent.body[0].type === "NGMicrosyntaxExpression" &&
           (node.key.name === "then" ||
             node.key.name === "else" ||
-            node.key.name === "as")) ||
-          (index === 2 &&
-            ((node.key.name === "else" &&
-              parent.body[index - 1].type === "NGMicrosyntaxKeyedExpression" &&
-              parent.body[index - 1].key.name === "then") ||
-              node.key.name === "track"))) &&
-          parent.body[0].type === "NGMicrosyntaxExpression");
+            node.key.name === "as" ||
+            (index === 2 && node.key.name === "track")));
       return [
         print("key"),
         shouldNotPrintColon ? " " : ": ",

--- a/tests/format/angular/ng-if-microsyntax/__snapshots__/format.test.js.snap
+++ b/tests/format/angular/ng-if-microsyntax/__snapshots__/format.test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`ng-if.html format 1`] = `
+====================================options=====================================
+parsers: ["angular"]
+                                                      printWidth: 80 (default) |
+=====================================input======================================
+<div *ngIf="item$ | async; let item; else loadingTemplate"></div>
+<div *ngIf="value; let item; then content; else loading"></div>
+<div *ngIf="value; let first; let second; else loading"></div>
+
+@if (tab.eventCount$ | async; as count) {
+  <x />
+}
+
+=====================================output=====================================
+<div *ngIf="item$ | async; let item; else loadingTemplate"></div>
+<div *ngIf="value; let item; then content; else loading"></div>
+<div *ngIf="value; let first; let second; else loading"></div>
+
+@if (tab.eventCount$ | async; as count) {
+  <x />
+}
+
+================================================================================
+`;

--- a/tests/format/angular/ng-if-microsyntax/format.test.js
+++ b/tests/format/angular/ng-if-microsyntax/format.test.js
@@ -1,0 +1,1 @@
+runFormatTest(import.meta, ["angular"]);

--- a/tests/format/angular/ng-if-microsyntax/ng-if.html
+++ b/tests/format/angular/ng-if-microsyntax/ng-if.html
@@ -1,0 +1,7 @@
+<div *ngIf="item$ | async; let item; else loadingTemplate"></div>
+<div *ngIf="value; let item; then content; else loading"></div>
+<div *ngIf="value; let first; let second; else loading"></div>
+
+@if (tab.eventCount$ | async; as count) {
+  <x />
+}


### PR DESCRIPTION
## Description

Fixes #15719.

Angular microsyntax printing only omitted the colon for `then`, `else`, and `as` at specific hard-coded positions. When a `let` declaration appeared before `else`, the key shifted to a later position and Prettier printed `else:`, producing invalid Angular syntax.

This change makes `then`, `else`, and `as` independent of their position in the microsyntax body while keeping the existing `track` handling unchanged.

Regression tests cover `let` before `else`, `then` / `else` after `let`, and multiple `let` declarations before `else`.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).
- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.